### PR TITLE
feat(librados): add vector_put public API 벡터 API 추가

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1,5 +1,6 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
 /*
  * Ceph - scalable distributed file system
  *
@@ -49,12 +50,15 @@ extern "C" {
 
 #define LIBRADOS_SUPPORTS_WATCH 1
 #define LIBRADOS_SUPPORTS_SERVICES 1
+#define LIBRADOS_SUPPORTS_GETADDRS 1
 #define LIBRADOS_SUPPORTS_APP_METADATA 1
 
 /* RADOS lock flags
  * They are also defined in cls_lock_types.h. Keep them in sync!
  */
-#define LIBRADOS_LOCK_FLAG_RENEW 0x1
+#define LIBRADOS_LOCK_FLAG_RENEW       (1u<<0)
+#define LIBRADOS_LOCK_FLAG_MAY_RENEW   LIBRADOS_LOCK_FLAG_RENEW
+#define LIBRADOS_LOCK_FLAG_MUST_RENEW  (1u<<1)
 
 /*
  * Constants for rados_write_op_create().
@@ -130,6 +134,8 @@ enum {
   LIBRADOS_OPERATION_FULL_FORCE		= 128,
   LIBRADOS_OPERATION_IGNORE_REDIRECT	= 256,
   LIBRADOS_OPERATION_ORDERSNAP          = 512,
+  /* enable/allow >0 return values and payloads on write/update */
+  LIBRADOS_OPERATION_RETURNVEC          = 1024,
 };
 /** @} */
 
@@ -150,6 +156,7 @@ enum {
   LIBRADOS_ALLOC_HINT_FLAG_LONGLIVED = 128,
   LIBRADOS_ALLOC_HINT_FLAG_COMPRESSIBLE = 256,
   LIBRADOS_ALLOC_HINT_FLAG_INCOMPRESSIBLE = 512,
+  LIBRADOS_ALLOC_HINT_FLAG_LOG = 1024,
 };
 /** @} */
 
@@ -162,15 +169,15 @@ typedef enum {
 /*
  * snap id contants
  */
-#define LIBRADOS_SNAP_HEAD  ((uint64_t)(-2))
-#define LIBRADOS_SNAP_DIR   ((uint64_t)(-1))
+#define LIBRADOS_SNAP_HEAD  UINT64_C(-2)
+#define LIBRADOS_SNAP_DIR   UINT64_C(-1)
 
 /**
  * @typedef rados_t
  *
  * A handle for interacting with a RADOS cluster. It encapsulates all
  * RADOS client configuration, including username, key for
- * authentication, logging, and debugging. Talking different clusters
+ * authentication, logging, and debugging. Talking to different clusters
  * -- or to the same cluster with different users -- requires
  * different cluster handles.
  */
@@ -219,7 +226,7 @@ typedef void *rados_ioctx_t;
  *
  * An iterator for listing the objects in a pool.
  * Used with rados_nobjects_list_open(),
- * rados_nobjects_list_next(), and
+ * rados_nobjects_list_next(), rados_nobjects_list_next2(), and
  * rados_nobjects_list_close().
  */
 typedef void *rados_list_ctx_t;
@@ -238,7 +245,7 @@ typedef void * rados_object_list_cursor;
  * The item populated by rados_object_list in
  * the results array.
  */
-typedef struct rados_object_list_item {
+typedef struct {
 
   /// oid length
   size_t oid_length;
@@ -462,10 +469,10 @@ CEPH_RADOS_API int rados_create_with_context(rados_t *cluster,
  * buffer and length pointers can be NULL, in which case they are
  * not filled in.
  *
- * @param      cluster    cluster handle
- * @param[in]  mon_id     ID of the monitor to ping
- * @param[out] outstr     double pointer with the resulting reply
- * @param[out] outstrlen  pointer with the size of the reply in outstr
+ * @param cluster         cluster handle
+ * @param mon_id [in]     ID of the monitor to ping
+ * @param outstr [out]    double pointer with the resulting reply
+ * @param outstrlen [out] pointer with the size of the reply in outstr
  */
 CEPH_RADOS_API int rados_ping_monitor(rados_t cluster, const char *mon_id,
                                       char **outstr, size_t *outstrlen);
@@ -651,7 +658,7 @@ CEPH_RADOS_API int rados_cluster_stat(rados_t cluster,
  * @param cluster where to get the fsid
  * @param buf where to write the fsid
  * @param len the size of buf in bytes (should be 37)
- * @returns 0 on success, negative error code on failure
+ * @returns length of the string on success, negative error code on failure
  * @returns -ERANGE if the buffer is too short to contain the
  * fsid
  */
@@ -739,7 +746,7 @@ CEPH_RADOS_API uint64_t rados_get_instance_id(rados_t cluster);
  * Gets the minimum compatible OSD version
  *
  * @param cluster cluster handle
- * @param[out] require_osd_release minimum compatible OSD version
+ * @param require_osd_release [out] minimum compatible OSD version
  *  based upon the current features
  * @returns 0 on sucess, negative error code on failure
  */
@@ -750,9 +757,9 @@ CEPH_RADOS_API int rados_get_min_compatible_osd(rados_t cluster,
  * Gets the minimum compatible client version
  *
  * @param cluster cluster handle
- * @param[out] min_compat_client minimum compatible client version
+ * @param min_compat_client [out] minimum compatible client version
  *  based upon the current features
- * @param[out] require_min_compat_client required minimum client version
+ * @param require_min_compat_client [out] required minimum client version
  *  based upon explicit setting
  * @returns 0 on success, negative error code on failure
  */
@@ -919,7 +926,7 @@ CEPH_RADOS_API int rados_pool_create_with_all(rados_t cluster,
  *
  * @param cluster the cluster the pool is in
  * @param pool ID of the pool to query
- * @param[out] base_tier base tier, or \c pool if tiering is not configured
+ * @param base_tier [out] base tier, or \c pool if tiering is not configured
  * @returns 0 on success, negative error code on failure
  */
 CEPH_RADOS_API int rados_pool_get_base_tier(rados_t cluster, int64_t pool,
@@ -1037,6 +1044,25 @@ CEPH_RADOS_API void rados_ioctx_locator_set_key(rados_ioctx_t io,
                                                 const char *key);
 
 /**
+ * Set the placement hash for objects within an io context
+ *
+ * When set to a non-negative value, this overrides the default hash
+ * (computed from object name/key via ceph_str_hash) for PG placement.
+ * Use this for vector/embedding data with LSH-based placement: compute
+ * crush_hash32_lsh(embedding, dim) and pass the result here so that
+ * similar vectors map to the same PG.
+ *
+ * Pass -1 to clear and revert to the default name/key-based hashing.
+ * When hash is set, the locator key is cleared (hash and key are mutually
+ * exclusive per object_locator_t semantics).
+ *
+ * @param io the io context to change
+ * @param hash placement hash (0 to 2^32-1), or -1 to use default hashing
+ */
+CEPH_RADOS_API void rados_ioctx_locator_set_hash(rados_ioctx_t io,
+                                                 int64_t hash);
+
+/**
  * Set the namespace for objects within an io context
  *
  * The namespace specification further refines a pool into different
@@ -1133,6 +1159,32 @@ CEPH_RADOS_API int rados_nobjects_list_next(rados_list_ctx_t ctx,
                                             const char **entry,
 	                                    const char **key,
                                             const char **nspace);
+
+/**
+ * Get the next object name, locator and their sizes in the pool
+ *
+ * The sizes allow to list objects with \0 (the NUL character)
+ * in .e.g *entry. Is is unusual see such object names but a bug
+ * in a client has risen the need to handle them as well.
+ * *entry and *key are valid until next call to rados_nobjects_list_*
+ *
+ * @param ctx iterator marking where you are in the listing
+ * @param entry where to store the name of the entry
+ * @param key where to store the object locator (set to NULL to ignore)
+ * @param nspace where to store the object namespace (set to NULL to ignore)
+ * @param entry_size where to store the size of name of the entry
+ * @param key_size where to store the size of object locator (set to NULL to ignore)
+ * @param nspace_size where to store the size of object namespace (set to NULL to ignore)
+ * @returns 0 on success, negative error code on failure
+ * @returns -ENOENT when there are no more objects to list
+ */
+CEPH_RADOS_API int rados_nobjects_list_next2(rados_list_ctx_t ctx,
+                                             const char **entry,
+                                             const char **key,
+                                             const char **nspace,
+                                             size_t *entry_size,
+                                             size_t *key_size,
+                                             size_t *nspace_size);
 
 /**
  * Close the object listing handle.
@@ -1782,9 +1834,7 @@ CEPH_RADOS_API unsigned int rados_omap_iter_size(rados_omap_iter_t iter);
 CEPH_RADOS_API void rados_omap_get_end(rados_omap_iter_t iter);
 
 /**
- * Get object stats (size/mtime)
- *
- * TODO: when are these set, and by whom? can they be out of date?
+ * Get object size and most recent update time from the OSD.
  *
  * @param io ioctx
  * @param o object name
@@ -1794,6 +1844,10 @@ CEPH_RADOS_API void rados_omap_get_end(rados_omap_iter_t iter);
  */
 CEPH_RADOS_API int rados_stat(rados_ioctx_t io, const char *o, uint64_t *psize,
                               time_t *pmtime);
+
+CEPH_RADOS_API int rados_stat2(rados_ioctx_t io, const char *o, uint64_t *psize,
+                              struct timespec *pmtime);
+
 /**
  * Execute an OSD class method on an object
  *
@@ -1855,7 +1909,7 @@ typedef void (*rados_callback_t)(rados_completion_t cb, void *arg);
  *
  * @param cb_arg application-defined data passed to the callback functions
  * @param cb_complete the function to be called when the operation is
- * in memory on all relpicas
+ * in memory on all replicas
  * @param cb_safe the function to be called when the operation is on
  * stable storage on all replicas
  * @param pc where to store the completion
@@ -1865,6 +1919,23 @@ CEPH_RADOS_API int rados_aio_create_completion(void *cb_arg,
                                                rados_callback_t cb_complete,
                                                rados_callback_t cb_safe,
 				               rados_completion_t *pc);
+
+/**
+ * Constructs a completion to use with asynchronous operations
+ *
+ * The complete callback corresponds to operation being acked.
+ *
+ * @note BUG: this should check for ENOMEM instead of throwing an exception
+ *
+ * @param cb_arg application-defined data passed to the callback functions
+ * @param cb_complete the function to be called when the operation is committed
+ * on all replicas
+ * @param pc where to store the completion
+ * @returns 0
+ */
+CEPH_RADOS_API int rados_aio_create_completion2(void *cb_arg,
+						rados_callback_t cb_complete,
+						rados_completion_t *pc);
 
 /**
  * Block until an operation completes
@@ -1888,7 +1959,8 @@ CEPH_RADOS_API int rados_aio_wait_for_complete(rados_completion_t c);
  * @param c operation to wait for
  * @returns 0
  */
-CEPH_RADOS_API int rados_aio_wait_for_safe(rados_completion_t c);
+CEPH_RADOS_API int rados_aio_wait_for_safe(rados_completion_t c)
+  __attribute__((deprecated));
 
 /**
  * Has an asynchronous operation completed?
@@ -1934,7 +2006,8 @@ CEPH_RADOS_API int rados_aio_wait_for_complete_and_cb(rados_completion_t c);
  * @param c operation to wait for
  * @returns 0
  */
-CEPH_RADOS_API int rados_aio_wait_for_safe_and_cb(rados_completion_t c);
+CEPH_RADOS_API int rados_aio_wait_for_safe_and_cb(rados_completion_t c)
+  __attribute__((deprecated));
 
 /**
  * Has an asynchronous operation and callback completed
@@ -2160,6 +2233,10 @@ CEPH_RADOS_API int rados_aio_stat(rados_ioctx_t io, const char *o,
 		                  rados_completion_t completion,
 		                  uint64_t *psize, time_t *pmtime);
 
+CEPH_RADOS_API int rados_aio_stat2(rados_ioctx_t io, const char *o,
+		                  rados_completion_t completion,
+		                  uint64_t *psize, struct timespec *pmtime);
+
 /**
  * Asynchronously compare an on-disk object range with a buffer
  *
@@ -2331,7 +2408,7 @@ typedef void (*rados_watchcb_t)(uint8_t opcode, uint64_t ver, void *arg);
  * @param handle the watcher handle we are notifying
  * @param notifier_id the unique client id for the notifier
  * @param data payload from the notifier
- * @param datalen length of payload buffer
+ * @param data_len length of payload buffer
  */
 typedef void (*rados_watchcb2_t)(void *arg,
 				 uint64_t notify_id,
@@ -2350,6 +2427,7 @@ typedef void (*rados_watchcb2_t)(void *arg,
  * we may have missed notify events.
  *
  * @param pre opaque user-defined value provided to rados_watch2()
+ * @param cookie the internal id assigned to the watch session
  * @param err error code
  */
   typedef void (*rados_watcherrcb_t)(void *pre, uint64_t cookie, int err);
@@ -2621,6 +2699,36 @@ CEPH_RADOS_API int rados_notify2(rados_ioctx_t io, const char *o,
 				 char **reply_buffer, size_t *reply_buffer_len);
 
 /**
+ * Decode a notify response
+ *
+ * Decode a notify response (from rados_aio_notify() call) into acks and
+ * timeout arrays.
+ *
+ * @param reply_buffer buffer from rados_aio_notify() call
+ * @param reply_buffer_len reply_buffer length
+ * @param acks pointer to struct notify_ack_t pointer
+ * @param nr_acks pointer to ack count
+ * @param timeouts pointer to notify_timeout_t pointer
+ * @param nr_timeouts pointer to timeout count
+ * @returns 0 on success
+ */
+CEPH_RADOS_API int rados_decode_notify_response(char *reply_buffer, size_t reply_buffer_len,
+                                                struct notify_ack_t **acks, size_t *nr_acks,
+                                                struct notify_timeout_t **timeouts, size_t *nr_timeouts);
+
+/**
+ * Free notify allocated buffer
+ *
+ * Release memory allocated by rados_decode_notify_response() call
+ *
+ * @param acks notify_ack_t struct (from rados_decode_notify_response())
+ * @param nr_acks ack count
+ * @param timeouts notify_timeout_t struct (from rados_decode_notify_response())
+ */
+CEPH_RADOS_API void rados_free_notify_response(struct notify_ack_t *acks, size_t nr_acks,
+                                               struct notify_timeout_t *timeouts);
+
+/**
  * Acknolwedge receipt of a notify
  *
  * @param io the pool the object is in
@@ -2752,6 +2860,10 @@ CEPH_RADOS_API int rados_set_alloc_hint2(rados_ioctx_t io, const char *o,
  * Create a new rados_write_op_t write operation. This will store all actions
  * to be performed atomically. You must call rados_release_write_op when you are
  * finished with it.
+ *
+ * @note the ownership of a write operartion is passed to the function
+ *       performing the operation, so the same instance of @c rados_write_op_t
+ *       cannot be used again after being performed.
  *
  * @returns non-NULL on success, NULL on memory allocation error.
  */
@@ -3136,10 +3248,30 @@ CEPH_RADOS_API int rados_aio_write_op_operate(rados_write_op_t write_op,
 			                      int flags);
 
 /**
- * Create a new rados_read_op_t write operation. This will store all
+ * Perform a write operation asynchronously
+ * @param write_op operation to perform
+ * @param io the ioctx that the object is in
+ * @param completion what to do when operation has been attempted
+ * @param oid the object id
+ * @param mtime the time to set the mtime to, NULL for the current time
+ * @param flags flags to apply to the entire operation (LIBRADOS_OPERATION_*)
+ */
+CEPH_RADOS_API int rados_aio_write_op_operate2(rados_write_op_t write_op,
+                                               rados_ioctx_t io,
+                                               rados_completion_t completion,
+                                               const char *oid,
+                                               struct timespec *mtime,
+                                               int flags);
+
+/**
+ * Create a new rados_read_op_t read operation. This will store all
  * actions to be performed atomically. You must call
  * rados_release_read_op when you are finished with it (after it
  * completes, or you decide not to send it in the first place).
+ *
+ * @note the ownership of a read operartion is passed to the function
+ *       performing the operation, so the same instance of @c rados_read_op_t
+ *       cannot be used again after being performed.
  *
  * @returns non-NULL on success, NULL on memory allocation error.
  */
@@ -3278,6 +3410,10 @@ CEPH_RADOS_API void rados_read_op_stat(rados_read_op_t read_op,
 			               time_t *pmtime,
 			               int *prval);
 
+CEPH_RADOS_API void rados_read_op_stat2(rados_read_op_t read_op,
+			               uint64_t *psize,
+			               struct timespec *pmtime,
+			               int *prval);
 /**
  * Read bytes from offset into buffer.
  *
@@ -3634,20 +3770,39 @@ CEPH_RADOS_API int rados_break_lock(rados_ioctx_t io, const char *o,
                                     const char *cookie);
 
 /**
- * Blacklists the specified client from the OSDs
+ * Blocklists the specified client from the OSDs
  *
  * @param cluster cluster handle
  * @param client_address client address
- * @param expire_seconds number of seconds to blacklist (0 for default)
+ * @param expire_seconds number of seconds to blocklist (0 for default)
  * @returns 0 on success, negative error code on failure
  */
-CEPH_RADOS_API int rados_blacklist_add(rados_t cluster,
+CEPH_RADOS_API int rados_blocklist_add(rados_t cluster,
 				       char *client_address,
 				       uint32_t expire_seconds);
+CEPH_RADOS_API int rados_blacklist_add(rados_t cluster,
+				       char *client_address,
+				       uint32_t expire_seconds)
+  __attribute__((deprecated));
 
-CEPH_RADOS_API void rados_set_osdmap_full_try(rados_ioctx_t io);
+/**
+ * Gets addresses of the RADOS session, suitable for blocklisting.
+ *
+ * @param cluster cluster handle
+ * @param addrs the output string.
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_getaddrs(rados_t cluster, char** addrs);
 
-CEPH_RADOS_API void rados_unset_osdmap_full_try(rados_ioctx_t io);
+CEPH_RADOS_API void rados_set_osdmap_full_try(rados_ioctx_t io)
+  __attribute__((deprecated));
+
+CEPH_RADOS_API void rados_unset_osdmap_full_try(rados_ioctx_t io)
+  __attribute__((deprecated));
+
+CEPH_RADOS_API void rados_set_pool_full_try(rados_ioctx_t io);
+
+CEPH_RADOS_API void rados_unset_pool_full_try(rados_ioctx_t io);
 
 /**
  * Enable an application on a pool
@@ -3807,6 +3962,38 @@ CEPH_RADOS_API int rados_mgr_command(rados_t cluster, const char **cmd,
                                      size_t *outslen);
 
 /**
+ * Send ceph-mgr tell command.
+ *
+ * @note Takes command string in carefully-formatted JSON; must match
+ * defined commands, types, etc.
+ *
+ * The result buffers are allocated on the heap; the caller is
+ * expected to release that memory with rados_buffer_free().  The
+ * buffer and length pointers can all be NULL, in which case they are
+ * not filled in.
+ *
+ * @param cluster cluster handle
+ * @param name mgr name to target
+ * @param cmd an array of char *'s representing the command
+ * @param cmdlen count of valid entries in cmd
+ * @param inbuf any bulk input data (crush map, etc.)
+ * @param inbuflen input buffer length
+ * @param outbuf double pointer to output buffer
+ * @param outbuflen pointer to output buffer length
+ * @param outs double pointer to status string
+ * @param outslen pointer to status string length
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_mgr_command_target(
+  rados_t cluster,
+  const char *name,
+  const char **cmd,
+  size_t cmdlen, const char *inbuf,
+  size_t inbuflen, char **outbuf,
+  size_t *outbuflen, char **outs,
+  size_t *outslen);
+
+/**
  * Send monitor command to a specific monitor.
  *
  * @note Takes command string in carefully-formatted JSON; must match
@@ -3855,12 +4042,6 @@ CEPH_RADOS_API int rados_pg_command(rados_t cluster, const char *pgstr,
 		                    const char *inbuf, size_t inbuflen,
 		                    char **outbuf, size_t *outbuflen,
 		                    char **outs, size_t *outslen);
-
-CEPH_RADOS_API int rados_mgr_command(rados_t cluster,
-                                     const char **cmd, size_t cmdlen,
-		                     const char *inbuf, size_t inbuflen,
-		                     char **outbuf, size_t *outbuflen,
-		                     char **outs, size_t *outslen);
 
 /*
  * This is not a doxygen comment leadin, because doxygen breaks on

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -19,6 +19,8 @@ namespace libradosstriper
   class RadosStriper;
 }
 
+namespace neorados { class RADOS; }
+
 namespace librados {
 
 using ceph::bufferlist;
@@ -102,8 +104,13 @@ inline namespace v14_2_0 {
   };
   CEPH_RADOS_API std::ostream& operator<<(std::ostream& os, const librados::ObjectCursor& oc);
 
-  class CEPH_RADOS_API NObjectIterator : public std::iterator <std::forward_iterator_tag, ListObject> {
+  class CEPH_RADOS_API NObjectIterator {
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ListObject;
+    using difference_type = std::ptrdiff_t;
+    using pointer = ListObject*;
+    using reference = ListObject&;
     static const NObjectIterator __EndObjectIterator;
     NObjectIterator(): impl(NULL) {}
     ~NObjectIterator();
@@ -191,16 +198,20 @@ inline namespace v14_2_0 {
 
   struct CEPH_RADOS_API AioCompletion {
     AioCompletion(AioCompletionImpl *pc_) : pc(pc_) {}
+    ~AioCompletion();
     int set_complete_callback(void *cb_arg, callback_t cb);
-    int set_safe_callback(void *cb_arg, callback_t cb);
+    int set_safe_callback(void *cb_arg, callback_t cb)
+      __attribute__ ((deprecated));
+    /// Request immediate cancellation as if by IoCtx::aio_cancel().
+    int cancel();
     int wait_for_complete();
-    int wait_for_safe();
+    int wait_for_safe() __attribute__ ((deprecated));
     int wait_for_complete_and_cb();
-    int wait_for_safe_and_cb();
+    int wait_for_safe_and_cb() __attribute__ ((deprecated));
     bool is_complete();
-    bool is_safe();
+    bool is_safe() __attribute__ ((deprecated));
     bool is_complete_and_cb();
-    bool is_safe_and_cb();
+    bool is_safe_and_cb() __attribute__ ((deprecated));
     int get_return_value();
     int get_version() __attribute__ ((deprecated));
     uint64_t get_version64();
@@ -210,6 +221,7 @@ inline namespace v14_2_0 {
 
   struct CEPH_RADOS_API PoolAsyncCompletion {
     PoolAsyncCompletion(PoolAsyncCompletionImpl *pc_) : pc(pc_) {}
+    ~PoolAsyncCompletion();
     int set_callback(void *cb_arg, callback_t cb);
     int wait();
     bool is_complete();
@@ -241,9 +253,11 @@ inline namespace v14_2_0 {
   /**
    * These flags apply to the ObjectOperation as a whole.
    *
-   * BALANCE_READS and LOCALIZE_READS should only be used
-   * when reading from data you're certain won't change,
-   * like a snapshot, or where eventual consistency is ok.
+   * Prior to octopus BALANCE_READS and LOCALIZE_READS should only
+   * be used when reading from data you're certain won't change, like
+   * a snapshot, or where eventual consistency is ok.  Since octopus
+   * (get_min_compatible_osd() >= CEPH_RELEASE_OCTOPUS) both are safe
+   * for general use.
    *
    * ORDER_READS_WRITES will order reads the same way writes are
    * ordered (e.g., waiting for degraded objects).  In particular, it
@@ -270,10 +284,12 @@ inline namespace v14_2_0 {
     // marked full; ops will either succeed (e.g., delete) or return
     // EDQUOT or ENOSPC
     OPERATION_FULL_TRY           = LIBRADOS_OPERATION_FULL_TRY,
-    //mainly for delete
+    // mainly for delete
     OPERATION_FULL_FORCE	 = LIBRADOS_OPERATION_FULL_FORCE,
     OPERATION_IGNORE_REDIRECT	 = LIBRADOS_OPERATION_IGNORE_REDIRECT,
     OPERATION_ORDERSNAP          = LIBRADOS_OPERATION_ORDERSNAP,
+    // enable/allow return value and per-op return code/buffers
+    OPERATION_RETURNVEC          = LIBRADOS_OPERATION_RETURNVEC,
   };
 
   /*
@@ -290,6 +306,7 @@ inline namespace v14_2_0 {
     ALLOC_HINT_FLAG_LONGLIVED = 128,
     ALLOC_HINT_FLAG_COMPRESSIBLE = 256,
     ALLOC_HINT_FLAG_INCOMPRESSIBLE = 512,
+    ALLOC_HINT_FLAG_LOG = 1024,
   };
 
   /*
@@ -455,6 +472,26 @@ inline namespace v14_2_0 {
 		   uint64_t src_version, uint32_t src_fadvise_flags);
 
     /**
+     * Copy an object
+     *
+     * Copies an object from another location.  The operation is atomic in that
+     * the copy either succeeds in its entirety or fails (e.g., because the
+     * source object was modified while the copy was in progress).  Instead of
+     * copying truncate_seq and truncate_size from the source object it receives
+     * these values as parameters.
+     *
+     * @param src source object name
+     * @param src_ioctx ioctx for the source object
+     * @param src_version current version of the source object
+     * @param truncate_seq truncate sequence for the destination object
+     * @param truncate_size truncate size for the destination object
+     * @param src_fadvise_flags the fadvise flags for source object
+     */
+    void copy_from2(const std::string& src, const IoCtx& src_ioctx,
+		    uint64_t src_version, uint32_t truncate_seq,
+		    uint64_t truncate_size, uint32_t src_fadvise_flags);
+
+    /**
      * undirty an object
      *
      * Clear an objects dirty flag
@@ -489,12 +526,8 @@ inline namespace v14_2_0 {
      */
     void set_redirect(const std::string& tgt_obj, const IoCtx& tgt_ioctx,
 		      uint64_t tgt_version, int flag = 0);
-    void set_chunk(uint64_t src_offset, uint64_t src_length, const IoCtx& tgt_ioctx,
-                   std::string tgt_oid, uint64_t tgt_offset, int flag = 0);
     void tier_promote();
     void unset_manifest();
-    void tier_flush();
-
 
     friend class IoCtx;
   };
@@ -526,7 +559,9 @@ inline namespace v14_2_0 {
      * see aio_sparse_read()
      */
     void sparse_read(uint64_t off, uint64_t len, std::map<uint64_t,uint64_t> *m,
-                    bufferlist *data_bl, int *prval);
+                     bufferlist *data_bl, int *prval,
+                     uint64_t truncate_size = 0,
+                     uint32_t truncate_seq = 0);
 
     /**
      * omap_get_vals: keys and values from the object omap
@@ -708,19 +743,62 @@ inline namespace v14_2_0 {
      * triggering a promote on the OSD (that is then evicted).
      */
     void cache_evict();
+
+    /**
+     * Extensible tier
+     *
+     * set_chunk: make a chunk pointing a part of the source object at the target 
+     * 		  object
+     *
+     * @param src_offset [in] source offset to indicate the start position of 
+     * 				a chunk in the source object
+     * @param src_length [in] source length to set the length of the chunk
+     * @param tgt_oid    [in] target object's id to set a chunk
+     * @param tgt_offset [in] the start position of the target object
+     * @param flag       [in] flag for the source object
+     *
+     */
+    void set_chunk(uint64_t src_offset, uint64_t src_length, const IoCtx& tgt_ioctx,
+                   std::string tgt_oid, uint64_t tgt_offset, int flag = 0);
+    /**
+     * flush a manifest tier object to backing tier, performing deduplication;
+     * will block racing updates.
+     *
+     * Invoking tier_flush() implicitly makes a manifest object even if
+     * the target object is not manifest. 
+     */
+    void tier_flush();
+    /**
+     * evict a manifest tier object to backing tier; will block racing
+     * updates.
+     */
+    void tier_evict();
   };
 
-  /* IoCtx : This is a context in which we can perform I/O.
-   * It includes a Pool,
+  /**
+   * @brief A handle to a RADOS pool used to perform I/O operations.
    *
    * Typical use (error checking omitted):
-   *
+   * @code
    * IoCtx p;
    * rados.ioctx_create("my_pool", p);
-   * p->stat(&stats);
-   * ... etc ...
+   * p.stat("my_object", &size, &mtime);
+   * @endcode
    *
-   * NOTE: be sure to call watch_flush() prior to destroying any IoCtx
+   * IoCtx holds a pointer to its underlying implementation. The dup()
+   * method performs a deep copy of this implementation, but the copy
+   * construction and assignment operations perform shallow copies by
+   * sharing that pointer.
+   *
+   * Function names starting with aio_ are asynchronous operations that
+   * return immediately after submitting a request, and whose completions
+   * are managed by the given AioCompletion pointer. The IoCtx's underlying
+   * implementation is involved in the delivery of these completions, so
+   * the caller must guarantee that its lifetime is preserved until then -
+   * if not by preserving the IoCtx instance that submitted the request,
+   * then by a copied/moved instance that shares the same implementation.
+   *
+   * @note Be sure to call watch_flush() prior to destroying any IoCtx
    * that is used for watch events to ensure that racing callbacks
    * have completed.
    */
@@ -729,9 +807,13 @@ inline namespace v14_2_0 {
   public:
     IoCtx();
     static void from_rados_ioctx_t(rados_ioctx_t p, IoCtx &pool);
+    /// Construct a shallow copy of rhs, sharing its underlying implementation.
     IoCtx(const IoCtx& rhs);
+    /// Assign a shallow copy of rhs, sharing its underlying implementation.
     IoCtx& operator=(const IoCtx& rhs);
+    /// Move construct from rhs, transferring its underlying implementation.
     IoCtx(IoCtx&& rhs) noexcept;
+    /// Move assign from rhs, transferring its underlying implementation.
     IoCtx& operator=(IoCtx&& rhs) noexcept;
 
     ~IoCtx();
@@ -1088,7 +1170,8 @@ inline namespace v14_2_0 {
     int aio_stat2(const std::string& oid, AioCompletion *c, uint64_t *psize, struct timespec *pts);
 
     /**
-     * Cancel aio operation
+     * Request immediate cancellation with error code -ECANCELED
+     * if the operation hasn't already completed.
      *
      * @param c completion handle
      * @returns 0 on success, negative error code on failure
@@ -1106,9 +1189,13 @@ inline namespace v14_2_0 {
 
     // compound object operations
     int operate(const std::string& oid, ObjectWriteOperation *op);
+    int operate(const std::string& oid, ObjectWriteOperation *op, int flags);
+    int operate(const std::string& oid, ObjectWriteOperation *op, int flags, const jspan_context *trace_info);
     int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl);
+    int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl, int flags);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op, int flags);
+    int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op, int flags, const jspan_context *trace_info);
     /**
      * Schedule an async write operation with explicit snapshot parameters
      *
@@ -1190,6 +1277,12 @@ inline namespace v14_2_0 {
                    bufferlist& bl,         ///< optional broadcast payload
                    uint64_t timeout_ms,    ///< timeout (in ms)
                    bufferlist *pbl);       ///< reply buffer
+   /*
+    * Decode a notify response into acks and timeout vectors.
+    */
+    void decode_notify_response(bufferlist &bl,
+                                std::vector<librados::notify_ack_t> *acks,
+                                std::vector<librados::notify_timeout_t> *timeouts);
 
     int list_watchers(const std::string& o, std::list<obj_watch_t> *out_watchers);
     int list_snaps(const std::string& o, snap_set_t *out_snaps);
@@ -1260,6 +1353,12 @@ inline namespace v14_2_0 {
     std::string get_pool_name() const;
 
     void locator_set_key(const std::string& key);
+    /**
+     * Set the placement hash for LSH-based vector PG routing.
+     * Pass crush_hash32_lsh(embedding, dim) so similar vectors map
+     * to the same PG. Pass -1 to revert to default name/key hashing.
+     */
+    void locator_set_hash(int64_t hash);
     void set_namespace(const std::string& nspace);
     std::string get_namespace() const;
 
@@ -1276,8 +1375,14 @@ inline namespace v14_2_0 {
 
     config_t cct();
 
-    void set_osdmap_full_try();
-    void unset_osdmap_full_try();
+    void set_osdmap_full_try()
+      __attribute__ ((deprecated));
+    void unset_osdmap_full_try()
+      __attribute__ ((deprecated));
+
+    bool get_pool_full_try();
+    void set_pool_full_try();
+    void unset_pool_full_try();
 
     int application_enable(const std::string& app_name, bool force);
     int application_enable_async(const std::string& app_name,
@@ -1294,6 +1399,8 @@ inline namespace v14_2_0 {
     int application_metadata_list(const std::string& app_name,
                                   std::map<std::string, std::string> *values);
 
+    void set_no_version_on_read(bool b);
+
   private:
     /* You can only get IoCtx instances from Rados */
     IoCtx(IoCtxImpl *io_ctx_impl_);
@@ -1301,6 +1408,7 @@ inline namespace v14_2_0 {
     friend class Rados; // Only Rados can use our private constructor to create IoCtxes.
     friend class libradosstriper::RadosStriper; // Striper needs to see our IoCtxImpl
     friend class ObjectWriteOperation;  // copy_from needs to see our IoCtxImpl
+    friend class ObjectReadOperation;  // set_chunk needs to see our IoCtxImpl
 
     IoCtxImpl *io_ctx_impl;
   };
@@ -1323,6 +1431,7 @@ inline namespace v14_2_0 {
     Rados();
     explicit Rados(IoCtx& ioctx);
     ~Rados();
+    static void from_rados_t(rados_t cluster, Rados &rados);
 
     int init(const char * const id);
     int init2(const char * const name, const char * const clustername,
@@ -1372,20 +1481,20 @@ inline namespace v14_2_0 {
     int get_min_compatible_client(int8_t* min_compat_client,
                                   int8_t* require_min_compat_client);
 
-    int mon_command(std::string cmd, const bufferlist& inbl,
+    int mon_command(std::string&& cmd, bufferlist&& inbl,
 		    bufferlist *outbl, std::string *outs);
-    int mgr_command(std::string cmd, const bufferlist& inbl,
+    int mgr_command(std::string&& cmd, bufferlist&& inbl,
 		    bufferlist *outbl, std::string *outs);
-    int osd_command(int osdid, std::string cmd, const bufferlist& inbl,
+    int osd_command(int osdid, std::string&& cmd, bufferlist&& inbl,
                     bufferlist *outbl, std::string *outs);
-    int pg_command(const char *pgstr, std::string cmd, const bufferlist& inbl,
+    int pg_command(const char *pgstr, std::string&& cmd, bufferlist&& inbl,
                    bufferlist *outbl, std::string *outs);
 
     int ioctx_create(const char *name, IoCtx &pioctx);
     int ioctx_create2(int64_t pool_id, IoCtx &pioctx);
 
     // Features useful for test cases
-    void test_blacklist_self(bool set);
+    void test_blocklist_self(bool set);
 
     /* pool info */
     int pool_list(std::list<std::string>& v);
@@ -1399,8 +1508,11 @@ inline namespace v14_2_0 {
     int get_pool_stats(std::list<std::string>& v,
                        std::string& category,
 		       std::map<std::string, stats_map>& stats);
-    /// check if pool has selfmanaged snaps
-    bool get_pool_is_selfmanaged_snaps_mode(const std::string& poolname);
+
+    /// check if pool has or had selfmanaged snaps
+    bool get_pool_is_selfmanaged_snaps_mode(const std::string& poolname)
+      __attribute__ ((deprecated));
+    int pool_is_in_selfmanaged_snaps_mode(const std::string& poolname);
 
     int cluster_stat(cluster_stat_t& result);
     int cluster_fsid(std::string *fsid);
@@ -1453,8 +1565,10 @@ inline namespace v14_2_0 {
     /// get/wait for the most recent osdmap
     int wait_for_latest_osdmap();
 
-    int blacklist_add(const std::string& client_address,
+    int blocklist_add(const std::string& client_address,
                       uint32_t expire_seconds);
+
+    std::string get_addrs() const;
 
     /*
      * pool aio
@@ -1467,10 +1581,14 @@ inline namespace v14_2_0 {
    // -- aio --
     static AioCompletion *aio_create_completion();
     static AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete,
-						callback_t cb_safe);
-    
+						callback_t cb_safe)
+      __attribute__ ((deprecated));
+    static AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete);
+
     friend std::ostream& operator<<(std::ostream &oss, const Rados& r);
   private:
+    friend class neorados::RADOS;
+
     // We don't allow assignment or copying
     Rados(const Rados& rhs);
     const Rados& operator=(const Rados& rhs);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1,5 +1,6 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
 /*
  * Ceph - scalable distributed file system
  *
@@ -28,34 +29,44 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "librados: "
 
+using std::string;
+using std::map;
+using std::unique_lock;
+using std::vector;
+
+namespace bs = boost::system;
+namespace ca = ceph::async;
+namespace cb = ceph::buffer;
+
 namespace librados {
 namespace {
 
-struct C_notify_Finish : public Context {
+struct CB_notify_Finish {
   CephContext *cct;
   Context *ctx;
   Objecter *objecter;
   Objecter::LingerOp *linger_op;
-  bufferlist reply_bl;
   bufferlist *preply_bl;
   char **preply_buf;
   size_t *preply_buf_len;
 
-  C_notify_Finish(CephContext *_cct, Context *_ctx, Objecter *_objecter,
-                  Objecter::LingerOp *_linger_op, bufferlist *_preply_bl,
-                  char **_preply_buf, size_t *_preply_buf_len)
+  CB_notify_Finish(CephContext *_cct, Context *_ctx, Objecter *_objecter,
+		   Objecter::LingerOp *_linger_op, bufferlist *_preply_bl,
+		   char **_preply_buf, size_t *_preply_buf_len)
     : cct(_cct), ctx(_ctx), objecter(_objecter), linger_op(_linger_op),
       preply_bl(_preply_bl), preply_buf(_preply_buf),
-      preply_buf_len(_preply_buf_len)
-  {
-    linger_op->on_notify_finish = this;
-    linger_op->notify_result_bl = &reply_bl;
-  }
+      preply_buf_len(_preply_buf_len) {}
 
-  void finish(int r) override
-  {
+
+  // move-only
+  CB_notify_Finish(const CB_notify_Finish&) = delete;
+  CB_notify_Finish& operator =(const CB_notify_Finish&) = delete;
+  CB_notify_Finish(CB_notify_Finish&&) = default;
+  CB_notify_Finish& operator =(CB_notify_Finish&&) = default;
+
+  void operator()(bs::error_code ec, bufferlist&& reply_bl) {
     ldout(cct, 10) << __func__ << " completed notify (linger op "
-                   << linger_op << "), r = " << r << dendl;
+                   << linger_op << "), ec = " << ec << dendl;
 
     // pass result back to user
     // NOTE: we do this regardless of what error code we return
@@ -70,42 +81,45 @@ struct C_notify_Finish : public Context {
     if (preply_buf_len)
       *preply_buf_len = reply_bl.length();
     if (preply_bl)
-      preply_bl->claim(reply_bl);
+      *preply_bl = std::move(reply_bl);
 
-    ctx->complete(r);
+    ctx->complete(ceph::from_error_code(ec));
   }
 };
 
-struct C_aio_linger_cancel : public Context {
+struct CB_aio_linger_cancel {
   Objecter *objecter;
-  Objecter::LingerOp *linger_op;
+  boost::intrusive_ptr<Objecter::LingerOp> linger_op;
 
-  C_aio_linger_cancel(Objecter *_objecter, Objecter::LingerOp *_linger_op)
-    : objecter(_objecter), linger_op(_linger_op)
+  CB_aio_linger_cancel(Objecter *_objecter,
+                       boost::intrusive_ptr<Objecter::LingerOp> op)
+    : objecter(_objecter), linger_op(std::move(op))
   {
   }
 
-  void finish(int r) override
-  {
-    objecter->linger_cancel(linger_op);
+  void operator()() {
+    objecter->linger_cancel(linger_op.get());
   }
 };
 
 struct C_aio_linger_Complete : public Context {
   AioCompletionImpl *c;
-  Objecter::LingerOp *linger_op;
+  boost::intrusive_ptr<Objecter::LingerOp> linger_op;
   bool cancel;
 
-  C_aio_linger_Complete(AioCompletionImpl *_c, Objecter::LingerOp *_linger_op, bool _cancel)
-    : c(_c), linger_op(_linger_op), cancel(_cancel)
+  C_aio_linger_Complete(AioCompletionImpl *_c,
+                        boost::intrusive_ptr<Objecter::LingerOp> op,
+                        bool _cancel)
+    : c(_c), linger_op(std::move(op)), cancel(_cancel)
   {
     c->get();
   }
 
   void finish(int r) override {
     if (cancel || r < 0)
-      c->io->client->finisher.queue(new C_aio_linger_cancel(c->io->objecter,
-                                                            linger_op));
+      boost::asio::defer(c->io->client->finish_strand,
+			 CB_aio_linger_cancel(c->io->objecter,
+					      std::move(linger_op)));
 
     c->lock.lock();
     c->rval = r;
@@ -114,7 +128,7 @@ struct C_aio_linger_Complete : public Context {
 
     if (c->callback_complete ||
 	c->callback_safe) {
-      c->io->client->finisher.queue(new C_AioComplete(c));
+      boost::asio::defer(c->io->client->finish_strand, CB_AioComplete(c));
     }
     c->put_unlock();
   }
@@ -126,8 +140,9 @@ struct C_aio_notify_Complete : public C_aio_linger_Complete {
   bool finished = false;
   int ret_val = 0;
 
-  C_aio_notify_Complete(AioCompletionImpl *_c, Objecter::LingerOp *_linger_op)
-    : C_aio_linger_Complete(_c, _linger_op, false) {
+  C_aio_notify_Complete(AioCompletionImpl *_c,
+                        boost::intrusive_ptr<Objecter::LingerOp> op)
+    : C_aio_linger_Complete(_c, std::move(op), false) {
   }
 
   void handle_ack(int r) {
@@ -161,12 +176,11 @@ struct C_aio_notify_Complete : public C_aio_linger_Complete {
 
 struct C_aio_notify_Ack : public Context {
   CephContext *cct;
-  C_notify_Finish *onfinish;
   C_aio_notify_Complete *oncomplete;
 
-  C_aio_notify_Ack(CephContext *_cct, C_notify_Finish *_onfinish,
+  C_aio_notify_Ack(CephContext *_cct,
                    C_aio_notify_Complete *_oncomplete)
-    : cct(_cct), onfinish(_onfinish), oncomplete(_oncomplete)
+    : cct(_cct), oncomplete(_oncomplete)
   {
   }
 
@@ -195,7 +209,7 @@ struct C_aio_selfmanaged_snap_op_Complete : public Context {
     c->cond.notify_all();
 
     if (c->callback_complete || c->callback_safe) {
-      client->finisher.queue(new librados::C_AioComplete(c));
+      boost::asio::defer(client->finish_strand, librados::CB_AioComplete(c));
     }
     c->put_unlock();
   }
@@ -232,6 +246,9 @@ librados::IoCtxImpl::IoCtxImpl(RadosClient *c, Objecter *objecter,
     oloc(poolid),
     aio_write_seq(0), objecter(objecter)
 {
+  if (!c->cct->_conf.get_val<bool>("rados_replica_read_policy_on_objclass")) {
+    objclass_flags_mask = ~(CEPH_OSD_FLAG_LOCALIZE_READS | CEPH_OSD_FLAG_BALANCE_READS);
+  }
 }
 
 void librados::IoCtxImpl::set_snap_read(snapid_t s)
@@ -305,7 +322,7 @@ void librados::IoCtxImpl::complete_aio_write(AioCompletionImpl *c)
     ldout(client->cct, 20) << " waking waiters on seq " << waiters->first << dendl;
     for (std::list<AioCompletionImpl*>::iterator it = waiters->second.begin();
 	 it != waiters->second.end(); ++it) {
-      client->finisher.queue(new C_AioCompleteAndSafe(*it));
+      boost::asio::defer(client->finish_strand, CB_AioCompleteAndSafe(*it));
       (*it)->put();
     }
     aio_write_waiters.erase(waiters++);
@@ -325,7 +342,7 @@ void librados::IoCtxImpl::flush_aio_writes_async(AioCompletionImpl *c)
   if (aio_write_list.empty()) {
     ldout(client->cct, 20) << "flush_aio_writes_async no writes. (tid "
 			   << seq << ")" << dendl;
-    client->finisher.queue(new C_AioCompleteAndSafe(c));
+    boost::asio::defer(client->finish_strand, CB_AioCompleteAndSafe(c));
   } else {
     ldout(client->cct, 20) << "flush_aio_writes_async " << aio_write_list.size()
 			   << " writes in flight; waiting on tid " << seq << dendl;
@@ -362,14 +379,10 @@ int librados::IoCtxImpl::snap_create(const char *snapName)
   ceph::condition_variable cond;
   bool done;
   Context *onfinish = new C_SafeCond(mylock, cond, &done, &reply);
-  reply = objecter->create_pool_snap(poolid, sName, onfinish);
+  objecter->create_pool_snap(poolid, sName, onfinish);
 
-  if (reply < 0) {
-    delete onfinish;
-  } else {
-    std::unique_lock l{mylock};
-    cond.wait(l, [&done] { return done; });
-  }
+  std::unique_lock l{mylock};
+  cond.wait(l, [&done] { return done; });
   return reply;
 }
 
@@ -382,18 +395,14 @@ int librados::IoCtxImpl::selfmanaged_snap_create(uint64_t *psnapid)
   bool done;
   Context *onfinish = new C_SafeCond(mylock, cond, &done, &reply);
   snapid_t snapid;
-  reply = objecter->allocate_selfmanaged_snap(poolid, &snapid, onfinish);
+  objecter->allocate_selfmanaged_snap(poolid, &snapid, onfinish);
 
-  if (reply < 0) {
-    delete onfinish;
-  } else {
-    {
-      std::unique_lock l{mylock};
-      cond.wait(l, [&done] { return done; });
-    }
-    if (reply == 0)
-      *psnapid = snapid;
+  {
+    std::unique_lock l{mylock};
+    cond.wait(l, [&done] { return done; });
   }
+  if (reply == 0)
+    *psnapid = snapid;
   return reply;
 }
 
@@ -402,11 +411,8 @@ void librados::IoCtxImpl::aio_selfmanaged_snap_create(uint64_t *snapid,
 {
   C_aio_selfmanaged_snap_create_Complete *onfinish =
     new C_aio_selfmanaged_snap_create_Complete(client, c, snapid);
-  int r = objecter->allocate_selfmanaged_snap(poolid, &onfinish->snapid,
-                                              onfinish);
-  if (r < 0) {
-    onfinish->complete(r);
-  }
+  objecter->allocate_selfmanaged_snap(poolid, &onfinish->snapid,
+				      onfinish);
 }
 
 int librados::IoCtxImpl::snap_remove(const char *snapName)
@@ -418,14 +424,9 @@ int librados::IoCtxImpl::snap_remove(const char *snapName)
   ceph::condition_variable cond;
   bool done;
   Context *onfinish = new C_SafeCond(mylock, cond, &done, &reply);
-  reply = objecter->delete_pool_snap(poolid, sName, onfinish);
-
-  if (reply < 0) {
-    delete onfinish; 
-  } else {
-    unique_lock l{mylock};
-    cond.wait(l, [&done] { return done; });
-  }
+  objecter->delete_pool_snap(poolid, sName, onfinish);
+  unique_lock l{mylock};
+  cond.wait(l, [&done] { return done; });
   return reply;
 }
 
@@ -444,7 +445,8 @@ int librados::IoCtxImpl::selfmanaged_snap_rollback_object(const object_t& oid,
   prepare_assert_ops(&op);
   op.rollback(snapid);
   objecter->mutate(oid, oloc,
-		   op, snapc, ceph::real_clock::now(), 0,
+		   op, snapc, ceph::real_clock::now(),
+		   extra_op_flags,
 		   onack, NULL);
 
   std::unique_lock l{mylock};
@@ -643,7 +645,7 @@ int librados::IoCtxImpl::writesame(const object_t& oid, bufferlist& bl,
 }
 
 int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
-				 ceph::real_time *pmtime, int flags)
+				 ceph::real_time *pmtime, int flags, const jspan_context* otel_trace)
 {
   ceph::real_time ut = (pmtime ? *pmtime :
     ceph::real_clock::now());
@@ -666,9 +668,11 @@ int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
   int op = o->ops[0].op.op;
   ldout(client->cct, 10) << ceph_osd_op_name(op) << " oid=" << oid
 			 << " nspace=" << oloc.nspace << dendl;
-  Objecter::Op *objecter_op = objecter->prepare_mutate_op(oid, oloc,
-							  *o, snapc, ut, flags,
-							  oncommit, &ver);
+  Objecter::Op *objecter_op = objecter->prepare_mutate_op(
+    oid, oloc,
+    *o, snapc, ut,
+    flags | extra_op_flags,
+    oncommit, &ver, osd_reqid_t(), nullptr, otel_trace);
   objecter->op_submit(objecter_op);
 
   {
@@ -683,10 +687,26 @@ int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
   return r;
 }
 
+version_t *librados::IoCtxImpl::get_objver_for_read(version_t *objver_p) const {
+  if (!no_version_on_read) {
+    return objver_p;
+  }
+
+  if (objver_p) {
+    *objver_p = std::numeric_limits<version_t>::max();
+  }
+  return nullptr;
+}
+
+void librados::IoCtxImpl::set_no_version_on_read(bool _val) {
+  no_version_on_read = _val;
+}
+
 int librados::IoCtxImpl::operate_read(const object_t& oid,
 				      ::ObjectOperation *o,
 				      bufferlist *pbl,
-				      int flags)
+				      int flags,
+                                      int flags_mask)
 {
   if (!o->size())
     return 0;
@@ -701,9 +721,12 @@ int librados::IoCtxImpl::operate_read(const object_t& oid,
 
   int op = o->ops[0].op.op;
   ldout(client->cct, 10) << ceph_osd_op_name(op) << " oid=" << oid << " nspace=" << oloc.nspace << dendl;
-  Objecter::Op *objecter_op = objecter->prepare_read_op(oid, oloc,
-	                                      *o, snap_seq, pbl, flags,
-	                                      onack, &ver);
+  Objecter::Op *objecter_op = objecter->prepare_read_op(
+    oid, oloc,
+    *o, snap_seq, pbl,
+    flags | extra_op_flags,
+    flags_mask,
+    onack, get_objver_for_read(&ver));
   objecter->op_submit(objecter_op);
 
   {
@@ -728,7 +751,7 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
   FUNCTRACE(client->cct);
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->is_read = true;
@@ -741,9 +764,10 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
   }
 
   trace.event("init root span");
-  Objecter::Op *objecter_op = objecter->prepare_read_op(oid, oloc,
-		 *o, snap_seq, pbl, flags,
-		 oncomplete, &c->objver, nullptr, 0, &trace);
+  Objecter::Op *objecter_op = objecter->prepare_read_op(
+    oid, oloc,
+    *o, snap_seq, pbl, flags | extra_op_flags, -1,
+    oncomplete, get_objver_for_read(&c->objver), nullptr, 0, &trace);
   objecter->op_submit(objecter_op, &c->tid);
   trace.event("rados operate read submitted");
 
@@ -752,18 +776,19 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 
 int librados::IoCtxImpl::aio_operate(const object_t& oid,
 				     ::ObjectOperation *o, AioCompletionImpl *c,
-				     const SnapContext& snap_context, int flags,
-                                     const blkin_trace_info *trace_info)
+				     const SnapContext& snap_context,
+				     const ceph::real_time *pmtime, int flags,
+                                     const blkin_trace_info *trace_info, const jspan_context *otel_trace)
 {
   FUNCTRACE(client->cct);
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_WRITE_OP_BEGIN");
-  auto ut = ceph::real_clock::now();
+  const ceph::real_time ut = (pmtime ? *pmtime : ceph::real_clock::now());
   /* can't write to a snapshot */
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
   Context *oncomplete = new C_aio_Complete(c);
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
 
@@ -778,8 +803,8 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
 
   trace.event("init root span");
   Objecter::Op *op = objecter->prepare_mutate_op(
-    oid, oloc, *o, snap_context, ut, flags,
-    oncomplete, &c->objver, osd_reqid_t(), &trace);
+    oid, oloc, *o, snap_context, ut, flags | extra_op_flags,
+    oncomplete, &c->objver, osd_reqid_t(), &trace, otel_trace);
   objecter->op_submit(op, &c->tid);
   trace.event("rados operate op submitted");
 
@@ -797,7 +822,7 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_READ_OP_BEGIN");
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->is_read = true;
@@ -810,8 +835,8 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
-    off, len, snapid, pbl, 0,
-    oncomplete, &c->objver, nullptr, 0, &trace);
+    off, len, snapid, pbl, extra_op_flags,
+    oncomplete, get_objver_for_read(&c->objver), nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -827,7 +852,7 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_READ_OP_BEGIN");
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->is_read = true;
@@ -843,8 +868,8 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
-    off, len, snapid, &c->bl, 0,
-    oncomplete, &c->objver, nullptr, 0, &trace);
+    off, len, snapid, &c->bl, extra_op_flags,
+    oncomplete, get_objver_for_read(&c->objver), nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -873,7 +898,7 @@ int librados::IoCtxImpl::aio_sparse_read(const object_t oid,
   Context *nested = new C_aio_Complete(c);
   C_ObjectOperation *onack = new C_ObjectOperation(nested);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) nested)->oid = oid;
 #endif
   c->is_read = true;
@@ -883,8 +908,8 @@ int librados::IoCtxImpl::aio_sparse_read(const object_t oid,
 
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
-    onack->m_ops, snapid, NULL, 0,
-    onack, &c->objver);
+    onack->m_ops, snapid, NULL, extra_op_flags, -1,
+    onack, get_objver_for_read(&c->objver));
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -903,8 +928,8 @@ int librados::IoCtxImpl::aio_cmpext(const object_t& oid,
   c->io = this;
 
   Objecter::Op *o = objecter->prepare_cmpext_op(
-    oid, oloc, off, cmp_bl, snap_seq, 0,
-    onack, &c->objver);
+    oid, oloc, off, cmp_bl, snap_seq, extra_op_flags,
+    onack, get_objver_for_read(&c->objver));
   objecter->op_submit(o, &c->tid);
 
   return 0;
@@ -932,7 +957,8 @@ int librados::IoCtxImpl::aio_cmpext(const object_t& oid,
   onack->m_ops.cmpext(off, cmp_len, cmp_buf, NULL);
 
   Objecter::Op *o = objecter->prepare_read_op(
-    oid, oloc, onack->m_ops, snap_seq, NULL, 0, onack, &c->objver);
+    oid, oloc, onack->m_ops, snap_seq, NULL, extra_op_flags, -1, onack,
+    get_objver_for_read(&c->objver));
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -954,7 +980,7 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
 
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   ZTracer::Trace trace;
@@ -966,7 +992,7 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
 
   Objecter::Op *o = objecter->prepare_write_op(
     oid, oloc,
-    off, len, snapc, bl, ut, 0,
+    off, len, snapc, bl, ut, extra_op_flags,
     oncomplete, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
 
@@ -986,7 +1012,7 @@ int librados::IoCtxImpl::aio_append(const object_t &oid, AioCompletionImpl *c,
     return -EROFS;
 
   Context *oncomplete = new C_aio_Complete(c);
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
 
@@ -995,7 +1021,7 @@ int librados::IoCtxImpl::aio_append(const object_t &oid, AioCompletionImpl *c,
 
   Objecter::Op *o = objecter->prepare_append_op(
     oid, oloc,
-    len, snapc, bl, ut, 0,
+    len, snapc, bl, ut, extra_op_flags,
     oncomplete, &c->objver);
   objecter->op_submit(o, &c->tid);
 
@@ -1016,7 +1042,7 @@ int librados::IoCtxImpl::aio_write_full(const object_t &oid,
     return -EROFS;
 
   Context *oncomplete = new C_aio_Complete(c);
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
 
@@ -1025,7 +1051,7 @@ int librados::IoCtxImpl::aio_write_full(const object_t &oid,
 
   Objecter::Op *o = objecter->prepare_write_full_op(
     oid, oloc,
-    snapc, bl, ut, 0,
+    snapc, bl, ut, extra_op_flags,
     oncomplete, &c->objver);
   objecter->op_submit(o, &c->tid);
 
@@ -1051,7 +1077,7 @@ int librados::IoCtxImpl::aio_writesame(const object_t &oid,
 
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->io = this;
@@ -1060,7 +1086,7 @@ int librados::IoCtxImpl::aio_writesame(const object_t &oid,
   Objecter::Op *o = objecter->prepare_writesame_op(
     oid, oloc,
     write_len, off,
-    snapc, bl, ut, 0,
+    snapc, bl, ut, extra_op_flags,
     oncomplete, &c->objver);
   objecter->op_submit(o, &c->tid);
 
@@ -1078,7 +1104,7 @@ int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c, i
 
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->io = this;
@@ -1086,7 +1112,7 @@ int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c, i
 
   Objecter::Op *o = objecter->prepare_remove_op(
     oid, oloc,
-    snapc, ut, flags,
+    snapc, ut, flags | extra_op_flags,
     oncomplete, &c->objver);
   objecter->op_submit(o, &c->tid);
 
@@ -1102,8 +1128,8 @@ int librados::IoCtxImpl::aio_stat(const object_t& oid, AioCompletionImpl *c,
   c->io = this;
   Objecter::Op *o = objecter->prepare_stat_op(
     oid, oloc,
-    snap_seq, psize, &onack->mtime, 0,
-    onack, &c->objver);
+    snap_seq, psize, &onack->mtime, extra_op_flags,
+    onack, get_objver_for_read(&c->objver));
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -1116,8 +1142,8 @@ int librados::IoCtxImpl::aio_stat2(const object_t& oid, AioCompletionImpl *c,
   c->io = this;
   Objecter::Op *o = objecter->prepare_stat_op(
     oid, oloc,
-    snap_seq, psize, &onack->mtime, 0,
-    onack, &c->objver);
+    snap_seq, psize, &onack->mtime, extra_op_flags,
+    onack, get_objver_for_read(&c->objver));
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -1138,7 +1164,7 @@ int librados::IoCtxImpl::aio_rmxattr(const object_t& oid, AioCompletionImpl *c,
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.rmxattr(name);
-  return aio_operate(oid, &op, c, snapc, 0);
+  return aio_operate(oid, &op, c, snapc, nullptr, 0);
 }
 
 int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
@@ -1147,7 +1173,7 @@ int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.setxattr(name, bl);
-  return aio_operate(oid, &op, c, snapc, 0);
+  return aio_operate(oid, &op, c, snapc, nullptr, 0);
 }
 
 namespace {
@@ -1155,7 +1181,7 @@ struct AioGetxattrsData {
   AioGetxattrsData(librados::AioCompletionImpl *c, map<string, bufferlist>* attrset,
 		   librados::RadosClient *_client) :
     user_completion(c), user_attrset(attrset), client(_client) {}
-  struct librados::C_AioCompleteAndSafe user_completion;
+  struct librados::CB_AioCompleteAndSafe user_completion;
   map<string, bufferlist> result_attrset;
   map<std::string, bufferlist>* user_attrset;
   librados::RadosClient *client;
@@ -1174,7 +1200,7 @@ static void aio_getxattrs_complete(rados_completion_t c, void *arg) {
       (*cdata->user_attrset)[p->first] = p->second;
     }
   }
-  cdata->user_completion.finish(rc);
+  cdata->user_completion(rc);
   ((librados::AioCompletionImpl*)c)->put();
   delete cdata;
 }
@@ -1208,7 +1234,7 @@ int librados::IoCtxImpl::hit_set_list(uint32_t hash, AioCompletionImpl *c,
   rd.hit_set_ls(pls, NULL);
   object_locator_t oloc(poolid);
   Objecter::Op *o = objecter->prepare_pg_read_op(
-    hash, oloc, rd, NULL, 0, oncomplete, NULL, NULL);
+    hash, oloc, rd, NULL, extra_op_flags, oncomplete, NULL, NULL);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -1225,7 +1251,7 @@ int librados::IoCtxImpl::hit_set_get(uint32_t hash, AioCompletionImpl *c,
   rd.hit_set_get(ceph::real_clock::from_time_t(stamp), pbl, 0);
   object_locator_t oloc(poolid);
   Objecter::Op *o = objecter->prepare_pg_read_op(
-    hash, oloc, rd, NULL, 0, oncomplete, NULL, NULL);
+    hash, oloc, rd, NULL, extra_op_flags, oncomplete, NULL, NULL);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -1235,7 +1261,7 @@ int librados::IoCtxImpl::remove(const object_t& oid)
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.remove();
-  return operate(oid, &op, nullptr, librados::OPERATION_FULL_FORCE);
+  return operate(oid, &op, nullptr, CEPH_OSD_FLAG_FULL_FORCE);
 }
 
 int librados::IoCtxImpl::remove(const object_t& oid, int flags)
@@ -1269,7 +1295,7 @@ int librados::IoCtxImpl::get_inconsistent_objects(const pg_t& pg,
   op.scrub_ls(start_after, max_to_get, objects, interval, &c->rval);
   object_locator_t oloc{poolid, pg.ps()};
   Objecter::Op *o = objecter->prepare_pg_read_op(
-    oloc.hash, oloc, op, nullptr, CEPH_OSD_FLAG_PGOP, oncomplete,
+    oloc.hash, oloc, op, nullptr, CEPH_OSD_FLAG_PGOP | extra_op_flags, oncomplete,
     nullptr, nullptr);
   objecter->op_submit(o, &c->tid);
   return 0;
@@ -1290,7 +1316,7 @@ int librados::IoCtxImpl::get_inconsistent_snapsets(const pg_t& pg,
   op.scrub_ls(start_after, max_to_get, snapsets, interval, &c->rval);
   object_locator_t oloc{poolid, pg.ps()};
   Objecter::Op *o = objecter->prepare_pg_read_op(
-    oloc.hash, oloc, op, nullptr, CEPH_OSD_FLAG_PGOP, oncomplete,
+    oloc.hash, oloc, op, nullptr, CEPH_OSD_FLAG_PGOP | extra_op_flags, oncomplete,
     nullptr, nullptr);
   objecter->op_submit(o, &c->tid);
   return 0;
@@ -1311,7 +1337,7 @@ int librados::IoCtxImpl::exec(const object_t& oid,
   ::ObjectOperation rd;
   prepare_assert_ops(&rd);
   rd.call(cls, method, inbl);
-  return operate_read(oid, &rd, &outbl);
+  return operate_read(oid, &rd, &outbl, 0, objclass_flags_mask);
 }
 
 int librados::IoCtxImpl::aio_exec(const object_t& oid, AioCompletionImpl *c,
@@ -1321,7 +1347,7 @@ int librados::IoCtxImpl::aio_exec(const object_t& oid, AioCompletionImpl *c,
   FUNCTRACE(client->cct);
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->is_read = true;
@@ -1331,7 +1357,7 @@ int librados::IoCtxImpl::aio_exec(const object_t& oid, AioCompletionImpl *c,
   prepare_assert_ops(&rd);
   rd.call(cls, method, inbl);
   Objecter::Op *o = objecter->prepare_read_op(
-    oid, oloc, rd, snap_seq, outbl, 0, oncomplete, &c->objver);
+    oid, oloc, rd, snap_seq, outbl, extra_op_flags, objclass_flags_mask, oncomplete, &c->objver);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -1343,7 +1369,7 @@ int librados::IoCtxImpl::aio_exec(const object_t& oid, AioCompletionImpl *c,
   FUNCTRACE(client->cct);
   Context *oncomplete = new C_aio_Complete(c);
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   ((C_aio_Complete *) oncomplete)->oid = oid;
 #endif
   c->is_read = true;
@@ -1357,7 +1383,7 @@ int librados::IoCtxImpl::aio_exec(const object_t& oid, AioCompletionImpl *c,
   prepare_assert_ops(&rd);
   rd.call(cls, method, inbl);
   Objecter::Op *o = objecter->prepare_read_op(
-    oid, oloc, rd, snap_seq, &c->bl, 0, oncomplete, &c->objver);
+    oid, oloc, rd, snap_seq, &c->bl, extra_op_flags, objclass_flags_mask, oncomplete, &c->objver);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -1409,7 +1435,7 @@ int librados::IoCtxImpl::mapext(const object_t& oid,
   Context *onack = new C_SafeCond(mylock, cond, &done, &r);
 
   objecter->mapext(oid, oloc,
-		   off, len, snap_seq, &bl, 0,
+		   off, len, snap_seq, &bl, extra_op_flags,
 		   onack);
 
   {
@@ -1477,7 +1503,7 @@ int librados::IoCtxImpl::stat(const object_t& oid, uint64_t *psize, time_t *pmti
 
   ::ObjectOperation rd;
   prepare_assert_ops(&rd);
-  rd.stat(psize, &mtime, NULL);
+  rd.stat(psize, &mtime, nullptr);
   int r = operate_read(oid, &rd, NULL);
 
   if (r >= 0 && pmtime) {
@@ -1497,7 +1523,7 @@ int librados::IoCtxImpl::stat2(const object_t& oid, uint64_t *psize, struct time
 
   ::ObjectOperation rd;
   prepare_assert_ops(&rd);
-  rd.stat(psize, &mtime, NULL);
+  rd.stat(psize, &mtime, nullptr);
   int r = operate_read(oid, &rd, NULL);
   if (r < 0) {
     return r;
@@ -1568,31 +1594,25 @@ void librados::IoCtxImpl::set_sync_op_version(version_t ver)
   last_objver = ver;
 }
 
-struct WatchInfo : public Objecter::WatchContext {
-  librados::IoCtxImpl *ioctx;
+namespace librados {
+void intrusive_ptr_add_ref(IoCtxImpl *p) { p->get(); }
+void intrusive_ptr_release(IoCtxImpl *p) { p->put(); }
+}
+
+struct WatchInfo {
+  boost::intrusive_ptr<librados::IoCtxImpl> ioctx;
   object_t oid;
   librados::WatchCtx *ctx;
   librados::WatchCtx2 *ctx2;
-  bool internal = false;
 
   WatchInfo(librados::IoCtxImpl *io, object_t o,
-	    librados::WatchCtx *c, librados::WatchCtx2 *c2,
-            bool inter)
-    : ioctx(io), oid(o), ctx(c), ctx2(c2), internal(inter) {
-    ioctx->get();
-  }
-  ~WatchInfo() override {
-    ioctx->put();
-    if (internal) {
-      delete ctx;
-      delete ctx2;
-    }
-  }
+	    librados::WatchCtx *c, librados::WatchCtx2 *c2)
+    : ioctx(io), oid(o), ctx(c), ctx2(c2) {}
 
   void handle_notify(uint64_t notify_id,
 		     uint64_t cookie,
 		     uint64_t notifier_id,
-		     bufferlist& bl) override {
+		     bufferlist& bl) {
     ldout(ioctx->client->cct, 10) << __func__ << " " << notify_id
 				  << " cookie " << cookie
 				  << " notifier_id " << notifier_id
@@ -1609,13 +1629,35 @@ struct WatchInfo : public Objecter::WatchContext {
       ioctx->notify_ack(oid, notify_id, cookie, empty);
     }
   }
-  void handle_error(uint64_t cookie, int err) override {
+  void handle_error(uint64_t cookie, int err) {
     ldout(ioctx->client->cct, 10) << __func__ << " cookie " << cookie
 				  << " err " << err
 				  << dendl;
     if (ctx2)
       ctx2->handle_error(cookie, err);
   }
+
+  void operator()(bs::error_code ec,
+		  uint64_t notify_id,
+		  uint64_t cookie,
+		  uint64_t notifier_id,
+		  bufferlist&& bl) {
+    if (ec) {
+      handle_error(cookie, ceph::from_error_code(ec));
+    } else {
+      handle_notify(notify_id, cookie, notifier_id, bl);
+    }
+  }
+};
+
+// internal WatchInfo that owns the context memory
+struct InternalWatchInfo : public WatchInfo {
+  std::unique_ptr<librados::WatchCtx> ctx;
+  std::unique_ptr<librados::WatchCtx2> ctx2;
+
+  InternalWatchInfo(librados::IoCtxImpl *io, object_t o,
+                    librados::WatchCtx *c, librados::WatchCtx2 *c2)
+    : WatchInfo(io, o, c, c2), ctx(c), ctx2(c2) {}
 };
 
 int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
@@ -1636,15 +1678,18 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
   version_t objver;
   C_SaferCond onfinish;
 
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc, 0);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
   *handle = linger_op->get_cookie();
-  linger_op->watch_context = new WatchInfo(this,
-					   oid, ctx, ctx2, internal);
-
+  if (internal) {
+    linger_op->handle = InternalWatchInfo(this, oid, ctx, ctx2);
+  } else {
+    linger_op->handle = WatchInfo(this, oid, ctx, ctx2);
+  }
   prepare_assert_ops(&wr);
   wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH, timeout);
   bufferlist bl;
-  objecter->linger_watch(linger_op, wr,
+  objecter->linger_watch(linger_op.get(), wr,
 			 snapc, ceph::real_clock::now(), bl,
 			 &onfinish,
 			 &objver);
@@ -1654,7 +1699,7 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
   set_sync_op_version(objver);
 
   if (r < 0) {
-    objecter->linger_cancel(linger_op);
+    objecter->linger_cancel(linger_op.get());
     *handle = 0;
   }
 
@@ -1678,18 +1723,23 @@ int librados::IoCtxImpl::aio_watch(const object_t& oid,
                                    uint32_t timeout,
                                    bool internal)
 {
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc, 0);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
   c->io = this;
   Context *oncomplete = new C_aio_linger_Complete(c, linger_op, false);
 
   ::ObjectOperation wr;
   *handle = linger_op->get_cookie();
-  linger_op->watch_context = new WatchInfo(this, oid, ctx, ctx2, internal);
+  if (internal) {
+    linger_op->handle = InternalWatchInfo(this, oid, ctx, ctx2);
+  } else {
+    linger_op->handle = WatchInfo(this, oid, ctx, ctx2);
+  }
 
   prepare_assert_ops(&wr);
   wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH, timeout);
   bufferlist bl;
-  objecter->linger_watch(linger_op, wr,
+  objecter->linger_watch(linger_op.get(), wr,
                          snapc, ceph::real_clock::now(), bl,
                          oncomplete, &c->objver);
 
@@ -1706,19 +1756,31 @@ int librados::IoCtxImpl::notify_ack(
   ::ObjectOperation rd;
   prepare_assert_ops(&rd);
   rd.notify_ack(notify_id, cookie, bl);
-  objecter->read(oid, oloc, rd, snap_seq, (bufferlist*)NULL, 0, 0, 0);
+  objecter->read(oid, oloc, rd, snap_seq, (bufferlist*)NULL, extra_op_flags, 0, 0);
   return 0;
 }
 
 int librados::IoCtxImpl::watch_check(uint64_t cookie)
 {
-  Objecter::LingerOp *linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
-  return objecter->linger_check(linger_op);
+  boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    return -ENOTCONN;
+  }
+  auto r = objecter->linger_check(linger_op.get());
+  if (r)
+    return 1 + std::chrono::duration_cast<
+      std::chrono::milliseconds>(*r).count();
+  else
+    return ceph::from_error_code(r.error());
 }
 
 int librados::IoCtxImpl::unwatch(uint64_t cookie)
 {
-  Objecter::LingerOp *linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
+  boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    return -ENOTCONN;
+  }
+
   C_SaferCond onfinish;
   version_t ver = 0;
 
@@ -1726,9 +1788,9 @@ int librados::IoCtxImpl::unwatch(uint64_t cookie)
   prepare_assert_ops(&wr);
   wr.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
-		   snapc, ceph::real_clock::now(), 0,
+		   snapc, ceph::real_clock::now(), extra_op_flags,
 		   &onfinish, &ver);
-  objecter->linger_cancel(linger_op);
+  objecter->linger_cancel(linger_op.get());
 
   int r = onfinish.wait();
   set_sync_op_version(ver);
@@ -1738,14 +1800,22 @@ int librados::IoCtxImpl::unwatch(uint64_t cookie)
 int librados::IoCtxImpl::aio_unwatch(uint64_t cookie, AioCompletionImpl *c)
 {
   c->io = this;
-  Objecter::LingerOp *linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
+  boost::intrusive_ptr linger_op = objecter->linger_by_cookie(cookie);
+  if (!linger_op) {
+    // reject invalid cookies with ENOTCONN, but deliver to the
+    // AioCompletion instead of returning directly
+    boost::asio::defer(client->finish_strand,
+        boost::asio::append(CB_AioCompleteAndSafe(c), -ENOTCONN));
+
+    return 0;
+  }
   Context *oncomplete = new C_aio_linger_Complete(c, linger_op, true);
 
   ::ObjectOperation wr;
   prepare_assert_ops(&wr);
   wr.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
-		   snapc, ceph::real_clock::now(), 0,
+		   snapc, ceph::real_clock::now(), extra_op_flags,
 		   oncomplete, &c->objver);
   return 0;
 }
@@ -1755,14 +1825,19 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
 				bufferlist *preply_bl,
 				char **preply_buf, size_t *preply_buf_len)
 {
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc, 0);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
 
   C_SaferCond notify_finish_cond;
-  Context *notify_finish = new C_notify_Finish(client->cct, &notify_finish_cond,
-                                               objecter, linger_op, preply_bl,
-                                               preply_buf, preply_buf_len);
-  (void) notify_finish;
-
+  auto e = boost::asio::prefer(
+    objecter->service.get_executor(),
+    boost::asio::execution::outstanding_work.tracked);
+  linger_op->on_notify_finish =
+    boost::asio::bind_executor(
+      std::move(e),
+      CB_notify_Finish(client->cct, &notify_finish_cond,
+                       objecter, linger_op.get(), preply_bl,
+                       preply_buf, preply_buf_len));
   uint32_t timeout = notify_timeout;
   if (timeout_ms)
     timeout = timeout_ms / 1000;
@@ -1776,7 +1851,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
   // Issue RADOS op
   C_SaferCond onack;
   version_t objver;
-  objecter->linger_notify(linger_op,
+  objecter->linger_notify(linger_op.get(),
 			  rd, snap_seq, inbl, NULL,
 			  &onack, &objver);
 
@@ -1796,7 +1871,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
     notify_finish_cond.wait();
   }
 
-  objecter->linger_cancel(linger_op);
+  objecter->linger_cancel(linger_op.get());
 
   set_sync_op_version(objver);
   return r;
@@ -1807,16 +1882,23 @@ int librados::IoCtxImpl::aio_notify(const object_t& oid, AioCompletionImpl *c,
                                     bufferlist *preply_bl, char **preply_buf,
                                     size_t *preply_buf_len)
 {
-  Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc, 0);
+  boost::intrusive_ptr linger_op = objecter->linger_register(oid, oloc,
+                                                             extra_op_flags);
 
   c->io = this;
 
   C_aio_notify_Complete *oncomplete = new C_aio_notify_Complete(c, linger_op);
-  C_notify_Finish *onnotify = new C_notify_Finish(client->cct, oncomplete,
-                                                  objecter, linger_op,
-                                                  preply_bl, preply_buf,
-                                                  preply_buf_len);
-  Context *onack = new C_aio_notify_Ack(client->cct, onnotify, oncomplete);
+  auto e = boost::asio::prefer(
+    objecter->service.get_executor(),
+    boost::asio::execution::outstanding_work.tracked);
+  linger_op->on_notify_finish =
+    boost::asio::bind_executor(
+      std::move(e),
+      CB_notify_Finish(client->cct, oncomplete,
+                       objecter, linger_op.get(),
+                       preply_bl, preply_buf,
+                       preply_buf_len));
+  Context *onack = new C_aio_notify_Ack(client->cct, oncomplete);
 
   uint32_t timeout = notify_timeout;
   if (timeout_ms)
@@ -1829,7 +1911,7 @@ int librados::IoCtxImpl::aio_notify(const object_t& oid, AioCompletionImpl *c,
   rd.notify(linger_op->get_cookie(), 1, timeout, bl, &inbl);
 
   // Issue RADOS op
-  objecter->linger_notify(linger_op,
+  objecter->linger_notify(linger_op.get(),
 			  rd, snap_seq, inbl, NULL,
 			  onack, &c->objver);
   return 0;
@@ -1900,7 +1982,7 @@ void librados::IoCtxImpl::C_aio_stat_Ack::finish(int r)
   }
 
   if (c->callback_complete) {
-    c->io->client->finisher.queue(new C_AioComplete(c));
+    boost::asio::defer(c->io->client->finish_strand, CB_AioComplete(c));
   }
 
   c->put_unlock();
@@ -1928,7 +2010,7 @@ void librados::IoCtxImpl::C_aio_stat2_Ack::finish(int r)
   }
 
   if (c->callback_complete) {
-    c->io->client->finisher.queue(new C_AioComplete(c));
+    boost::asio::defer(c->io->client->finish_strand, CB_AioComplete(c));
   }
 
   c->put_unlock();
@@ -1956,7 +2038,7 @@ void librados::IoCtxImpl::C_aio_Complete::finish(int r)
       c->rval = -ERANGE;
     } else {
       if (c->out_buf && !c->blp->is_provided_buffer(c->out_buf))
-        c->blp->copy(0, c->blp->length(), c->out_buf);
+        c->blp->begin().copy(c->blp->length(), c->out_buf);
 
       c->rval = c->blp->length();
     }
@@ -1964,14 +2046,14 @@ void librados::IoCtxImpl::C_aio_Complete::finish(int r)
 
   if (c->callback_complete ||
       c->callback_safe) {
-    c->io->client->finisher.queue(new C_AioComplete(c));
+    boost::asio::defer(c->io->client->finish_strand, CB_AioComplete(c));
   }
 
   if (c->aio_write_seq) {
     c->io->complete_aio_write(c);
   }
 
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_OP_COMPLETE");
 #endif
   c->put_unlock();
@@ -2028,6 +2110,7 @@ int librados::IoCtxImpl::application_enable(const std::string& app_name,
 
   r = c->get_return_value();
   c->release();
+  c->put();
   if (r < 0) {
     return r;
   }
@@ -2043,7 +2126,10 @@ void librados::IoCtxImpl::application_enable_async(const std::string& app_name,
   // preserved until Luminous is configured as minimim version.
   if (!client->get_required_monitor_features().contains_all(
         ceph::features::mon::FEATURE_LUMINOUS)) {
-    client->finisher.queue(new C_PoolAsync_Safe(c), -EOPNOTSUPP);
+    boost::asio::defer(client->finish_strand,
+		       [cb = CB_PoolAsync_Safe(c)]() mutable {
+			 cb(-EOPNOTSUPP);
+		       });
     return;
   }
 
@@ -2057,11 +2143,8 @@ void librados::IoCtxImpl::application_enable_async(const std::string& app_name,
   }
   cmd << "}";
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd.str());
-  bufferlist inbl;
-  client->mon_command_async(cmds, inbl, nullptr, nullptr,
-                            new C_PoolAsync_Safe(c));
+  client->mon_command_async({cmd.str()}, {}, nullptr, nullptr,
+                            make_lambda_context(CB_PoolAsync_Safe(c)));
 }
 
 int librados::IoCtxImpl::application_list(std::set<std::string> *app_names)
@@ -2124,10 +2207,7 @@ int librados::IoCtxImpl::application_metadata_set(const std::string& app_name,
       << "\"value\":\"" << value << "\""
       << "}";
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd.str());
-  bufferlist inbl;
-  int r = client->mon_command(cmds, inbl, nullptr, nullptr);
+  int r = client->mon_command({cmd.str()}, {}, nullptr, nullptr);
   if (r < 0) {
     return r;
   }
@@ -2147,10 +2227,7 @@ int librados::IoCtxImpl::application_metadata_remove(const std::string& app_name
       << "\"key\":\"" << key << "\""
       << "}";
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd.str());
-  bufferlist inbl;
-  int r = client->mon_command(cmds, inbl, nullptr, nullptr);
+  int r = client->mon_command({cmd.str()}, {}, nullptr, nullptr);
   if (r < 0) {
     return r;
   }

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -1,5 +1,6 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
 /*
  * Ceph - scalable distributed file system
  *
@@ -39,14 +40,17 @@ struct librados::IoCtxImpl {
   uint64_t assert_ver = 0;
   version_t last_objver = 0;
   uint32_t notify_timeout = 30;
+  bool no_version_on_read = false;
   object_locator_t oloc;
+  int extra_op_flags = 0;
+  int objclass_flags_mask = -1;
 
   ceph::mutex aio_write_list_lock =
     ceph::make_mutex("librados::IoCtxImpl::aio_write_list_lock");
   ceph_tid_t aio_write_seq = 0;
   ceph::condition_variable aio_write_cond;
   xlist<AioCompletionImpl*> aio_write_list;
-  map<ceph_tid_t, std::list<AioCompletionImpl*> > aio_write_waiters;
+  std::map<ceph_tid_t, std::list<AioCompletionImpl*> > aio_write_waiters;
 
   Objecter *objecter = nullptr;
 
@@ -64,11 +68,12 @@ struct librados::IoCtxImpl {
     last_objver = rhs.last_objver;
     notify_timeout = rhs.notify_timeout;
     oloc = rhs.oloc;
+    extra_op_flags = rhs.extra_op_flags;
     objecter = rhs.objecter;
   }
 
   void set_snap_read(snapid_t s);
-  int set_snap_write_context(snapid_t seq, vector<snapid_t>& snaps);
+  int set_snap_write_context(snapid_t seq, std::vector<snapid_t>& snaps);
 
   void get() {
     ref_cnt++;
@@ -88,7 +93,7 @@ struct librados::IoCtxImpl {
     return poolid;
   }
 
-  string get_cached_pool_name();
+  std::string get_cached_pool_name();
 
   int get_object_hash_position(const std::string& oid, uint32_t *hash_position);
   int get_object_pg_hash_position(const std::string& oid, uint32_t *pg_hash_position);
@@ -96,7 +101,7 @@ struct librados::IoCtxImpl {
   ::ObjectOperation *prepare_assert_ops(::ObjectOperation *op);
 
   // snaps
-  int snap_list(vector<uint64_t> *snaps);
+  int snap_list(std::vector<uint64_t> *snaps);
   int snap_lookup(const char *name, uint64_t *snapid);
   int snap_get_name(uint64_t snapid, std::string *s);
   int snap_get_stamp(uint64_t snapid, time_t *t);
@@ -149,14 +154,15 @@ struct librados::IoCtxImpl {
 
   int getxattr(const object_t& oid, const char *name, bufferlist& bl);
   int setxattr(const object_t& oid, const char *name, bufferlist& bl);
-  int getxattrs(const object_t& oid, map<string, bufferlist>& attrset);
+  int getxattrs(const object_t& oid, std::map<std::string, bufferlist>& attrset);
   int rmxattr(const object_t& oid, const char *name);
 
-  int operate(const object_t& oid, ::ObjectOperation *o, ceph::real_time *pmtime, int flags=0);
-  int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
+  int operate(const object_t& oid, ::ObjectOperation *o, ceph::real_time *pmtime, int flags=0, const jspan_context *otel_trace = nullptr);
+  int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0, int flags_mask=-1);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags, const blkin_trace_info *trace_info = nullptr);
+		  const ceph::real_time *pmtime, int flags,
+		  const blkin_trace_info *trace_info = nullptr, const jspan_context *otel_trace = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
 
@@ -177,7 +183,7 @@ struct librados::IoCtxImpl {
   };
 
   struct C_aio_Complete : public Context {
-#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
+#if defined(WITH_EVENTTRACE)
     object_t oid;
 #endif
     AioCompletionImpl *c;
@@ -219,7 +225,7 @@ struct librados::IoCtxImpl {
   int aio_setxattr(const object_t& oid, AioCompletionImpl *c,
 		   const char *name, bufferlist& bl);
   int aio_getxattrs(const object_t& oid, AioCompletionImpl *c,
-		    map<string, bufferlist>& attrset);
+		    std::map<std::string, bufferlist>& attrset);
   int aio_rmxattr(const object_t& oid, AioCompletionImpl *c,
 		  const char *name);
   int aio_cancel(AioCompletionImpl *c);
@@ -292,6 +298,9 @@ struct librados::IoCtxImpl {
   int application_metadata_list(const std::string& app_name,
                                 std::map<std::string, std::string> *values);
 
+  void set_no_version_on_read(bool _val);
+ private:
+  version_t *get_objver_for_read(version_t *objver_p) const;
 };
 
 #endif

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -1,35 +1,30 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
 
 #include <limits.h>
 
-#include "common/config.h"
-#include "common/errno.h"
+#include "acconfig.h"
 #include "common/ceph_argparse.h"
-#include "common/ceph_json.h"
 #include "common/common_init.h"
 #include "common/TracepointProvider.h"
 #include "common/hobject.h"
+#include "common/async/waiter.h"
 #include "include/rados/librados.h"
-#include "include/types.h"
-#include <include/stringify.h>
 
 #include "librados/librados_c.h"
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
-#include "librados/PoolAsyncCompletionImpl.h"
+#include "librados/ObjectOperationImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/RadosXattrIter.h"
 #include "librados/ListObjectImpl.h"
 #include "librados/librados_util.h"
-#include <cls/lock/cls_lock_client.h>
 
 #include <string>
 #include <map>
 #include <set>
 #include <vector>
 #include <list>
-#include <stdexcept>
 
 #ifdef WITH_LTTNG
 #define TRACEPOINT_DEFINE
@@ -41,13 +36,45 @@
 #define tracepoint(...)
 #endif
 
+#if defined(LIBRADOS_SHARED) && (defined(HAVE_ASM_SYMVER) || defined(HAVE_ATTR_SYMVER))
+// prefer __attribute__() over global asm(".symver"). because the latter
+// is not parsed by the compiler and is partitioned away by GCC if
+// lto-partitions is enabled, in other words, these asm() statements
+// are dropped by the -flto option by default. the way to address it is
+// to use __attribute__. so this information can be processed by the
+// C compiler, and be preserved after LTO partitions the code
+#ifdef HAVE_ATTR_SYMVER
+#define LIBRADOS_C_API_BASE(fn)               \
+  extern __typeof (_##fn##_base) _##fn##_base __attribute__((__symver__ (#fn "@")))
+#define LIBRADOS_C_API_BASE_DEFAULT(fn)       \
+  extern __typeof (_##fn) _##fn __attribute__((__symver__ (#fn "@@")))
+#define LIBRADOS_C_API_DEFAULT(fn, ver)       \
+  extern __typeof (_##fn) _##fn __attribute__((__symver__ (#fn "@@LIBRADOS_" #ver)))
+#else
 #define LIBRADOS_C_API_BASE(fn)               \
   asm(".symver _" #fn "_base, " #fn "@")
 #define LIBRADOS_C_API_BASE_DEFAULT(fn)       \
   asm(".symver _" #fn ", " #fn "@@")
 #define LIBRADOS_C_API_DEFAULT(fn, ver)       \
   asm(".symver _" #fn ", " #fn "@@LIBRADOS_" #ver)
+#endif
 
+#define LIBRADOS_C_API_BASE_F(fn) _ ## fn ## _base
+#define LIBRADOS_C_API_DEFAULT_F(fn) _ ## fn
+
+#else
+#define LIBRADOS_C_API_BASE(fn)
+#define LIBRADOS_C_API_BASE_DEFAULT(fn)
+#define LIBRADOS_C_API_DEFAULT(fn, ver)
+
+#define LIBRADOS_C_API_BASE_F(fn) _ ## fn ## _base
+// There shouldn't be multiple default versions of the same
+// function.
+#define LIBRADOS_C_API_DEFAULT_F(fn) fn
+#endif
+
+using std::ostringstream;
+using std::pair;
 using std::string;
 using std::map;
 using std::set;
@@ -84,8 +111,9 @@ static TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tra
 
 ///////////////////////////// C API //////////////////////////////
 
-static CephContext *rados_create_cct(const char * const clustername,
-                                     CephInitParameters *iparams)
+static CephContext *rados_create_cct(
+  const char * const clustername,
+  CephInitParameters *iparams)
 {
   // missing things compared to global_init:
   // g_ceph_context, g_conf, g_lockdep, signal handlers
@@ -99,7 +127,9 @@ static CephContext *rados_create_cct(const char * const clustername,
   return cct;
 }
 
-extern "C" int _rados_create(rados_t *pcluster, const char * const id)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_create)(
+  rados_t *pcluster,
+  const char * const id)
 {
   CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
   if (id) {
@@ -122,8 +152,11 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_create);
 // 3) flags is for future expansion (maybe some of the global_init()
 //    behavior is appropriate for some consumers of librados, for instance)
 
-extern "C" int _rados_create2(rados_t *pcluster, const char *const clustername,
-			      const char * const name, uint64_t flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_create2)(
+  rados_t *pcluster,
+  const char *const clustername,
+  const char * const name,
+  uint64_t flags)
 {
   // client is assumed, but from_str will override
   int retval = 0;
@@ -148,7 +181,9 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_create2);
  * already called global_init and want to use that particular configuration for
  * their cluster.
  */
-extern "C" int _rados_create_with_context(rados_t *pcluster, rados_config_t cct_)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_create_with_context)(
+  rados_t *pcluster,
+  rados_config_t cct_)
 {
   CephContext *cct = (CephContext *)cct_;
   TracepointProvider::initialize<tracepoint_traits>(cct);
@@ -161,7 +196,7 @@ extern "C" int _rados_create_with_context(rados_t *pcluster, rados_config_t cct_
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_create_with_context);
 
-extern "C" rados_config_t _rados_cct(rados_t cluster)
+extern "C" rados_config_t LIBRADOS_C_API_DEFAULT_F(rados_cct)(rados_t cluster)
 {
   tracepoint(librados, rados_cct_enter, cluster);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -171,7 +206,7 @@ extern "C" rados_config_t _rados_cct(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_cct);
 
-extern "C" int _rados_connect(rados_t cluster)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_connect)(rados_t cluster)
 {
   tracepoint(librados, rados_connect_enter, cluster);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -181,7 +216,7 @@ extern "C" int _rados_connect(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_connect);
 
-extern "C" void _rados_shutdown(rados_t cluster)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_shutdown)(rados_t cluster)
 {
   tracepoint(librados, rados_shutdown_enter, cluster);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -191,7 +226,8 @@ extern "C" void _rados_shutdown(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_shutdown);
 
-extern "C" uint64_t _rados_get_instance_id(rados_t cluster)
+extern "C" uint64_t LIBRADOS_C_API_DEFAULT_F(rados_get_instance_id)(
+  rados_t cluster)
 {
   tracepoint(librados, rados_get_instance_id_enter, cluster);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -201,17 +237,19 @@ extern "C" uint64_t _rados_get_instance_id(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_get_instance_id);
 
-extern "C" int _rados_get_min_compatible_osd(rados_t cluster,
-                                             int8_t* require_osd_release)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_get_min_compatible_osd)(
+  rados_t cluster,
+  int8_t* require_osd_release)
 {
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   return client->get_min_compatible_osd(require_osd_release);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_get_min_compatible_osd);
 
-extern "C" int _rados_get_min_compatible_client(rados_t cluster,
-                                                int8_t* min_compat_client,
-                                                int8_t* require_min_compat_client)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_get_min_compatible_client)(
+  rados_t cluster,
+  int8_t* min_compat_client,
+  int8_t* require_min_compat_client)
 {
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   return client->get_min_compatible_client(min_compat_client,
@@ -219,7 +257,8 @@ extern "C" int _rados_get_min_compatible_client(rados_t cluster,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_get_min_compatible_client);
 
-extern "C" void _rados_version(int *major, int *minor, int *extra)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_version)(
+  int *major, int *minor, int *extra)
 {
   tracepoint(librados, rados_version_enter, major, minor, extra);
   if (major)
@@ -234,7 +273,9 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_version);
 
 
 // -- config --
-extern "C" int _rados_conf_read_file(rados_t cluster, const char *path_list)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_read_file)(
+  rados_t cluster,
+  const char *path_list)
 {
   tracepoint(librados, rados_conf_read_file_enter, cluster, path_list);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -257,7 +298,10 @@ extern "C" int _rados_conf_read_file(rados_t cluster, const char *path_list)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_conf_read_file);
 
-extern "C" int _rados_conf_parse_argv(rados_t cluster, int argc, const char **argv)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_parse_argv)(
+  rados_t cluster,
+  int argc,
+  const char **argv)
 {
   tracepoint(librados, rados_conf_parse_argv_enter, cluster, argc);
   int i;
@@ -266,8 +310,7 @@ extern "C" int _rados_conf_parse_argv(rados_t cluster, int argc, const char **ar
   }
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   auto& conf = client->cct->_conf;
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   int ret = conf.parse_argv(args);
   if (ret) {
     tracepoint(librados, rados_conf_parse_argv_exit, ret);
@@ -284,9 +327,10 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_conf_parse_argv);
 // remargv will contain n <= argc pointers to original argv[], the end
 // of which may be NULL
 
-extern "C" int _rados_conf_parse_argv_remainder(rados_t cluster, int argc,
-					        const char **argv,
-					        const char **remargv)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_parse_argv_remainder)(
+  rados_t cluster, int argc,
+  const char **argv,
+  const char **remargv)
 {
   tracepoint(librados, rados_conf_parse_argv_remainder_enter, cluster, argc);
   unsigned int i;
@@ -317,7 +361,8 @@ extern "C" int _rados_conf_parse_argv_remainder(rados_t cluster, int argc,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_conf_parse_argv_remainder);
 
-extern "C" int _rados_conf_parse_env(rados_t cluster, const char *env)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_parse_env)(
+  rados_t cluster, const char *env)
 {
   tracepoint(librados, rados_conf_parse_env_enter, cluster, env);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -329,7 +374,10 @@ extern "C" int _rados_conf_parse_env(rados_t cluster, const char *env)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_conf_parse_env);
 
-extern "C" int _rados_conf_set(rados_t cluster, const char *option, const char *value)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_set)(
+  rados_t cluster,
+  const char *option,
+  const char *value)
 {
   tracepoint(librados, rados_conf_set_enter, cluster, option, value);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -346,7 +394,9 @@ extern "C" int _rados_conf_set(rados_t cluster, const char *option, const char *
 LIBRADOS_C_API_BASE_DEFAULT(rados_conf_set);
 
 /* cluster info */
-extern "C" int _rados_cluster_stat(rados_t cluster, rados_cluster_stat_t *result)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_cluster_stat)(
+  rados_t cluster,
+  rados_cluster_stat_t *result)
 {
   tracepoint(librados, rados_cluster_stat_enter, cluster);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -362,7 +412,10 @@ extern "C" int _rados_cluster_stat(rados_t cluster, rados_cluster_stat_t *result
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_cluster_stat);
 
-extern "C" int _rados_conf_get(rados_t cluster, const char *option, char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_get)(
+  rados_t cluster,
+  const char *option,
+  char *buf, size_t len)
 {
   tracepoint(librados, rados_conf_get_enter, cluster, option, len);
   char *tmp = buf;
@@ -374,7 +427,9 @@ extern "C" int _rados_conf_get(rados_t cluster, const char *option, char *buf, s
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_conf_get);
 
-extern "C" int64_t _rados_pool_lookup(rados_t cluster, const char *name)
+extern "C" int64_t LIBRADOS_C_API_DEFAULT_F(rados_pool_lookup)(
+  rados_t cluster,
+  const char *name)
 {
   tracepoint(librados, rados_pool_lookup_enter, cluster, name);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -384,13 +439,16 @@ extern "C" int64_t _rados_pool_lookup(rados_t cluster, const char *name)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_lookup);
 
-extern "C" int _rados_pool_reverse_lookup(rados_t cluster, int64_t id,
-					  char *buf, size_t maxlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_reverse_lookup)(
+  rados_t cluster,
+  int64_t id,
+  char *buf,
+  size_t maxlen)
 {
   tracepoint(librados, rados_pool_reverse_lookup_enter, cluster, id, maxlen);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
   std::string name;
-  int r = radosp->pool_get_name(id, &name);
+  int r = radosp->pool_get_name(id, &name, true);
   if (r < 0) {
     tracepoint(librados, rados_pool_reverse_lookup_exit, r, "");
     return r;
@@ -406,8 +464,10 @@ extern "C" int _rados_pool_reverse_lookup(rados_t cluster, int64_t id,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_reverse_lookup);
 
-extern "C" int _rados_cluster_fsid(rados_t cluster, char *buf,
-				   size_t maxlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_cluster_fsid)(
+  rados_t cluster,
+  char *buf,
+  size_t maxlen)
 {
   tracepoint(librados, rados_cluster_fsid_enter, cluster, maxlen);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -424,7 +484,8 @@ extern "C" int _rados_cluster_fsid(rados_t cluster, char *buf,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_cluster_fsid);
 
-extern "C" int _rados_wait_for_latest_osdmap(rados_t cluster)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_wait_for_latest_osdmap)(
+  rados_t cluster)
 {
   tracepoint(librados, rados_wait_for_latest_osdmap_enter, cluster);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -434,38 +495,83 @@ extern "C" int _rados_wait_for_latest_osdmap(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_wait_for_latest_osdmap);
 
-extern "C" int _rados_blacklist_add(rados_t cluster, char *client_address,
-				    uint32_t expire_seconds)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_blocklist_add)(
+  rados_t cluster,
+  char *client_address,
+  uint32_t expire_seconds)
 {
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
-  return radosp->blacklist_add(client_address, expire_seconds);
+  return radosp->blocklist_add(client_address, expire_seconds);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_blocklist_add);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_blacklist_add)(
+  rados_t cluster,
+  char *client_address,
+  uint32_t expire_seconds)
+{
+  return LIBRADOS_C_API_DEFAULT_F(rados_blocklist_add)(
+    cluster, client_address, expire_seconds);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_blacklist_add);
 
-extern "C" void _rados_set_osdmap_full_try(rados_ioctx_t io)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_getaddrs)(
+  rados_t cluster,
+  char** addrs)
+{
+  librados::RadosClient *radosp = (librados::RadosClient *)cluster;
+  auto s = radosp->get_addrs();
+  *addrs = strdup(s.c_str());
+  return 0;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_getaddrs);
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_set_osdmap_full_try)(
+  rados_ioctx_t io)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
-  ctx->objecter->set_osdmap_full_try();
+  ctx->extra_op_flags |= CEPH_OSD_FLAG_FULL_TRY;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_set_osdmap_full_try);
 
-extern "C" void _rados_unset_osdmap_full_try(rados_ioctx_t io)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_unset_osdmap_full_try)(
+  rados_ioctx_t io)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
-  ctx->objecter->unset_osdmap_full_try();
+  ctx->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_unset_osdmap_full_try);
 
-extern "C" int _rados_application_enable(rados_ioctx_t io, const char *app_name,
-                                         int force)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_set_pool_full_try)(
+  rados_ioctx_t io)
+{
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  ctx->extra_op_flags |= CEPH_OSD_FLAG_FULL_TRY;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_set_pool_full_try);
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_unset_pool_full_try)(
+  rados_ioctx_t io)
+{
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  ctx->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_unset_pool_full_try);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_enable)(
+  rados_ioctx_t io,
+  const char *app_name,
+  int force)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   return ctx->application_enable(app_name, force != 0);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_application_enable);
 
-extern "C" int _rados_application_list(rados_ioctx_t io, char *values,
-                                       size_t *values_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_list)(
+  rados_ioctx_t io,
+  char *values,
+  size_t *values_len)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   std::set<std::string> app_names;
@@ -496,10 +602,12 @@ extern "C" int _rados_application_list(rados_ioctx_t io, char *values,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_application_list);
 
-extern "C" int _rados_application_metadata_get(rados_ioctx_t io,
-                                               const char *app_name,
-                                               const char *key, char *value,
-                                               size_t *value_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_metadata_get)(
+  rados_ioctx_t io,
+  const char *app_name,
+  const char *key,
+  char *value,
+  size_t *value_len)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   std::string value_str;
@@ -520,29 +628,32 @@ extern "C" int _rados_application_metadata_get(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_application_metadata_get);
 
-extern "C" int _rados_application_metadata_set(rados_ioctx_t io,
-                                               const char *app_name,
-                                               const char *key,
-                                               const char *value)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_metadata_set)(
+  rados_ioctx_t io,
+  const char *app_name,
+  const char *key,
+  const char *value)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   return ctx->application_metadata_set(app_name, key, value);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_application_metadata_set);
 
-extern "C" int _rados_application_metadata_remove(rados_ioctx_t io,
-                                                  const char *app_name,
-                                                  const char *key)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_metadata_remove)(
+  rados_ioctx_t io,
+  const char *app_name,
+  const char *key)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   return ctx->application_metadata_remove(app_name, key);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_application_metadata_remove);
 
-extern "C" int _rados_application_metadata_list(rados_ioctx_t io,
-                                                const char *app_name,
-                                                char *keys, size_t *keys_len,
-                                                char *values, size_t *vals_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_metadata_list)(
+  rados_ioctx_t io,
+  const char *app_name,
+  char *keys, size_t *keys_len,
+  char *values, size_t *vals_len)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   std::map<std::string, std::string> metadata;
@@ -584,7 +695,10 @@ extern "C" int _rados_application_metadata_list(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_application_metadata_list);
 
-extern "C" int _rados_pool_list(rados_t cluster, char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_list)(
+  rados_t cluster,
+  char *buf,
+  size_t len)
 {
   tracepoint(librados, rados_pool_list_enter, cluster, len);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -601,8 +715,10 @@ extern "C" int _rados_pool_list(rados_t cluster, char *buf, size_t len)
   }
 
   char *b = buf;
-  if (b)
+  if (b) {
+    // FIPS zeroization audit 20191116: this memset is not security related.
     memset(b, 0, len);
+  }
   int needed = 0;
   std::list<std::pair<int64_t, std::string> >::const_iterator i = pools.begin();
   std::list<std::pair<int64_t, std::string> >::const_iterator p_end =
@@ -630,8 +746,11 @@ extern "C" int _rados_pool_list(rados_t cluster, char *buf, size_t len)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_list);
 
-extern "C" int _rados_inconsistent_pg_list(rados_t cluster, int64_t pool_id,
-					   char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_inconsistent_pg_list)(
+  rados_t cluster,
+  int64_t pool_id,
+  char *buf,
+  size_t len)
 {
   tracepoint(librados, rados_inconsistent_pg_list_enter, cluster, pool_id, len);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -647,8 +766,10 @@ extern "C" int _rados_inconsistent_pg_list(rados_t cluster, int64_t pool_id,
   }
 
   char *b = buf;
-  if (b)
+  if (b) {
+    // FIPS zeroization audit 20191116: this memset is not security related.
     memset(b, 0, len);
+  }
   int needed = 0;
   for (const auto& s : pgs) {
     unsigned rl = s.length() + 1;
@@ -679,9 +800,11 @@ static void dict_to_map(const char *dict,
   }
 }
 
-extern "C" int _rados_service_register(rados_t cluster, const char *service,
-                                       const char *daemon,
-                                       const char *metadata_dict)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_service_register)(
+  rados_t cluster,
+  const char *service,
+  const char *daemon,
+  const char *metadata_dict)
 {
   librados::RadosClient *client = (librados::RadosClient *)cluster;
 
@@ -692,8 +815,9 @@ extern "C" int _rados_service_register(rados_t cluster, const char *service,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_service_register);
 
-extern "C" int _rados_service_update_status(rados_t cluster,
-                                            const char *status_dict)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_service_update_status)(
+  rados_t cluster,
+  const char *status_dict)
 {
   librados::RadosClient *client = (librados::RadosClient *)cluster;
 
@@ -732,8 +856,11 @@ static void do_out_buffer(string& outbl, char **outbuf, size_t *outbuflen)
     *outbuflen = outbl.length();
 }
 
-extern "C" int _rados_ping_monitor(rados_t cluster, const char *mon_id,
-                                   char **outstr, size_t *outstrlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ping_monitor)(
+  rados_t cluster,
+  const char *mon_id,
+  char **outstr,
+  size_t *outstrlen)
 {
   tracepoint(librados, rados_ping_monitor_enter, cluster, mon_id);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -753,11 +880,12 @@ extern "C" int _rados_ping_monitor(rados_t cluster, const char *mon_id,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ping_monitor);
 
-extern "C" int _rados_mon_command(rados_t cluster, const char **cmd,
-				  size_t cmdlen,
-				  const char *inbuf, size_t inbuflen,
-				  char **outbuf, size_t *outbuflen,
-				  char **outs, size_t *outslen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mon_command)(
+  rados_t cluster,
+  const char **cmd, size_t cmdlen,
+  const char *inbuf, size_t inbuflen,
+  char **outbuf, size_t *outbuflen,
+  char **outs, size_t *outslen)
 {
   tracepoint(librados, rados_mon_command_enter, cluster, cmdlen, inbuf, inbuflen);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -772,7 +900,7 @@ extern "C" int _rados_mon_command(rados_t cluster, const char **cmd,
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->mon_command(cmdvec, inbl, &outbl, &outstring);
+  int ret = client->mon_command(std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -781,12 +909,13 @@ extern "C" int _rados_mon_command(rados_t cluster, const char **cmd,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_mon_command);
 
-extern "C" int _rados_mon_command_target(rados_t cluster, const char *name,
-					 const char **cmd,
-					 size_t cmdlen,
-					 const char *inbuf, size_t inbuflen,
-					 char **outbuf, size_t *outbuflen,
-					 char **outs, size_t *outslen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mon_command_target)(
+  rados_t cluster,
+  const char *name,
+  const char **cmd, size_t cmdlen,
+  const char *inbuf, size_t inbuflen,
+  char **outbuf, size_t *outbuflen,
+  char **outs, size_t *outslen)
 {
   tracepoint(librados, rados_mon_command_target_enter, cluster, name, cmdlen, inbuf, inbuflen);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -814,9 +943,9 @@ extern "C" int _rados_mon_command_target(rados_t cluster, const char *name,
   inbl.append(inbuf, inbuflen);
   int ret;
   if (rank >= 0)
-    ret = client->mon_command(rank, cmdvec, inbl, &outbl, &outstring);
+    ret = client->mon_command(rank, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
   else
-    ret = client->mon_command(name, cmdvec, inbl, &outbl, &outstring);
+    ret = client->mon_command(name, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -825,11 +954,12 @@ extern "C" int _rados_mon_command_target(rados_t cluster, const char *name,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_mon_command_target);
 
-extern "C" int _rados_osd_command(rados_t cluster, int osdid, const char **cmd,
-				  size_t cmdlen,
-				  const char *inbuf, size_t inbuflen,
-				  char **outbuf, size_t *outbuflen,
-				  char **outs, size_t *outslen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_osd_command)(
+  rados_t cluster, int osdid, const char **cmd,
+  size_t cmdlen,
+  const char *inbuf, size_t inbuflen,
+  char **outbuf, size_t *outbuflen,
+  char **outs, size_t *outslen)
 {
   tracepoint(librados, rados_osd_command_enter, cluster, osdid, cmdlen, inbuf, inbuflen);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -844,7 +974,7 @@ extern "C" int _rados_osd_command(rados_t cluster, int osdid, const char **cmd,
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->osd_command(osdid, cmdvec, inbl, &outbl, &outstring);
+  int ret = client->osd_command(osdid, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -853,11 +983,12 @@ extern "C" int _rados_osd_command(rados_t cluster, int osdid, const char **cmd,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_osd_command);
 
-extern "C" int _rados_mgr_command(rados_t cluster, const char **cmd,
-				  size_t cmdlen,
-				  const char *inbuf, size_t inbuflen,
-				  char **outbuf, size_t *outbuflen,
-				  char **outs, size_t *outslen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mgr_command)(
+  rados_t cluster, const char **cmd,
+  size_t cmdlen,
+  const char *inbuf, size_t inbuflen,
+  char **outbuf, size_t *outbuflen,
+  char **outs, size_t *outslen)
 {
   tracepoint(librados, rados_mgr_command_enter, cluster, cmdlen, inbuf,
       inbuflen);
@@ -874,7 +1005,7 @@ extern "C" int _rados_mgr_command(rados_t cluster, const char **cmd,
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->mgr_command(cmdvec, inbl, &outbl, &outstring);
+  int ret = client->mgr_command(std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -884,11 +1015,46 @@ extern "C" int _rados_mgr_command(rados_t cluster, const char **cmd,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_mgr_command);
 
-extern "C" int _rados_pg_command(rados_t cluster, const char *pgstr,
-				 const char **cmd, size_t cmdlen,
-				 const char *inbuf, size_t inbuflen,
-				 char **outbuf, size_t *outbuflen,
-				 char **outs, size_t *outslen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mgr_command_target)(
+  rados_t cluster,
+  const char *name,
+  const char **cmd,
+  size_t cmdlen,
+  const char *inbuf, size_t inbuflen,
+  char **outbuf, size_t *outbuflen,
+  char **outs, size_t *outslen)
+{
+  tracepoint(librados, rados_mgr_command_target_enter, cluster, name, cmdlen,
+	     inbuf, inbuflen);
+
+  librados::RadosClient *client = (librados::RadosClient *)cluster;
+  bufferlist inbl;
+  bufferlist outbl;
+  string outstring;
+  vector<string> cmdvec;
+
+  for (size_t i = 0; i < cmdlen; i++) {
+    tracepoint(librados, rados_mgr_command_target_cmd, cmd[i]);
+    cmdvec.push_back(cmd[i]);
+  }
+
+  inbl.append(inbuf, inbuflen);
+  int ret = client->mgr_command(name, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
+
+  do_out_buffer(outbl, outbuf, outbuflen);
+  do_out_buffer(outstring, outs, outslen);
+  tracepoint(librados, rados_mgr_command_target_exit, ret, outbuf, outbuflen,
+	     outs, outslen);
+  return ret;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_mgr_command_target);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pg_command)(
+  rados_t cluster, const char *pgstr,
+  const char **cmd, size_t cmdlen,
+  const char *inbuf, size_t inbuflen,
+  char **outbuf, size_t *outbuflen,
+  char **outs, size_t *outslen)
 {
   tracepoint(librados, rados_pg_command_enter, cluster, pgstr, cmdlen, inbuf, inbuflen);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -907,7 +1073,7 @@ extern "C" int _rados_pg_command(rados_t cluster, const char *pgstr,
   if (!pgid.parse(pgstr))
     return -EINVAL;
 
-  int ret = client->pg_command(pgid, cmdvec, inbl, &outbl, &outstring);
+  int ret = client->pg_command(pgid, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -916,7 +1082,7 @@ extern "C" int _rados_pg_command(rados_t cluster, const char *pgstr,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pg_command);
 
-extern "C" void _rados_buffer_free(char *buf)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_buffer_free)(char *buf)
 {
   tracepoint(librados, rados_buffer_free_enter, buf);
   if (buf)
@@ -925,7 +1091,11 @@ extern "C" void _rados_buffer_free(char *buf)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_buffer_free);
 
-extern "C" int _rados_monitor_log(rados_t cluster, const char *level, rados_log_callback_t cb, void *arg)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_monitor_log)(
+  rados_t cluster,
+  const char *level,
+  rados_log_callback_t cb,
+  void *arg)
 {
   tracepoint(librados, rados_monitor_log_enter, cluster, level, cb, arg);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -935,8 +1105,11 @@ extern "C" int _rados_monitor_log(rados_t cluster, const char *level, rados_log_
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_monitor_log);
 
-extern "C" int _rados_monitor_log2(rados_t cluster, const char *level,
-				   rados_log_callback2_t cb, void *arg)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_monitor_log2)(
+  rados_t cluster,
+  const char *level,
+	rados_log_callback2_t cb,
+  void *arg)
 {
   tracepoint(librados, rados_monitor_log2_enter, cluster, level, cb, arg);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -946,7 +1119,10 @@ extern "C" int _rados_monitor_log2(rados_t cluster, const char *level,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_monitor_log2);
 
-extern "C" int _rados_ioctx_create(rados_t cluster, const char *name, rados_ioctx_t *io)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_create)(
+  rados_t cluster,
+  const char *name,
+  rados_ioctx_t *io)
 {
   tracepoint(librados, rados_ioctx_create_enter, cluster, name);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -965,8 +1141,10 @@ extern "C" int _rados_ioctx_create(rados_t cluster, const char *name, rados_ioct
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_create);
 
-extern "C" int _rados_ioctx_create2(rados_t cluster, int64_t pool_id,
-                                    rados_ioctx_t *io)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_create2)(
+  rados_t cluster,
+  int64_t pool_id,
+  rados_ioctx_t *io)
 {
   tracepoint(librados, rados_ioctx_create2_enter, cluster, pool_id);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -985,17 +1163,20 @@ extern "C" int _rados_ioctx_create2(rados_t cluster, int64_t pool_id,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_create2);
 
-extern "C" void _rados_ioctx_destroy(rados_ioctx_t io)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_ioctx_destroy)(rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_destroy_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
-  ctx->put();
+  if (ctx) {
+    ctx->put();
+  }
   tracepoint(librados, rados_ioctx_destroy_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_destroy);
 
-extern "C" int _rados_ioctx_pool_stat(rados_ioctx_t io,
-                                      struct rados_pool_stat_t *stats)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_stat)(
+  rados_ioctx_t io,
+  struct rados_pool_stat_t *stats)
 {
   tracepoint(librados, rados_ioctx_pool_stat_enter, io);
   librados::IoCtxImpl *io_ctx_impl = (librados::IoCtxImpl *)io;
@@ -1050,11 +1231,11 @@ extern "C" int _rados_ioctx_pool_stat(rados_ioctx_t io,
 }
 LIBRADOS_C_API_DEFAULT(rados_ioctx_pool_stat, 14.2.0);
 
-extern "C" int _rados_ioctx_pool_stat_base(
+extern "C" int LIBRADOS_C_API_BASE_F(rados_ioctx_pool_stat)(
     rados_ioctx_t io, struct __librados_base::rados_pool_stat_t *stats)
 {
   struct rados_pool_stat_t new_stats;
-  int r = _rados_ioctx_pool_stat(io, &new_stats);
+  int r = LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_stat)(io, &new_stats);
   if (r < 0) {
     return r;
   }
@@ -1075,7 +1256,8 @@ extern "C" int _rados_ioctx_pool_stat_base(
 }
 LIBRADOS_C_API_BASE(rados_ioctx_pool_stat);
 
-extern "C" rados_config_t _rados_ioctx_cct(rados_ioctx_t io)
+extern "C" rados_config_t LIBRADOS_C_API_DEFAULT_F(rados_ioctx_cct)(
+  rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_cct_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1085,7 +1267,9 @@ extern "C" rados_config_t _rados_ioctx_cct(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_cct);
 
-extern "C" void _rados_ioctx_snap_set_read(rados_ioctx_t io, rados_snap_t seq)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_set_read)(
+  rados_ioctx_t io,
+  rados_snap_t seq)
 {
   tracepoint(librados, rados_ioctx_snap_set_read_enter, io, seq);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1094,8 +1278,11 @@ extern "C" void _rados_ioctx_snap_set_read(rados_ioctx_t io, rados_snap_t seq)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_set_read);
 
-extern "C" int _rados_ioctx_selfmanaged_snap_set_write_ctx(
-    rados_ioctx_t io, rados_snap_t seq, rados_snap_t *snaps, int num_snaps)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_selfmanaged_snap_set_write_ctx)(
+  rados_ioctx_t io,
+  rados_snap_t seq,
+  rados_snap_t *snaps,
+  int num_snaps)
 {
   tracepoint(librados, rados_ioctx_selfmanaged_snap_set_write_ctx_enter, io, seq, snaps, num_snaps);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1110,7 +1297,12 @@ extern "C" int _rados_ioctx_selfmanaged_snap_set_write_ctx(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_selfmanaged_snap_set_write_ctx);
 
-extern "C" int _rados_write(rados_ioctx_t io, const char *o, const char *buf, size_t len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *buf,
+  size_t len,
+  uint64_t off)
 {
   tracepoint(librados, rados_write_enter, io, o, buf, len, off);
   if (len > UINT_MAX/2)
@@ -1125,7 +1317,11 @@ extern "C" int _rados_write(rados_ioctx_t io, const char *o, const char *buf, si
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write);
 
-extern "C" int _rados_append(rados_ioctx_t io, const char *o, const char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_append)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *buf,
+  size_t len)
 {
   tracepoint(librados, rados_append_enter, io, o, buf, len);
   if (len > UINT_MAX/2)
@@ -1140,7 +1336,11 @@ extern "C" int _rados_append(rados_ioctx_t io, const char *o, const char *buf, s
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_append);
 
-extern "C" int _rados_write_full(rados_ioctx_t io, const char *o, const char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_full)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *buf,
+  size_t len)
 {
   tracepoint(librados, rados_write_full_enter, io, o, buf, len);
   if (len > UINT_MAX/2)
@@ -1155,12 +1355,13 @@ extern "C" int _rados_write_full(rados_ioctx_t io, const char *o, const char *bu
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_full);
 
-extern "C" int _rados_writesame(rados_ioctx_t io,
-				const char *o,
-				const char *buf,
-				size_t data_len,
-				size_t write_len,
-				uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_writesame)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *buf,
+  size_t data_len,
+  size_t write_len,
+  uint64_t off)
 {
   tracepoint(librados, rados_writesame_enter, io, o, buf, data_len, write_len, off);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1173,7 +1374,10 @@ extern "C" int _rados_writesame(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_writesame);
 
-extern "C" int _rados_trunc(rados_ioctx_t io, const char *o, uint64_t size)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_trunc)(
+  rados_ioctx_t io,
+  const char *o,
+  uint64_t size)
 {
   tracepoint(librados, rados_trunc_enter, io, o, size);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1184,7 +1388,9 @@ extern "C" int _rados_trunc(rados_ioctx_t io, const char *o, uint64_t size)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_trunc);
 
-extern "C" int _rados_remove(rados_ioctx_t io, const char *o)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_remove)(
+  rados_ioctx_t io,
+  const char *o)
 {
   tracepoint(librados, rados_remove_enter, io, o);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1195,7 +1401,12 @@ extern "C" int _rados_remove(rados_ioctx_t io, const char *o)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_remove);
 
-extern "C" int _rados_read(rados_ioctx_t io, const char *o, char *buf, size_t len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_read)(
+  rados_ioctx_t io,
+  const char *o,
+  char *buf,
+  size_t len,
+  uint64_t off)
 {
   tracepoint(librados, rados_read_enter, io, o, buf, len, off);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1213,7 +1424,7 @@ extern "C" int _rados_read(rados_ioctx_t io, const char *o, char *buf, size_t le
       return -ERANGE;
     }
     if (!bl.is_provided_buffer(buf))
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
     ret = bl.length();    // hrm :/
   }
 
@@ -1222,11 +1433,12 @@ extern "C" int _rados_read(rados_ioctx_t io, const char *o, char *buf, size_t le
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read);
 
-extern "C" int _rados_checksum(rados_ioctx_t io, const char *o,
-                               rados_checksum_type_t type,
-                               const char *init_value, size_t init_value_len,
-                               size_t len, uint64_t off, size_t chunk_size,
-			       char *pchecksum, size_t checksum_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_checksum)(
+  rados_ioctx_t io, const char *o,
+  rados_checksum_type_t type,
+  const char *init_value, size_t init_value_len,
+  size_t len, uint64_t off, size_t chunk_size,
+  char *pchecksum, size_t checksum_len)
 {
   tracepoint(librados, rados_checksum_enter, io, o, type, init_value,
 	     init_value_len, len, off, chunk_size);
@@ -1246,14 +1458,15 @@ extern "C" int _rados_checksum(rados_ioctx_t io, const char *o,
       return -ERANGE;
     }
 
-    checksum_bl.copy(0, checksum_bl.length(), pchecksum);
+    checksum_bl.begin().copy(checksum_bl.length(), pchecksum);
   }
   tracepoint(librados, rados_checksum_exit, retval, pchecksum, checksum_len);
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_checksum);
 
-extern "C" uint64_t _rados_get_last_version(rados_ioctx_t io)
+extern "C" uint64_t LIBRADOS_C_API_DEFAULT_F(rados_get_last_version)(
+  rados_ioctx_t io)
 {
   tracepoint(librados, rados_get_last_version_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1263,7 +1476,9 @@ extern "C" uint64_t _rados_get_last_version(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_get_last_version);
 
-extern "C" int _rados_pool_create(rados_t cluster, const char *name)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_create)(
+  rados_t cluster,
+  const char *name)
 {
   tracepoint(librados, rados_pool_create_enter, cluster, name);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -1274,8 +1489,10 @@ extern "C" int _rados_pool_create(rados_t cluster, const char *name)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_create);
 
-extern "C" int _rados_pool_create_with_auid(rados_t cluster, const char *name,
-					    uint64_t auid)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_create_with_auid)(
+  rados_t cluster,
+  const char *name,
+  uint64_t auid)
 {
   tracepoint(librados, rados_pool_create_with_auid_enter, cluster, name, auid);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -1291,8 +1508,10 @@ extern "C" int _rados_pool_create_with_auid(rados_t cluster, const char *name,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_create_with_auid);
 
-extern "C" int _rados_pool_create_with_crush_rule(rados_t cluster, const char *name,
-						  __u8 crush_rule_num)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_create_with_crush_rule)(
+  rados_t cluster,
+  const char *name,
+  __u8 crush_rule_num)
 {
   tracepoint(librados, rados_pool_create_with_crush_rule_enter, cluster, name, crush_rule_num);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -1303,8 +1522,11 @@ extern "C" int _rados_pool_create_with_crush_rule(rados_t cluster, const char *n
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_create_with_crush_rule);
 
-extern "C" int _rados_pool_create_with_all(rados_t cluster, const char *name,
-					   uint64_t auid, __u8 crush_rule_num)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_create_with_all)(
+  rados_t cluster,
+  const char *name,
+  uint64_t auid,
+  __u8 crush_rule_num)
 {
   tracepoint(librados, rados_pool_create_with_all_enter, cluster, name, auid, crush_rule_num);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
@@ -1320,7 +1542,10 @@ extern "C" int _rados_pool_create_with_all(rados_t cluster, const char *name,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_create_with_all);
 
-extern "C" int _rados_pool_get_base_tier(rados_t cluster, int64_t pool_id, int64_t* base_tier)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_get_base_tier)(
+  rados_t cluster,
+  int64_t pool_id,
+  int64_t* base_tier)
 {
   tracepoint(librados, rados_pool_get_base_tier_enter, cluster, pool_id);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -1330,7 +1555,9 @@ extern "C" int _rados_pool_get_base_tier(rados_t cluster, int64_t pool_id, int64
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_get_base_tier);
 
-extern "C" int _rados_pool_delete(rados_t cluster, const char *pool_name)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pool_delete)(
+  rados_t cluster,
+  const char *pool_name)
 {
   tracepoint(librados, rados_pool_delete_enter, cluster, pool_name);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -1340,7 +1567,9 @@ extern "C" int _rados_pool_delete(rados_t cluster, const char *pool_name)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_pool_delete);
 
-extern "C" int _rados_ioctx_pool_set_auid(rados_ioctx_t io, uint64_t auid)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_set_auid)(
+  rados_ioctx_t io,
+  uint64_t auid)
 {
   tracepoint(librados, rados_ioctx_pool_set_auid_enter, io, auid);
   int retval = -EOPNOTSUPP;
@@ -1349,7 +1578,9 @@ extern "C" int _rados_ioctx_pool_set_auid(rados_ioctx_t io, uint64_t auid)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_pool_set_auid);
 
-extern "C" int _rados_ioctx_pool_get_auid(rados_ioctx_t io, uint64_t *auid)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_get_auid)(
+  rados_ioctx_t io,
+  uint64_t *auid)
 {
   tracepoint(librados, rados_ioctx_pool_get_auid_enter, io);
   int retval = -EOPNOTSUPP;
@@ -1358,7 +1589,8 @@ extern "C" int _rados_ioctx_pool_get_auid(rados_ioctx_t io, uint64_t *auid)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_pool_get_auid);
 
-extern "C" int _rados_ioctx_pool_requires_alignment(rados_ioctx_t io)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_requires_alignment)(
+  rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_pool_requires_alignment_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1368,8 +1600,9 @@ extern "C" int _rados_ioctx_pool_requires_alignment(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_pool_requires_alignment);
 
-extern "C" int _rados_ioctx_pool_requires_alignment2(rados_ioctx_t io,
-                                                     int *requires)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_requires_alignment2)(
+  rados_ioctx_t io,
+  int *req)
 {
   tracepoint(librados, rados_ioctx_pool_requires_alignment_enter2, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1378,13 +1611,14 @@ extern "C" int _rados_ioctx_pool_requires_alignment2(rados_ioctx_t io,
   	&requires_alignment);
   tracepoint(librados, rados_ioctx_pool_requires_alignment_exit2, retval, 
   	requires_alignment);
-  if (requires)
-    *requires = requires_alignment;
+  if (req)
+    *req = requires_alignment;
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_pool_requires_alignment2);
 
-extern "C" uint64_t _rados_ioctx_pool_required_alignment(rados_ioctx_t io)
+extern "C" uint64_t LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_required_alignment)(
+  rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_pool_required_alignment_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1394,8 +1628,9 @@ extern "C" uint64_t _rados_ioctx_pool_required_alignment(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_pool_required_alignment);
 
-extern "C" int _rados_ioctx_pool_required_alignment2(rados_ioctx_t io,
-                                                     uint64_t *alignment)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_pool_required_alignment2)(
+  rados_ioctx_t io,
+  uint64_t *alignment)
 {
   tracepoint(librados, rados_ioctx_pool_required_alignment_enter2, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1407,7 +1642,9 @@ extern "C" int _rados_ioctx_pool_required_alignment2(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_pool_required_alignment2);
 
-extern "C" void _rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_ioctx_locator_set_key)(
+  rados_ioctx_t io,
+  const char *key)
 {
   tracepoint(librados, rados_ioctx_locator_set_key_enter, io, key);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1419,7 +1656,20 @@ extern "C" void _rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_locator_set_key);
 
-extern "C" void _rados_ioctx_set_namespace(rados_ioctx_t io, const char *nspace)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_ioctx_locator_set_hash)(
+  rados_ioctx_t io,
+  int64_t hash)
+{
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  ctx->oloc.hash = hash;
+  if (hash >= 0)
+    ctx->oloc.key.clear();
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_locator_set_hash);
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_ioctx_set_namespace)(
+  rados_ioctx_t io,
+  const char *nspace)
 {
   tracepoint(librados, rados_ioctx_set_namespace_enter, io, nspace);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1431,8 +1681,10 @@ extern "C" void _rados_ioctx_set_namespace(rados_ioctx_t io, const char *nspace)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_set_namespace);
 
-extern "C" int _rados_ioctx_get_namespace(rados_ioctx_t io, char *s,
-                                          unsigned maxlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_get_namespace)(
+  rados_ioctx_t io,
+  char *s,
+  unsigned maxlen)
 {
   tracepoint(librados, rados_ioctx_get_namespace_enter, io, maxlen);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1448,7 +1700,8 @@ extern "C" int _rados_ioctx_get_namespace(rados_ioctx_t io, char *s,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_get_namespace);
 
-extern "C" rados_t _rados_ioctx_get_cluster(rados_ioctx_t io)
+extern "C" rados_t LIBRADOS_C_API_DEFAULT_F(rados_ioctx_get_cluster)(
+  rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_get_cluster_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1458,7 +1711,8 @@ extern "C" rados_t _rados_ioctx_get_cluster(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_get_cluster);
 
-extern "C" int64_t _rados_ioctx_get_id(rados_ioctx_t io)
+extern "C" int64_t LIBRADOS_C_API_DEFAULT_F(rados_ioctx_get_id)(
+  rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_get_id_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1468,7 +1722,10 @@ extern "C" int64_t _rados_ioctx_get_id(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_get_id);
 
-extern "C" int _rados_ioctx_get_pool_name(rados_ioctx_t io, char *s, unsigned maxlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_get_pool_name)(
+  rados_ioctx_t io,
+  char *s,
+  unsigned maxlen)
 {
   tracepoint(librados, rados_ioctx_get_pool_name_enter, io, maxlen);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1492,7 +1749,9 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_get_pool_name);
 
 // snaps
 
-extern "C" int _rados_ioctx_snap_create(rados_ioctx_t io, const char *snapname)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_create)(
+  rados_ioctx_t io,
+  const char *snapname)
 {
   tracepoint(librados, rados_ioctx_snap_create_enter, io, snapname);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1502,7 +1761,9 @@ extern "C" int _rados_ioctx_snap_create(rados_ioctx_t io, const char *snapname)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_create);
 
-extern "C" int _rados_ioctx_snap_remove(rados_ioctx_t io, const char *snapname)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_remove)(
+  rados_ioctx_t io,
+  const char *snapname)
 {
   tracepoint(librados, rados_ioctx_snap_remove_enter, io, snapname);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1512,8 +1773,10 @@ extern "C" int _rados_ioctx_snap_remove(rados_ioctx_t io, const char *snapname)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_remove);
 
-extern "C" int _rados_ioctx_snap_rollback(rados_ioctx_t io, const char *oid,
-			                  const char *snapname)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_rollback)(
+  rados_ioctx_t io,
+  const char *oid,
+  const char *snapname)
 {
   tracepoint(librados, rados_ioctx_snap_rollback_enter, io, oid, snapname);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1524,15 +1787,18 @@ extern "C" int _rados_ioctx_snap_rollback(rados_ioctx_t io, const char *oid,
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_rollback);
 
 // Deprecated name kept for backward compatibility
-extern "C" int _rados_rollback(rados_ioctx_t io, const char *oid,
-			       const char *snapname)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_rollback)(
+  rados_ioctx_t io,
+  const char *oid,
+  const char *snapname)
 {
-  return _rados_ioctx_snap_rollback(io, oid, snapname);
+  return LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_rollback)(io, oid, snapname);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_rollback);
 
-extern "C" int _rados_ioctx_selfmanaged_snap_create(rados_ioctx_t io,
-					            uint64_t *snapid)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_selfmanaged_snap_create)(
+  rados_ioctx_t io,
+  uint64_t *snapid)
 {
   tracepoint(librados, rados_ioctx_selfmanaged_snap_create_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1542,10 +1808,10 @@ extern "C" int _rados_ioctx_selfmanaged_snap_create(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_selfmanaged_snap_create);
 
-extern "C" void
-_rados_aio_ioctx_selfmanaged_snap_create(rados_ioctx_t io,
-                                         rados_snap_t *snapid,
-                                         rados_completion_t completion)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_aio_ioctx_selfmanaged_snap_create)(
+  rados_ioctx_t io,
+  rados_snap_t *snapid,
+  rados_completion_t completion)
 {
   tracepoint(librados, rados_ioctx_selfmanaged_snap_create_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1555,8 +1821,9 @@ _rados_aio_ioctx_selfmanaged_snap_create(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_ioctx_selfmanaged_snap_create);
 
-extern "C" int _rados_ioctx_selfmanaged_snap_remove(rados_ioctx_t io,
-					            uint64_t snapid)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_selfmanaged_snap_remove)(
+  rados_ioctx_t io,
+  uint64_t snapid)
 {
   tracepoint(librados, rados_ioctx_selfmanaged_snap_remove_enter, io, snapid);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1566,10 +1833,10 @@ extern "C" int _rados_ioctx_selfmanaged_snap_remove(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_selfmanaged_snap_remove);
 
-extern "C" void
-_rados_aio_ioctx_selfmanaged_snap_remove(rados_ioctx_t io,
-                                         rados_snap_t snapid,
-                                         rados_completion_t completion)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_aio_ioctx_selfmanaged_snap_remove)(
+  rados_ioctx_t io,
+  rados_snap_t snapid,
+  rados_completion_t completion)
 {
   tracepoint(librados, rados_ioctx_selfmanaged_snap_remove_enter, io, snapid);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1579,9 +1846,10 @@ _rados_aio_ioctx_selfmanaged_snap_remove(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_ioctx_selfmanaged_snap_remove);
 
-extern "C" int _rados_ioctx_selfmanaged_snap_rollback(rados_ioctx_t io,
-						      const char *oid,
-						      uint64_t snapid)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_selfmanaged_snap_rollback)(
+  rados_ioctx_t io,
+  const char *oid,
+  uint64_t snapid)
 {
   tracepoint(librados, rados_ioctx_selfmanaged_snap_rollback_enter, io, oid, snapid);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1591,8 +1859,10 @@ extern "C" int _rados_ioctx_selfmanaged_snap_rollback(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_selfmanaged_snap_rollback);
 
-extern "C" int _rados_ioctx_snap_list(rados_ioctx_t io, rados_snap_t *snaps,
-				      int maxlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_list)(
+  rados_ioctx_t io,
+  rados_snap_t *snaps,
+  int maxlen)
 {
   tracepoint(librados, rados_ioctx_snap_list_enter, io, maxlen);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1616,8 +1886,10 @@ extern "C" int _rados_ioctx_snap_list(rados_ioctx_t io, rados_snap_t *snaps,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_list);
 
-extern "C" int _rados_ioctx_snap_lookup(rados_ioctx_t io, const char *name,
-				         rados_snap_t *id)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_lookup)(
+  rados_ioctx_t io,
+  const char *name,
+  rados_snap_t *id)
 {
   tracepoint(librados, rados_ioctx_snap_lookup_enter, io, name);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1627,8 +1899,11 @@ extern "C" int _rados_ioctx_snap_lookup(rados_ioctx_t io, const char *name,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_lookup);
 
-extern "C" int _rados_ioctx_snap_get_name(rados_ioctx_t io, rados_snap_t id,
-					  char *name, int maxlen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_get_name)(
+  rados_ioctx_t io,
+  rados_snap_t id,
+  char *name,
+  int maxlen)
 {
   tracepoint(librados, rados_ioctx_snap_get_name_enter, io, id, maxlen);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1649,7 +1924,10 @@ extern "C" int _rados_ioctx_snap_get_name(rados_ioctx_t io, rados_snap_t id,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_get_name);
 
-extern "C" int _rados_ioctx_snap_get_stamp(rados_ioctx_t io, rados_snap_t id, time_t *t)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_ioctx_snap_get_stamp)(
+  rados_ioctx_t io,
+  rados_snap_t id,
+  time_t *t)
 {
   tracepoint(librados, rados_ioctx_snap_get_stamp_enter, io, id);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1659,8 +1937,12 @@ extern "C" int _rados_ioctx_snap_get_stamp(rados_ioctx_t io, rados_snap_t id, ti
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_snap_get_stamp);
 
-extern "C" int _rados_cmpext(rados_ioctx_t io, const char *o,
-			     const char *cmp_buf, size_t cmp_len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_cmpext)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *cmp_buf,
+  size_t cmp_len,
+  uint64_t off)
 {
   tracepoint(librados, rados_cmpext_enter, io, o, cmp_buf, cmp_len, off);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1677,8 +1959,12 @@ extern "C" int _rados_cmpext(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_cmpext);
 
-extern "C" int _rados_getxattr(rados_ioctx_t io, const char *o, const char *name,
-			       char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_getxattr)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *name,
+  char *buf,
+  size_t len)
 {
   tracepoint(librados, rados_getxattr_enter, io, o, name, len);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1693,7 +1979,7 @@ extern "C" int _rados_getxattr(rados_ioctx_t io, const char *o, const char *name
       return -ERANGE;
     }
     if (!bl.is_provided_buffer(buf))
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
     ret = bl.length();
   }
 
@@ -1702,8 +1988,10 @@ extern "C" int _rados_getxattr(rados_ioctx_t io, const char *o, const char *name
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_getxattr);
 
-extern "C" int _rados_getxattrs(rados_ioctx_t io, const char *oid,
-			        rados_xattrs_iter_t *iter)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_getxattrs)(
+  rados_ioctx_t io,
+  const char *oid,
+  rados_xattrs_iter_t *iter)
 {
   tracepoint(librados, rados_getxattrs_enter, io, oid);
   librados::RadosXattrsIter *it = new librados::RadosXattrsIter();
@@ -1727,9 +2015,11 @@ extern "C" int _rados_getxattrs(rados_ioctx_t io, const char *oid,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_getxattrs);
 
-extern "C" int _rados_getxattrs_next(rados_xattrs_iter_t iter,
-				     const char **name, const char **val,
-                                     size_t *len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_getxattrs_next)(
+  rados_xattrs_iter_t iter,
+  const char **name,
+  const char **val,
+  size_t *len)
 {
   tracepoint(librados, rados_getxattrs_next_enter, iter);
   librados::RadosXattrsIter *it = static_cast<librados::RadosXattrsIter*>(iter);
@@ -1767,7 +2057,8 @@ extern "C" int _rados_getxattrs_next(rados_xattrs_iter_t iter,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_getxattrs_next);
 
-extern "C" void _rados_getxattrs_end(rados_xattrs_iter_t iter)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_getxattrs_end)(
+  rados_xattrs_iter_t iter)
 {
   tracepoint(librados, rados_getxattrs_end_enter, iter);
   librados::RadosXattrsIter *it = static_cast<librados::RadosXattrsIter*>(iter);
@@ -1776,7 +2067,12 @@ extern "C" void _rados_getxattrs_end(rados_xattrs_iter_t iter)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_getxattrs_end);
 
-extern "C" int _rados_setxattr(rados_ioctx_t io, const char *o, const char *name, const char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_setxattr)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *name,
+  const char *buf,
+  size_t len)
 {
   tracepoint(librados, rados_setxattr_enter, io, o, name, buf, len);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1789,7 +2085,10 @@ extern "C" int _rados_setxattr(rados_ioctx_t io, const char *o, const char *name
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_setxattr);
 
-extern "C" int _rados_rmxattr(rados_ioctx_t io, const char *o, const char *name)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_rmxattr)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *name)
 {
   tracepoint(librados, rados_rmxattr_enter, io, o, name);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1800,7 +2099,11 @@ extern "C" int _rados_rmxattr(rados_ioctx_t io, const char *o, const char *name)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_rmxattr);
 
-extern "C" int _rados_stat(rados_ioctx_t io, const char *o, uint64_t *psize, time_t *pmtime)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_stat)(
+  rados_ioctx_t io,
+  const char *o,
+  uint64_t *psize,
+  time_t *pmtime)
 {
   tracepoint(librados, rados_stat_enter, io, o);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1811,8 +2114,26 @@ extern "C" int _rados_stat(rados_ioctx_t io, const char *o, uint64_t *psize, tim
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_stat);
 
-extern "C" int _rados_tmap_update_base(rados_ioctx_t io, const char *o,
-                                       const char *cmdbuf, size_t cmdbuflen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_stat2)(
+  rados_ioctx_t io,
+  const char *o,
+  uint64_t *psize,
+  struct timespec *pmtime)
+{
+  tracepoint(librados, rados_stat2_enter, io, o);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  int retval = ctx->stat2(oid, psize, pmtime);
+  tracepoint(librados, rados_stat2_exit, retval, psize, pmtime);
+  return retval;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_stat2);
+
+extern "C" int LIBRADOS_C_API_BASE_F(rados_tmap_update)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *cmdbuf,
+  size_t cmdbuflen)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   object_t oid(o);
@@ -1822,15 +2143,21 @@ extern "C" int _rados_tmap_update_base(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE(rados_tmap_update);
 
-extern "C" int _rados_tmap_update(rados_ioctx_t io, const char *o,
-                                  const char *cmdbuf, size_t cmdbuflen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_tmap_update)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *cmdbuf,
+  size_t cmdbuflen)
 {
   return -ENOTSUP;
 }
 LIBRADOS_C_API_DEFAULT(rados_tmap_update, 14.2.0);
 
-extern "C" int _rados_tmap_put_base(rados_ioctx_t io, const char *o,
-                                    const char *buf, size_t buflen)
+extern "C" int LIBRADOS_C_API_BASE_F(rados_tmap_put)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *buf,
+  size_t buflen)
 {
   bufferlist bl;
   bl.append(buf, buflen);
@@ -1845,33 +2172,50 @@ extern "C" int _rados_tmap_put_base(rados_ioctx_t io, const char *o,
   encode(header, out_bl);
   encode(m, out_bl);
 
-  return _rados_write_full(io, o, out_bl.c_str(), out_bl.length());
+  return LIBRADOS_C_API_DEFAULT_F(rados_write_full)(
+    io, o, out_bl.c_str(), out_bl.length());
 }
 LIBRADOS_C_API_BASE(rados_tmap_put);
 
-extern "C" int _rados_tmap_put(rados_ioctx_t io, const char *o,
-                               const char *buf, size_t buflen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_tmap_put)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *buf,
+  size_t buflen)
 {
   return -EOPNOTSUPP;
 }
 LIBRADOS_C_API_DEFAULT(rados_tmap_put, 14.2.0);
 
-extern "C" int _rados_tmap_get_base(rados_ioctx_t io, const char *o, char *buf,
-                                    size_t buflen)
+extern "C" int LIBRADOS_C_API_BASE_F(rados_tmap_get)(
+  rados_ioctx_t io,
+  const char *o,
+  char *buf,
+  size_t buflen)
 {
-  return _rados_read(io, o, buf, buflen, 0);
+  return LIBRADOS_C_API_DEFAULT_F(rados_read)(io, o, buf, buflen, 0);
 }
 LIBRADOS_C_API_BASE(rados_tmap_get);
 
-extern "C" int _rados_tmap_get(rados_ioctx_t io, const char *o, char *buf,
-                               size_t buflen)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_tmap_get)(
+  rados_ioctx_t io,
+  const char *o,
+  char *buf,
+  size_t buflen)
 {
   return -EOPNOTSUPP;
 }
 LIBRADOS_C_API_DEFAULT(rados_tmap_get, 14.2.0);
 
-extern "C" int _rados_exec(rados_ioctx_t io, const char *o, const char *cls, const char *method,
-                           const char *inbuf, size_t in_len, char *buf, size_t out_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_exec)(
+  rados_ioctx_t io,
+  const char *o,
+  const char *cls,
+  const char *method,
+  const char *inbuf,
+  size_t in_len,
+  char *buf,
+  size_t out_len)
 {
   tracepoint(librados, rados_exec_enter, io, o, cls, method, inbuf, in_len, out_len);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -1886,7 +2230,7 @@ extern "C" int _rados_exec(rados_ioctx_t io, const char *o, const char *cls, con
 	tracepoint(librados, rados_exec_exit, -ERANGE, buf, 0);
 	return -ERANGE;
       }
-      outbl.copy(0, outbl.length(), buf);
+      outbl.begin().copy(outbl.length(), buf);
       ret = outbl.length();   // hrm :/
     }
   }
@@ -1895,7 +2239,8 @@ extern "C" int _rados_exec(rados_ioctx_t io, const char *o, const char *cls, con
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_exec);
 
-extern "C" rados_object_list_cursor _rados_object_list_begin(rados_ioctx_t io)
+extern "C" rados_object_list_cursor LIBRADOS_C_API_DEFAULT_F(rados_object_list_begin)(
+  rados_ioctx_t io)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
@@ -1904,7 +2249,8 @@ extern "C" rados_object_list_cursor _rados_object_list_begin(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list_begin);
 
-extern "C" rados_object_list_cursor _rados_object_list_end(rados_ioctx_t io)
+extern "C" rados_object_list_cursor LIBRADOS_C_API_DEFAULT_F(rados_object_list_end)(
+  rados_ioctx_t io)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
@@ -1913,26 +2259,28 @@ extern "C" rados_object_list_cursor _rados_object_list_end(rados_ioctx_t io)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list_end);
 
-extern "C" int _rados_object_list_is_end(
-    rados_ioctx_t io, rados_object_list_cursor cur)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_object_list_is_end)(
+  rados_ioctx_t io,
+  rados_object_list_cursor cur)
 {
   hobject_t *hobj = (hobject_t*)cur;
   return hobj->is_max();
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list_is_end);
 
-extern "C" void _rados_object_list_cursor_free(
-    rados_ioctx_t io, rados_object_list_cursor cur)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_object_list_cursor_free)(
+  rados_ioctx_t io,
+  rados_object_list_cursor cur)
 {
   hobject_t *hobj = (hobject_t*)cur;
   delete hobj;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list_cursor_free);
 
-extern "C" int _rados_object_list_cursor_cmp(
-    rados_ioctx_t io,
-    rados_object_list_cursor lhs_cur,
-    rados_object_list_cursor rhs_cur)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_object_list_cursor_cmp)(
+  rados_ioctx_t io,
+  rados_object_list_cursor lhs_cur,
+  rados_object_list_cursor rhs_cur)
 {
   hobject_t *lhs = (hobject_t*)lhs_cur;
   hobject_t *rhs = (hobject_t*)rhs_cur;
@@ -1940,56 +2288,54 @@ extern "C" int _rados_object_list_cursor_cmp(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list_cursor_cmp);
 
-extern "C" int _rados_object_list(rados_ioctx_t io,
-    const rados_object_list_cursor start,
-    const rados_object_list_cursor finish,
-    const size_t result_item_count,
-    const char *filter_buf,
-    const size_t filter_buf_len,
-    rados_object_list_item *result_items,
-    rados_object_list_cursor *next)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_object_list)(rados_ioctx_t io,
+  const rados_object_list_cursor start,
+  const rados_object_list_cursor finish,
+  const size_t result_item_count,
+  const char *filter_buf,
+  const size_t filter_buf_len,
+  rados_object_list_item *result_items,
+  rados_object_list_cursor *next)
 {
   ceph_assert(next);
 
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
   // Zero out items so that they will be safe to free later
+  // FIPS zeroization audit 20191116: this memset is not security related.
   memset(result_items, 0, sizeof(rados_object_list_item) * result_item_count);
-
-  std::list<librados::ListObjectImpl> result;
-  hobject_t next_hash;
 
   bufferlist filter_bl;
   if (filter_buf != nullptr) {
     filter_bl.append(filter_buf, filter_buf_len);
   }
 
-  C_SaferCond cond;
-  ctx->objecter->enumerate_objects(
+  ceph::async::waiter<boost::system::error_code,
+		      std::vector<librados::ListObjectImpl>,
+		      hobject_t> w;
+  ctx->objecter->enumerate_objects<librados::ListObjectImpl>(
       ctx->poolid,
       ctx->oloc.nspace,
       *((hobject_t*)start),
       *((hobject_t*)finish),
       result_item_count,
       filter_bl,
-      &result,
-      &next_hash,
-      &cond);
+      w);
 
   hobject_t *next_hobj = (hobject_t*)(*next);
   ceph_assert(next_hobj);
 
-  int r = cond.wait();
-  if (r < 0) {
+  auto [ec, result, next_hash] = w.wait();
+
+  if (ec) {
     *next_hobj = hobject_t::get_max();
-    return r;
+    return ceph::from_error_code(ec);
   }
 
   ceph_assert(result.size() <= result_item_count);  // Don't overflow!
 
   int k = 0;
-  for (std::list<librados::ListObjectImpl>::iterator i = result.begin();
-       i != result.end(); ++i) {
+  for (auto i = result.begin(); i != result.end(); ++i) {
     rados_object_list_item &item = result_items[k++];
     do_out_buffer(i->oid, &item.oid, &item.oid_length);
     do_out_buffer(i->nspace, &item.nspace, &item.nspace_length);
@@ -2002,23 +2348,25 @@ extern "C" int _rados_object_list(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list);
 
-extern "C" void _rados_object_list_free(
-    const size_t result_size,
-    rados_object_list_item *results)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_object_list_free)(
+  const size_t result_size,
+  rados_object_list_item *results)
 {
   ceph_assert(results);
 
   for (unsigned int i = 0; i < result_size; ++i) {
-    _rados_buffer_free(results[i].oid);
-    _rados_buffer_free(results[i].locator);
-    _rados_buffer_free(results[i].nspace);
+    LIBRADOS_C_API_DEFAULT_F(rados_buffer_free)(results[i].oid);
+    LIBRADOS_C_API_DEFAULT_F(rados_buffer_free)(results[i].locator);
+    LIBRADOS_C_API_DEFAULT_F(rados_buffer_free)(results[i].nspace);
   }
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_object_list_free);
 
 /* list objects */
 
-extern "C" int _rados_nobjects_list_open(rados_ioctx_t io, rados_list_ctx_t *listh)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_open)(
+  rados_ioctx_t io,
+  rados_list_ctx_t *listh)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
@@ -2034,7 +2382,8 @@ extern "C" int _rados_nobjects_list_open(rados_ioctx_t io, rados_list_ctx_t *lis
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_open);
 
-extern "C" void _rados_nobjects_list_close(rados_list_ctx_t h)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_close)(
+  rados_list_ctx_t h)
 {
   tracepoint(librados, rados_nobjects_list_close_enter, h);
   librados::ObjListCtx *lh = (librados::ObjListCtx *)h;
@@ -2043,8 +2392,9 @@ extern "C" void _rados_nobjects_list_close(rados_list_ctx_t h)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_close);
 
-extern "C" uint32_t _rados_nobjects_list_seek(rados_list_ctx_t listctx,
-					      uint32_t pos)
+extern "C" uint32_t LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_seek)(
+  rados_list_ctx_t listctx,
+  uint32_t pos)
 {
   librados::ObjListCtx *lh = (librados::ObjListCtx *)listctx;
   tracepoint(librados, rados_nobjects_list_seek_enter, listctx, pos);
@@ -2054,8 +2404,9 @@ extern "C" uint32_t _rados_nobjects_list_seek(rados_list_ctx_t listctx,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_seek);
 
-extern "C" uint32_t _rados_nobjects_list_seek_cursor(rados_list_ctx_t listctx,
-                                                     rados_object_list_cursor cursor)
+extern "C" uint32_t LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_seek_cursor)(
+  rados_list_ctx_t listctx,
+  rados_object_list_cursor cursor)
 {
   librados::ObjListCtx *lh = (librados::ObjListCtx *)listctx;
 
@@ -2066,8 +2417,9 @@ extern "C" uint32_t _rados_nobjects_list_seek_cursor(rados_list_ctx_t listctx,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_seek_cursor);
 
-extern "C" int _rados_nobjects_list_get_cursor(rados_list_ctx_t listctx,
-                                               rados_object_list_cursor *cursor)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_get_cursor)(
+  rados_list_ctx_t listctx,
+  rados_object_list_cursor *cursor)
 {
   librados::ObjListCtx *lh = (librados::ObjListCtx *)listctx;
 
@@ -2078,7 +2430,7 @@ extern "C" int _rados_nobjects_list_get_cursor(rados_list_ctx_t listctx,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_get_cursor);
 
-extern "C" uint32_t _rados_nobjects_list_get_pg_hash_position(
+extern "C" uint32_t LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_get_pg_hash_position)(
   rados_list_ctx_t listctx)
 {
   librados::ObjListCtx *lh = (librados::ObjListCtx *)listctx;
@@ -2089,9 +2441,29 @@ extern "C" uint32_t _rados_nobjects_list_get_pg_hash_position(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_get_pg_hash_position);
 
-extern "C" int _rados_nobjects_list_next(rados_list_ctx_t listctx, const char **entry, const char **key, const char **nspace)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_next)(
+  rados_list_ctx_t listctx,
+  const char **entry,
+  const char **key,
+  const char **nspace)
 {
   tracepoint(librados, rados_nobjects_list_next_enter, listctx);
+  uint32_t retval = rados_nobjects_list_next2(listctx, entry, key, nspace, NULL, NULL, NULL);
+  tracepoint(librados, rados_nobjects_list_next_exit, 0, *entry, key, nspace);
+  return retval;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_next2)(
+  rados_list_ctx_t listctx,
+  const char **entry,
+  const char **key,
+  const char **nspace,
+  size_t *entry_size,
+  size_t *key_size,
+  size_t *nspace_size)
+{
+  tracepoint(librados, rados_nobjects_list_next2_enter, listctx);
   librados::ObjListCtx *lh = (librados::ObjListCtx *)listctx;
   Objecter::NListContext *h = lh->nlc;
 
@@ -2103,11 +2475,11 @@ extern "C" int _rados_nobjects_list_next(rados_list_ctx_t listctx, const char **
   if (h->list.empty()) {
     int ret = lh->ctx->nlist(lh->nlc, RADOS_LIST_MAX_ENTRIES);
     if (ret < 0) {
-      tracepoint(librados, rados_nobjects_list_next_exit, ret, NULL, NULL, NULL);
+      tracepoint(librados, rados_nobjects_list_next2_exit, ret, NULL, NULL, NULL, NULL, NULL, NULL);
       return ret;
     }
     if (h->list.empty()) {
-      tracepoint(librados, rados_nobjects_list_next_exit, -ENOENT, NULL, NULL, NULL);
+      tracepoint(librados, rados_nobjects_list_next2_exit, -ENOENT, NULL, NULL, NULL, NULL, NULL, NULL);
       return -ENOENT;
     }
   }
@@ -2122,10 +2494,19 @@ extern "C" int _rados_nobjects_list_next(rados_list_ctx_t listctx, const char **
   }
   if (nspace)
     *nspace = h->list.front().nspace.c_str();
-  tracepoint(librados, rados_nobjects_list_next_exit, 0, *entry, key, nspace);
+
+  if (entry_size)
+    *entry_size = h->list.front().oid.size();
+  if (key_size)
+    *key_size = h->list.front().locator.size();
+  if (nspace_size)
+    *nspace_size = h->list.front().nspace.size();
+
+  tracepoint(librados, rados_nobjects_list_next2_exit, 0, entry, key, nspace,
+             entry_size, key_size, nspace_size);
   return 0;
 }
-LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next);
+LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next2);
 
 
 /*
@@ -2133,7 +2514,7 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next);
  *
  * thse return -ENOTSUP where possible.
  */
-extern "C" int _rados_objects_list_open(
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_objects_list_open)(
   rados_ioctx_t io,
   rados_list_ctx_t *ctx)
 {
@@ -2141,14 +2522,14 @@ extern "C" int _rados_objects_list_open(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_objects_list_open);
 
-extern "C" uint32_t _rados_objects_list_get_pg_hash_position(
+extern "C" uint32_t LIBRADOS_C_API_DEFAULT_F(rados_objects_list_get_pg_hash_position)(
   rados_list_ctx_t ctx)
 {
   return 0;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_objects_list_get_pg_hash_position);
 
-extern "C" uint32_t _rados_objects_list_seek(
+extern "C" uint32_t LIBRADOS_C_API_DEFAULT_F(rados_objects_list_seek)(
   rados_list_ctx_t ctx,
   uint32_t pos)
 {
@@ -2156,7 +2537,7 @@ extern "C" uint32_t _rados_objects_list_seek(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_objects_list_seek);
 
-extern "C" int _rados_objects_list_next(
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_objects_list_next)(
   rados_list_ctx_t ctx,
   const char **entry,
   const char **key)
@@ -2165,7 +2546,7 @@ extern "C" int _rados_objects_list_next(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_objects_list_next);
 
-extern "C" void _rados_objects_list_close(
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_objects_list_close)(
   rados_list_ctx_t ctx)
 {
 }
@@ -2175,10 +2556,11 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_objects_list_close);
 // -------------------------
 // aio
 
-extern "C" int _rados_aio_create_completion(void *cb_arg,
-					    rados_callback_t cb_complete,
-					    rados_callback_t cb_safe,
-					    rados_completion_t *pc)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_create_completion)(
+  void *cb_arg,
+  rados_callback_t cb_complete,
+  rados_callback_t cb_safe,
+  rados_completion_t *pc)
 {
   tracepoint(librados, rados_aio_create_completion_enter, cb_arg, cb_complete, cb_safe);
   librados::AioCompletionImpl *c = new librados::AioCompletionImpl;
@@ -2192,7 +2574,23 @@ extern "C" int _rados_aio_create_completion(void *cb_arg,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_create_completion);
 
-extern "C" int _rados_aio_wait_for_complete(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_create_completion2)(
+  void *cb_arg,
+  rados_callback_t cb_complete,
+  rados_completion_t *pc)
+{
+  tracepoint(librados, rados_aio_create_completion2_enter, cb_arg, cb_complete);
+  librados::AioCompletionImpl *c = new librados::AioCompletionImpl;
+  if (cb_complete)
+    c->set_complete_callback(cb_arg, cb_complete);
+  *pc = c;
+  tracepoint(librados, rados_aio_create_completion2_exit, 0, *pc);
+  return 0;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_aio_create_completion2);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_wait_for_complete)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_wait_for_complete_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->wait_for_complete();
@@ -2201,16 +2599,18 @@ extern "C" int _rados_aio_wait_for_complete(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_wait_for_complete);
 
-extern "C" int _rados_aio_wait_for_safe(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_wait_for_safe)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_wait_for_safe_enter, c);
-  int retval = ((librados::AioCompletionImpl*)c)->wait_for_safe();
+  int retval = ((librados::AioCompletionImpl*)c)->wait_for_complete();
   tracepoint(librados, rados_aio_wait_for_safe_exit, retval);
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_wait_for_safe);
 
-extern "C" int _rados_aio_is_complete(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_is_complete)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_is_complete_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->is_complete();
@@ -2219,7 +2619,8 @@ extern "C" int _rados_aio_is_complete(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_is_complete);
 
-extern "C" int _rados_aio_is_safe(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_is_safe)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_is_safe_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->is_safe();
@@ -2228,7 +2629,8 @@ extern "C" int _rados_aio_is_safe(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_is_safe);
 
-extern "C" int _rados_aio_wait_for_complete_and_cb(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_wait_for_complete_and_cb)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_wait_for_complete_and_cb_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->wait_for_complete_and_cb();
@@ -2237,7 +2639,8 @@ extern "C" int _rados_aio_wait_for_complete_and_cb(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_wait_for_complete_and_cb);
 
-extern "C" int _rados_aio_wait_for_safe_and_cb(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_wait_for_safe_and_cb)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_wait_for_safe_and_cb_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->wait_for_safe_and_cb();
@@ -2246,7 +2649,8 @@ extern "C" int _rados_aio_wait_for_safe_and_cb(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_wait_for_safe_and_cb);
 
-extern "C" int _rados_aio_is_complete_and_cb(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_is_complete_and_cb)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_is_complete_and_cb_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->is_complete_and_cb();
@@ -2255,7 +2659,8 @@ extern "C" int _rados_aio_is_complete_and_cb(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_is_complete_and_cb);
 
-extern "C" int _rados_aio_is_safe_and_cb(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_is_safe_and_cb)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_is_safe_and_cb_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->is_safe_and_cb();
@@ -2264,7 +2669,8 @@ extern "C" int _rados_aio_is_safe_and_cb(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_is_safe_and_cb);
 
-extern "C" int _rados_aio_get_return_value(rados_completion_t c)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_get_return_value)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_get_return_value_enter, c);
   int retval = ((librados::AioCompletionImpl*)c)->get_return_value();
@@ -2273,7 +2679,8 @@ extern "C" int _rados_aio_get_return_value(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_get_return_value);
 
-extern "C" uint64_t _rados_aio_get_version(rados_completion_t c)
+extern "C" uint64_t LIBRADOS_C_API_DEFAULT_F(rados_aio_get_version)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_get_version_enter, c);
   uint64_t retval = ((librados::AioCompletionImpl*)c)->get_version();
@@ -2282,17 +2689,19 @@ extern "C" uint64_t _rados_aio_get_version(rados_completion_t c)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_get_version);
 
-extern "C" void _rados_aio_release(rados_completion_t c)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_aio_release)(
+  rados_completion_t c)
 {
   tracepoint(librados, rados_aio_release_enter, c);
   ((librados::AioCompletionImpl*)c)->put();
   tracepoint(librados, rados_aio_release_exit);
-LIBRADOS_C_API_BASE_DEFAULT(rados_aio_release);
 }
+LIBRADOS_C_API_BASE_DEFAULT(rados_aio_release);
 
-extern "C" int _rados_aio_read(rados_ioctx_t io, const char *o,
-			       rados_completion_t completion,
-			       char *buf, size_t len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_read)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  char *buf, size_t len, uint64_t off)
 {
   tracepoint(librados, rados_aio_read_enter, io, o, completion, len, off);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2305,10 +2714,11 @@ extern "C" int _rados_aio_read(rados_ioctx_t io, const char *o,
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_read);
 
 #ifdef WITH_BLKIN
-extern "C" int _rados_aio_read_traced(rados_ioctx_t io, const char *o,
-				      rados_completion_t completion,
-				      char *buf, size_t len, uint64_t off,
-				      struct blkin_trace_info *info)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_read_traced)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  char *buf, size_t len, uint64_t off,
+  struct blkin_trace_info *info)
 {
   tracepoint(librados, rados_aio_read_enter, io, o, completion, len, off);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2321,9 +2731,10 @@ extern "C" int _rados_aio_read_traced(rados_ioctx_t io, const char *o,
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_read_traced);
 #endif
 
-extern "C" int _rados_aio_write(rados_ioctx_t io, const char *o,
-				rados_completion_t completion,
-				const char *buf, size_t len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *buf, size_t len, uint64_t off)
 {
   tracepoint(librados, rados_aio_write_enter, io, o, completion, buf, len, off);
   if (len > UINT_MAX/2)
@@ -2340,10 +2751,11 @@ extern "C" int _rados_aio_write(rados_ioctx_t io, const char *o,
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write);
 
 #ifdef WITH_BLKIN
-extern "C" int _rados_aio_write_traced(rados_ioctx_t io, const char *o,
-                                       rados_completion_t completion,
-                                       const char *buf, size_t len, uint64_t off,
-                                       struct blkin_trace_info *info)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_traced)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *buf, size_t len, uint64_t off,
+  struct blkin_trace_info *info)
 {
   tracepoint(librados, rados_aio_write_enter, io, o, completion, buf, len, off);
   if (len > UINT_MAX/2)
@@ -2360,9 +2772,10 @@ extern "C" int _rados_aio_write_traced(rados_ioctx_t io, const char *o,
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_traced);
 #endif
 
-extern "C" int _rados_aio_append(rados_ioctx_t io, const char *o,
-				 rados_completion_t completion,
-				 const char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_append)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *buf, size_t len)
 {
   tracepoint(librados, rados_aio_append_enter, io, o, completion, buf, len);
   if (len > UINT_MAX/2)
@@ -2378,9 +2791,10 @@ extern "C" int _rados_aio_append(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_append);
 
-extern "C" int _rados_aio_write_full(rados_ioctx_t io, const char *o,
-				     rados_completion_t completion,
-				     const char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_full)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *buf, size_t len)
 {
   tracepoint(librados, rados_aio_write_full_enter, io, o, completion, buf, len);
   if (len > UINT_MAX/2)
@@ -2395,10 +2809,11 @@ extern "C" int _rados_aio_write_full(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_full);
 
-extern "C" int _rados_aio_writesame(rados_ioctx_t io, const char *o,
-				    rados_completion_t completion,
-				    const char *buf, size_t data_len,
-				    size_t write_len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_writesame)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *buf, size_t data_len,
+  size_t write_len, uint64_t off)
 {
   tracepoint(librados, rados_aio_writesame_enter, io, o, completion, buf,
 						data_len, write_len, off);
@@ -2413,8 +2828,9 @@ extern "C" int _rados_aio_writesame(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_writesame);
 
-extern "C" int _rados_aio_remove(rados_ioctx_t io, const char *o,
-				 rados_completion_t completion)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_remove)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion)
 {
   tracepoint(librados, rados_aio_remove_enter, io, o, completion);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2425,8 +2841,9 @@ extern "C" int _rados_aio_remove(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_remove);
 
-extern "C" int _rados_aio_flush_async(rados_ioctx_t io,
-				      rados_completion_t completion)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_flush_async)(
+  rados_ioctx_t io,
+  rados_completion_t completion)
 {
   tracepoint(librados, rados_aio_flush_async_enter, io, completion);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2436,7 +2853,7 @@ extern "C" int _rados_aio_flush_async(rados_ioctx_t io,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_flush_async);
 
-extern "C" int _rados_aio_flush(rados_ioctx_t io)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_flush)(rados_ioctx_t io)
 {
   tracepoint(librados, rados_aio_flush_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2452,28 +2869,30 @@ struct AioGetxattrData {
   bufferlist bl;
   char* user_buf;
   size_t len;
-  struct librados::C_AioCompleteAndSafe user_completion;
+  struct librados::CB_AioCompleteAndSafe user_completion;
 };
 
 static void rados_aio_getxattr_complete(rados_completion_t c, void *arg) {
   AioGetxattrData *cdata = reinterpret_cast<AioGetxattrData*>(arg);
-  int rc = _rados_aio_get_return_value(c);
+  int rc = LIBRADOS_C_API_DEFAULT_F(rados_aio_get_return_value)(c);
   if (rc >= 0) {
     if (cdata->bl.length() > cdata->len) {
       rc = -ERANGE;
     } else {
       if (!cdata->bl.is_provided_buffer(cdata->user_buf))
-	cdata->bl.copy(0, cdata->bl.length(), cdata->user_buf);
+	cdata->bl.begin().copy(cdata->bl.length(), cdata->user_buf);
       rc = cdata->bl.length();
     }
   }
-  cdata->user_completion.finish(rc);
+  cdata->user_completion(rc);
+  reinterpret_cast<librados::AioCompletionImpl*>(c)->put();
   delete cdata;
 }
 
-extern "C" int _rados_aio_getxattr(rados_ioctx_t io, const char *o,
-				   rados_completion_t completion,
-				   const char *name, char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_getxattr)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *name, char *buf, size_t len)
 {
   tracepoint(librados, rados_aio_getxattr_enter, io, o, completion, name, len);
   // create data object to be passed to async callback
@@ -2506,27 +2925,29 @@ struct AioGetxattrsData {
   }
   librados::RadosXattrsIter *it;
   rados_xattrs_iter_t *iter;
-  struct librados::C_AioCompleteAndSafe user_completion;
+  struct librados::CB_AioCompleteAndSafe user_completion;
 };
 }
 
 static void rados_aio_getxattrs_complete(rados_completion_t c, void *arg) {
   AioGetxattrsData *cdata = reinterpret_cast<AioGetxattrsData*>(arg);
-  int rc = _rados_aio_get_return_value(c);
+  int rc = LIBRADOS_C_API_DEFAULT_F(rados_aio_get_return_value)(c);
   if (rc) {
-    cdata->user_completion.finish(rc);
+    cdata->user_completion(rc);
   } else {
     cdata->it->i = cdata->it->attrset.begin();
     *cdata->iter = cdata->it;
     cdata->it = 0;
-    cdata->user_completion.finish(0);
+    cdata->user_completion(0);
   }
+  reinterpret_cast<librados::AioCompletionImpl*>(c)->put();
   delete cdata;
 }
 
-extern "C" int _rados_aio_getxattrs(rados_ioctx_t io, const char *oid,
-				    rados_completion_t completion,
-				    rados_xattrs_iter_t *iter)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_getxattrs)(
+  rados_ioctx_t io, const char *oid,
+  rados_completion_t completion,
+  rados_xattrs_iter_t *iter)
 {
   tracepoint(librados, rados_aio_getxattrs_enter, io, oid, completion);
   // create data object to be passed to async callback
@@ -2547,9 +2968,10 @@ extern "C" int _rados_aio_getxattrs(rados_ioctx_t io, const char *oid,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_getxattrs);
 
-extern "C" int _rados_aio_setxattr(rados_ioctx_t io, const char *o,
-				   rados_completion_t completion,
-				   const char *name, const char *buf, size_t len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_setxattr)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *name, const char *buf, size_t len)
 {
   tracepoint(librados, rados_aio_setxattr_enter, io, o, completion, name, buf, len);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2562,9 +2984,10 @@ extern "C" int _rados_aio_setxattr(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_setxattr);
 
-extern "C" int _rados_aio_rmxattr(rados_ioctx_t io, const char *o,
-				  rados_completion_t completion,
-				  const char *name)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_rmxattr)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *name)
 {
   tracepoint(librados, rados_aio_rmxattr_enter, io, o, completion, name);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2575,9 +2998,10 @@ extern "C" int _rados_aio_rmxattr(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_rmxattr);
 
-extern "C" int _rados_aio_stat(rados_ioctx_t io, const char *o,
-			       rados_completion_t completion,
-			       uint64_t *psize, time_t *pmtime)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_stat)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  uint64_t *psize, time_t *pmtime)
 {
   tracepoint(librados, rados_aio_stat_enter, io, o, completion);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2589,9 +3013,25 @@ extern "C" int _rados_aio_stat(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_stat);
 
-extern "C" int _rados_aio_cmpext(rados_ioctx_t io, const char *o,
-				 rados_completion_t completion, const char *cmp_buf,
-				 size_t cmp_len, uint64_t off)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_stat2)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  uint64_t *psize, struct timespec *pmtime)
+{
+  tracepoint(librados, rados_aio_stat2_enter, io, o, completion);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  int retval = ctx->aio_stat2(oid, (librados::AioCompletionImpl*)completion,
+		       psize, pmtime);
+  tracepoint(librados, rados_aio_stat2_exit, retval);
+  return retval;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_aio_stat2);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_cmpext)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion, const char *cmp_buf,
+  size_t cmp_len, uint64_t off)
 {
   tracepoint(librados, rados_aio_cmpext_enter, io, o, completion, cmp_buf,
 	     cmp_len, off);
@@ -2604,18 +3044,21 @@ extern "C" int _rados_aio_cmpext(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_cmpext);
 
-extern "C" int _rados_aio_cancel(rados_ioctx_t io, rados_completion_t completion)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_cancel)(
+  rados_ioctx_t io,
+  rados_completion_t completion)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   return ctx->aio_cancel((librados::AioCompletionImpl*)completion);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_cancel);
 
-extern "C" int _rados_aio_exec(rados_ioctx_t io, const char *o,
-			       rados_completion_t completion,
-			       const char *cls, const char *method,
-			       const char *inbuf, size_t in_len,
-			       char *buf, size_t out_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_exec)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *cls, const char *method,
+  const char *inbuf, size_t in_len,
+  char *buf, size_t out_len)
 {
   tracepoint(librados, rados_aio_exec_enter, io, o, completion);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2638,9 +3081,10 @@ struct C_WatchCB : public librados::WatchCtx {
   }
 };
 
-extern "C" int _rados_watch(rados_ioctx_t io, const char *o, uint64_t ver,
-			    uint64_t *handle,
-			    rados_watchcb_t watchcb, void *arg)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_watch)(
+  rados_ioctx_t io, const char *o, uint64_t ver,
+  uint64_t *handle,
+  rados_watchcb_t watchcb, void *arg)
 {
   tracepoint(librados, rados_watch_enter, io, o, ver, watchcb, arg);
   uint64_t *cookie = handle;
@@ -2672,11 +3116,12 @@ struct C_WatchCB2 : public librados::WatchCtx2 {
   }
 };
 
-extern "C" int _rados_watch3(rados_ioctx_t io, const char *o, uint64_t *handle,
-			     rados_watchcb2_t watchcb,
-			     rados_watcherrcb_t watcherrcb,
-			     uint32_t timeout,
-			     void *arg)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_watch3)(
+  rados_ioctx_t io, const char *o, uint64_t *handle,
+  rados_watchcb2_t watchcb,
+  rados_watcherrcb_t watcherrcb,
+  uint32_t timeout,
+  void *arg)
 {
   tracepoint(librados, rados_watch3_enter, io, o, handle, watchcb, timeout, arg);
   int ret;
@@ -2694,20 +3139,24 @@ extern "C" int _rados_watch3(rados_ioctx_t io, const char *o, uint64_t *handle,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_watch3);
 
-extern "C" int _rados_watch2(rados_ioctx_t io, const char *o, uint64_t *handle,
-			     rados_watchcb2_t watchcb,
-			     rados_watcherrcb_t watcherrcb,
-			     void *arg) {
-  return _rados_watch3(io, o, handle, watchcb, watcherrcb, 0, arg);
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_watch2)(
+  rados_ioctx_t io, const char *o, uint64_t *handle,
+  rados_watchcb2_t watchcb,
+  rados_watcherrcb_t watcherrcb,
+  void *arg)
+{
+  return LIBRADOS_C_API_DEFAULT_F(rados_watch3)(
+    io, o, handle, watchcb, watcherrcb, 0, arg);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_watch2);
 
-extern "C" int _rados_aio_watch2(rados_ioctx_t io, const char *o,
-                                 rados_completion_t completion,
-                                 uint64_t *handle,
-                                 rados_watchcb2_t watchcb,
-                                 rados_watcherrcb_t watcherrcb,
-                                 uint32_t timeout, void *arg)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_watch2)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  uint64_t *handle,
+  rados_watchcb2_t watchcb,
+  rados_watcherrcb_t watcherrcb,
+  uint32_t timeout, void *arg)
 {
   tracepoint(librados, rados_aio_watch2_enter, io, o, completion, handle, watchcb, timeout, arg);
   int ret;
@@ -2727,16 +3176,22 @@ extern "C" int _rados_aio_watch2(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_watch2);
 
-extern "C" int _rados_aio_watch(rados_ioctx_t io, const char *o,
-                                rados_completion_t completion,
-                                uint64_t *handle,
-                                rados_watchcb2_t watchcb,
-                                rados_watcherrcb_t watcherrcb, void *arg) {
-  return _rados_aio_watch2(io, o, completion, handle, watchcb, watcherrcb, 0, arg);
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_watch)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  uint64_t *handle,
+  rados_watchcb2_t watchcb,
+  rados_watcherrcb_t watcherrcb, void *arg)
+{
+  return LIBRADOS_C_API_DEFAULT_F(rados_aio_watch2)(
+    io, o, completion, handle, watchcb, watcherrcb, 0, arg);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_watch);
 
-extern "C" int _rados_unwatch(rados_ioctx_t io, const char *o, uint64_t handle)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_unwatch)(
+  rados_ioctx_t io,
+  const char *o,
+  uint64_t handle)
 {
   tracepoint(librados, rados_unwatch_enter, io, o, handle);
   uint64_t cookie = handle;
@@ -2747,7 +3202,9 @@ extern "C" int _rados_unwatch(rados_ioctx_t io, const char *o, uint64_t handle)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_unwatch);
 
-extern "C" int _rados_unwatch2(rados_ioctx_t io, uint64_t handle)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_unwatch2)(
+  rados_ioctx_t io,
+  uint64_t handle)
 {
   tracepoint(librados, rados_unwatch2_enter, io, handle);
   uint64_t cookie = handle;
@@ -2758,8 +3215,9 @@ extern "C" int _rados_unwatch2(rados_ioctx_t io, uint64_t handle)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_unwatch2);
 
-extern "C" int _rados_aio_unwatch(rados_ioctx_t io, uint64_t handle,
-                                  rados_completion_t completion)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_unwatch)(
+  rados_ioctx_t io, uint64_t handle,
+  rados_completion_t completion)
 {
   tracepoint(librados, rados_aio_unwatch_enter, io, handle, completion);
   uint64_t cookie = handle;
@@ -2772,7 +3230,9 @@ extern "C" int _rados_aio_unwatch(rados_ioctx_t io, uint64_t handle,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_unwatch);
 
-extern "C" int _rados_watch_check(rados_ioctx_t io, uint64_t handle)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_watch_check)(
+  rados_ioctx_t io,
+  uint64_t handle)
 {
   tracepoint(librados, rados_watch_check_enter, io, handle);
   uint64_t cookie = handle;
@@ -2783,8 +3243,9 @@ extern "C" int _rados_watch_check(rados_ioctx_t io, uint64_t handle)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_watch_check);
 
-extern "C" int _rados_notify(rados_ioctx_t io, const char *o,
-			     uint64_t ver, const char *buf, int buf_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_notify)(
+  rados_ioctx_t io, const char *o,
+  uint64_t ver, const char *buf, int buf_len)
 {
   tracepoint(librados, rados_notify_enter, io, o, ver, buf, buf_len);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2801,11 +3262,12 @@ extern "C" int _rados_notify(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_notify);
 
-extern "C" int _rados_notify2(rados_ioctx_t io, const char *o,
-			      const char *buf, int buf_len,
-			      uint64_t timeout_ms,
-			      char **reply_buffer,
-			      size_t *reply_buffer_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_notify2)(
+  rados_ioctx_t io, const char *o,
+  const char *buf, int buf_len,
+  uint64_t timeout_ms,
+  char **reply_buffer,
+  size_t *reply_buffer_len)
 {
   tracepoint(librados, rados_notify2_enter, io, o, buf, buf_len, timeout_ms);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2822,11 +3284,85 @@ extern "C" int _rados_notify2(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_notify2);
 
-extern "C" int _rados_aio_notify(rados_ioctx_t io, const char *o,
-                                 rados_completion_t completion,
-                                 const char *buf, int buf_len,
-                                 uint64_t timeout_ms, char **reply_buffer,
-                                 size_t *reply_buffer_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_decode_notify_response)(
+  char *reply_buffer, size_t reply_buffer_len,
+  struct notify_ack_t **acks, size_t *nr_acks,
+  struct notify_timeout_t **timeouts, size_t *nr_timeouts)
+{
+  if (!reply_buffer || !reply_buffer_len) {
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  bl.append(reply_buffer, reply_buffer_len);
+
+  map<pair<uint64_t,uint64_t>,bufferlist> acked;
+  set<pair<uint64_t,uint64_t>> missed;
+  auto iter = bl.cbegin();
+  decode(acked, iter);
+  decode(missed, iter);
+
+  *acks = nullptr;
+  *nr_acks = acked.size();
+  if (*nr_acks) {
+    *acks = new notify_ack_t[*nr_acks];
+    struct notify_ack_t *ack = *acks;
+    for (auto &[who, payload] : acked) {
+      ack->notifier_id = who.first;
+      ack->cookie = who.second;
+      ack->payload = nullptr;
+      ack->payload_len = payload.length();
+      if (ack->payload_len) {
+        ack->payload = (char *)malloc(ack->payload_len);
+        memcpy(ack->payload, payload.c_str(), ack->payload_len);
+      }
+
+      ack++;
+    }
+  }
+
+  *timeouts = nullptr;
+  *nr_timeouts = missed.size();
+  if (*nr_timeouts) {
+    *timeouts = new notify_timeout_t[*nr_timeouts];
+    struct notify_timeout_t *timeout = *timeouts;
+    for (auto &[notifier_id, cookie] : missed) {
+      timeout->notifier_id = notifier_id;
+      timeout->cookie = cookie;
+      timeout++;
+    }
+  }
+
+  return 0;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_decode_notify_response);
+
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_free_notify_response)(
+  struct notify_ack_t *acks, size_t nr_acks,
+  struct notify_timeout_t *timeouts)
+{
+  for (uint64_t n = 0; n < nr_acks; ++n) {
+    assert(acks);
+    if (acks[n].payload) {
+      free(acks[n].payload);
+    }
+  }
+  if (acks) {
+    delete[] acks;
+  }
+  if (timeouts) {
+    delete[] timeouts;
+  }
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_free_notify_response);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_notify)(
+  rados_ioctx_t io, const char *o,
+  rados_completion_t completion,
+  const char *buf, int buf_len,
+  uint64_t timeout_ms, char **reply_buffer,
+  size_t *reply_buffer_len)
 {
   tracepoint(librados, rados_aio_notify_enter, io, o, completion, buf, buf_len,
              timeout_ms);
@@ -2845,9 +3381,10 @@ extern "C" int _rados_aio_notify(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_notify);
 
-extern "C" int _rados_notify_ack(rados_ioctx_t io, const char *o,
-				 uint64_t notify_id, uint64_t handle,
-				 const char *buf, int buf_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_notify_ack)(
+  rados_ioctx_t io, const char *o,
+  uint64_t notify_id, uint64_t handle,
+  const char *buf, int buf_len)
 {
   tracepoint(librados, rados_notify_ack_enter, io, o, notify_id, handle, buf, buf_len);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2864,7 +3401,7 @@ extern "C" int _rados_notify_ack(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_notify_ack);
 
-extern "C" int _rados_watch_flush(rados_t cluster)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_watch_flush)(rados_t cluster)
 {
   tracepoint(librados, rados_watch_flush_enter, cluster);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -2874,7 +3411,9 @@ extern "C" int _rados_watch_flush(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_watch_flush);
 
-extern "C" int _rados_aio_watch_flush(rados_t cluster, rados_completion_t completion)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_watch_flush)(
+  rados_t cluster,
+  rados_completion_t completion)
 {
   tracepoint(librados, rados_aio_watch_flush_enter, cluster, completion);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
@@ -2885,9 +3424,10 @@ extern "C" int _rados_aio_watch_flush(rados_t cluster, rados_completion_t comple
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_watch_flush);
 
-extern "C" int _rados_set_alloc_hint(rados_ioctx_t io, const char *o,
-                                     uint64_t expected_object_size,
-                                     uint64_t expected_write_size)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_set_alloc_hint)(
+  rados_ioctx_t io, const char *o,
+  uint64_t expected_object_size,
+  uint64_t expected_write_size)
 {
   tracepoint(librados, rados_set_alloc_hint_enter, io, o, expected_object_size, expected_write_size);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2899,10 +3439,11 @@ extern "C" int _rados_set_alloc_hint(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_set_alloc_hint);
 
-extern "C" int _rados_set_alloc_hint2(rados_ioctx_t io, const char *o,
-				      uint64_t expected_object_size,
-				      uint64_t expected_write_size,
-				      uint32_t flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_set_alloc_hint2)(
+  rados_ioctx_t io, const char *o,
+  uint64_t expected_object_size,
+  uint64_t expected_write_size,
+  uint32_t flags)
 {
   tracepoint(librados, rados_set_alloc_hint2_enter, io, o, expected_object_size, expected_write_size, flags);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -2914,10 +3455,11 @@ extern "C" int _rados_set_alloc_hint2(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_set_alloc_hint2);
 
-extern "C" int _rados_lock_exclusive(rados_ioctx_t io, const char * o,
-                                     const char * name, const char * cookie,
-                                     const char * desc,
-                                     struct timeval * duration, uint8_t flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_lock_exclusive)(
+  rados_ioctx_t io, const char * o,
+  const char * name, const char * cookie,
+  const char * desc,
+  struct timeval * duration, uint8_t flags)
 {
   tracepoint(librados, rados_lock_exclusive_enter, io, o, name, cookie, desc, duration, flags);
   librados::IoCtx ctx;
@@ -2929,10 +3471,11 @@ extern "C" int _rados_lock_exclusive(rados_ioctx_t io, const char * o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_lock_exclusive);
 
-extern "C" int _rados_lock_shared(rados_ioctx_t io, const char * o,
-                                  const char * name, const char * cookie,
-                                  const char * tag, const char * desc,
-                                  struct timeval * duration, uint8_t flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_lock_shared)(
+  rados_ioctx_t io, const char * o,
+  const char * name, const char * cookie,
+  const char * tag, const char * desc,
+  struct timeval * duration, uint8_t flags)
 {
   tracepoint(librados, rados_lock_shared_enter, io, o, name, cookie, tag, desc, duration, flags);
   librados::IoCtx ctx;
@@ -2944,8 +3487,9 @@ extern "C" int _rados_lock_shared(rados_ioctx_t io, const char * o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_lock_shared);
 
-extern "C" int _rados_unlock(rados_ioctx_t io, const char *o, const char *name,
-			     const char *cookie)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_unlock)(
+  rados_ioctx_t io, const char *o, const char *name,
+  const char *cookie)
 {
   tracepoint(librados, rados_unlock_enter, io, o, name, cookie);
   librados::IoCtx ctx;
@@ -2957,13 +3501,15 @@ extern "C" int _rados_unlock(rados_ioctx_t io, const char *o, const char *name,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_unlock);
 
-extern "C" int _rados_aio_unlock(rados_ioctx_t io, const char *o, const char *name,
-			         const char *cookie, rados_completion_t completion)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_unlock)(
+  rados_ioctx_t io, const char *o, const char *name,
+  const char *cookie, rados_completion_t completion)
 {
   tracepoint(librados, rados_aio_unlock_enter, io, o, name, cookie, completion);
   librados::IoCtx ctx;
   librados::IoCtx::from_rados_ioctx_t(io, ctx);
   librados::AioCompletionImpl *comp = (librados::AioCompletionImpl*)completion;
+  comp->get();
   librados::AioCompletion c(comp);
   int retval = ctx.aio_unlock(o, name, cookie, &c);
   tracepoint(librados, rados_aio_unlock_exit, retval);
@@ -2971,12 +3517,13 @@ extern "C" int _rados_aio_unlock(rados_ioctx_t io, const char *o, const char *na
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_unlock);
 
-extern "C" ssize_t _rados_list_lockers(rados_ioctx_t io, const char *o,
-				       const char *name, int *exclusive,
-				       char *tag, size_t *tag_len,
-				       char *clients, size_t *clients_len,
-				       char *cookies, size_t *cookies_len,
-				       char *addrs, size_t *addrs_len)
+extern "C" ssize_t LIBRADOS_C_API_DEFAULT_F(rados_list_lockers)(
+  rados_ioctx_t io, const char *o,
+  const char *name, int *exclusive,
+  char *tag, size_t *tag_len,
+  char *clients, size_t *clients_len,
+  char *cookies, size_t *cookies_len,
+  char *addrs, size_t *addrs_len)
 {
   tracepoint(librados, rados_list_lockers_enter, io, o, name, *tag_len, *clients_len, *cookies_len, *addrs_len);
   librados::IoCtx ctx;
@@ -3039,9 +3586,10 @@ extern "C" ssize_t _rados_list_lockers(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_list_lockers);
 
-extern "C" int _rados_break_lock(rados_ioctx_t io, const char *o,
-				 const char *name, const char *client,
-				 const char *cookie)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_break_lock)(
+  rados_ioctx_t io, const char *o,
+  const char *name, const char *client,
+  const char *cookie)
 {
   tracepoint(librados, rados_break_lock_enter, io, o, name, client, cookie);
   librados::IoCtx ctx;
@@ -3053,73 +3601,86 @@ extern "C" int _rados_break_lock(rados_ioctx_t io, const char *o,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_break_lock);
 
-extern "C" rados_write_op_t _rados_create_write_op()
+extern "C" rados_write_op_t LIBRADOS_C_API_DEFAULT_F(rados_create_write_op)()
 {
   tracepoint(librados, rados_create_write_op_enter);
-  rados_write_op_t retval = new (std::nothrow)::ObjectOperation;
+  rados_write_op_t retval = new (std::nothrow) librados::ObjectOperationImpl;
   tracepoint(librados, rados_create_write_op_exit, retval);
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_create_write_op);
 
-extern "C" void _rados_release_write_op(rados_write_op_t write_op)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_release_write_op)(
+  rados_write_op_t write_op)
 {
   tracepoint(librados, rados_release_write_op_enter, write_op);
-  delete (::ObjectOperation*)write_op;
+  delete static_cast<librados::ObjectOperationImpl*>(write_op);
   tracepoint(librados, rados_release_write_op_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_release_write_op);
 
-extern "C" void _rados_write_op_set_flags(rados_write_op_t write_op, int flags)
+static ::ObjectOperation* to_object_operation(rados_write_op_t write_op)
+{
+  return &static_cast<librados::ObjectOperationImpl*>(write_op)->o;
+}
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_flags)(
+  rados_write_op_t write_op,
+  int flags)
 {
   tracepoint(librados, rados_write_op_set_flags_enter, write_op, flags);
-  ((::ObjectOperation *)write_op)->set_last_op_flags(get_op_flags(flags));
+  to_object_operation(write_op)->set_last_op_flags(get_op_flags(flags));
   tracepoint(librados, rados_write_op_set_flags_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_flags);
 
-extern "C" void _rados_write_op_assert_version(rados_write_op_t write_op, uint64_t ver)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_assert_version)(
+  rados_write_op_t write_op,
+  uint64_t ver)
 {
   tracepoint(librados, rados_write_op_assert_version_enter, write_op, ver);
-  ((::ObjectOperation *)write_op)->assert_version(ver);
+  to_object_operation(write_op)->assert_version(ver);
   tracepoint(librados, rados_write_op_assert_version_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_assert_version);
 
-extern "C" void _rados_write_op_assert_exists(rados_write_op_t write_op)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_assert_exists)(
+  rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_assert_exists_enter, write_op);
-  ((::ObjectOperation *)write_op)->stat(NULL, (ceph::real_time *)NULL, NULL);
+  to_object_operation(write_op)->stat(nullptr, nullptr, nullptr);
   tracepoint(librados, rados_write_op_assert_exists_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_assert_exists);
 
-extern "C" void _rados_write_op_cmpext(rados_write_op_t write_op,
-				       const char *cmp_buf,
-				       size_t cmp_len,
-				       uint64_t off,
-				       int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_cmpext)(
+  rados_write_op_t write_op,
+  const char *cmp_buf,
+  size_t cmp_len,
+  uint64_t off,
+  int *prval)
 {
   tracepoint(librados, rados_write_op_cmpext_enter, write_op, cmp_buf,
 	     cmp_len, off, prval);
-  ((::ObjectOperation *)write_op)->cmpext(off, cmp_len, cmp_buf, prval);
+  to_object_operation(write_op)->cmpext(off, cmp_len, cmp_buf, prval);
   tracepoint(librados, rados_write_op_cmpext_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_cmpext);
 
-extern "C" void _rados_write_op_cmpxattr(rados_write_op_t write_op,
-                                         const char *name,
-				         uint8_t comparison_operator,
-				         const char *value,
-				         size_t value_len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_cmpxattr)(
+  rados_write_op_t write_op,
+  const char *name,
+  uint8_t comparison_operator,
+  const char *value,
+  size_t value_len)
 {
   tracepoint(librados, rados_write_op_cmpxattr_enter, write_op, name, comparison_operator, value, value_len);
   bufferlist bl;
   bl.append(value, value_len);
-  ((::ObjectOperation *)write_op)->cmpxattr(name,
-					    comparison_operator,
-					    CEPH_OSD_CMPXATTR_MODE_STRING,
-					    bl);
+  to_object_operation(write_op)->cmpxattr(name,
+					  comparison_operator,
+					  CEPH_OSD_CMPXATTR_MODE_STRING,
+					  bl);
   tracepoint(librados, rados_write_op_cmpxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_cmpxattr);
@@ -3141,166 +3702,179 @@ static void rados_c_omap_cmp(ObjectOperation *op,
   op->omap_cmp(assertions, prval);
 }
 
-extern "C" void _rados_write_op_omap_cmp(rados_write_op_t write_op,
-                                         const char *key,
-                                         uint8_t comparison_operator,
-                                         const char *val,
-                                         size_t val_len,
-                                         int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_cmp)(
+  rados_write_op_t write_op,
+  const char *key,
+  uint8_t comparison_operator,
+  const char *val,
+  size_t val_len,
+  int *prval)
 {
   tracepoint(librados, rados_write_op_omap_cmp_enter, write_op, key, comparison_operator, val, val_len, prval);
-  rados_c_omap_cmp((::ObjectOperation *)write_op, key, comparison_operator,
+  rados_c_omap_cmp(to_object_operation(write_op), key, comparison_operator,
                    val, strlen(key), val_len, prval);
   tracepoint(librados, rados_write_op_omap_cmp_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_cmp);
 
-extern "C" void _rados_write_op_omap_cmp2(rados_write_op_t write_op,
-                                          const char *key,
-                                          uint8_t comparison_operator,
-                                          const char *val,
-                                          size_t key_len,
-                                          size_t val_len,
-                                          int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_cmp2)(
+  rados_write_op_t write_op,
+  const char *key,
+  uint8_t comparison_operator,
+  const char *val,
+  size_t key_len,
+  size_t val_len,
+  int *prval)
 {
   tracepoint(librados, rados_write_op_omap_cmp_enter, write_op, key, comparison_operator, val, val_len, prval);
-  rados_c_omap_cmp((::ObjectOperation *)write_op, key, comparison_operator,
+  rados_c_omap_cmp(to_object_operation(write_op), key, comparison_operator,
                    val, key_len, val_len, prval);
   tracepoint(librados, rados_write_op_omap_cmp_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_cmp2);
 
-extern "C" void _rados_write_op_setxattr(rados_write_op_t write_op,
-                                         const char *name,
-				         const char *value,
-				         size_t value_len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_setxattr)(
+  rados_write_op_t write_op,
+  const char *name,
+  const char *value,
+  size_t value_len)
 {
   tracepoint(librados, rados_write_op_setxattr_enter, write_op, name, value, value_len);
   bufferlist bl;
   bl.append(value, value_len);
-  ((::ObjectOperation *)write_op)->setxattr(name, bl);
+  to_object_operation(write_op)->setxattr(name, bl);
   tracepoint(librados, rados_write_op_setxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_setxattr);
 
-extern "C" void _rados_write_op_rmxattr(rados_write_op_t write_op,
-                                        const char *name)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_rmxattr)(
+  rados_write_op_t write_op,
+  const char *name)
 {
   tracepoint(librados, rados_write_op_rmxattr_enter, write_op, name);
-  ((::ObjectOperation *)write_op)->rmxattr(name);
+  to_object_operation(write_op)->rmxattr(name);
   tracepoint(librados, rados_write_op_rmxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_rmxattr);
 
-extern "C" void _rados_write_op_create(rados_write_op_t write_op,
-                                       int exclusive,
-				       const char* category) // unused
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_create)(
+  rados_write_op_t write_op,
+  int exclusive,
+  const char* category) // unused
 {
   tracepoint(librados, rados_write_op_create_enter, write_op, exclusive);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
-  oo->create(!!exclusive);
+  to_object_operation(write_op)->create(!!exclusive);
   tracepoint(librados, rados_write_op_create_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_create);
 
-extern "C" void _rados_write_op_write(rados_write_op_t write_op,
-				      const char *buffer,
-				      size_t len,
-                                      uint64_t offset)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_write)(
+  rados_write_op_t write_op,
+  const char *buffer,
+  size_t len,
+  uint64_t offset)
 {
   tracepoint(librados, rados_write_op_write_enter, write_op, buffer, len, offset);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->write(offset, bl);
+  to_object_operation(write_op)->write(offset, bl);
   tracepoint(librados, rados_write_op_write_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_write);
 
-extern "C" void _rados_write_op_write_full(rados_write_op_t write_op,
-				           const char *buffer,
-				           size_t len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_write_full)(
+  rados_write_op_t write_op,
+  const char *buffer,
+  size_t len)
 {
   tracepoint(librados, rados_write_op_write_full_enter, write_op, buffer, len);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->write_full(bl);
+  to_object_operation(write_op)->write_full(bl);
   tracepoint(librados, rados_write_op_write_full_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_write_full);
 
-extern "C" void _rados_write_op_writesame(rados_write_op_t write_op,
-				          const char *buffer,
-				          size_t data_len,
-				          size_t write_len,
-					  uint64_t offset)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_writesame)(
+  rados_write_op_t write_op,
+  const char *buffer,
+  size_t data_len,
+  size_t write_len,
+  uint64_t offset)
 {
   tracepoint(librados, rados_write_op_writesame_enter, write_op, buffer, data_len, write_len, offset);
   bufferlist bl;
   bl.append(buffer, data_len);
-  ((::ObjectOperation *)write_op)->writesame(offset, write_len, bl);
+  to_object_operation(write_op)->writesame(offset, write_len, bl);
   tracepoint(librados, rados_write_op_writesame_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_writesame);
 
-extern "C" void _rados_write_op_append(rados_write_op_t write_op,
-				       const char *buffer,
-				       size_t len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_append)(
+  rados_write_op_t write_op,
+  const char *buffer,
+  size_t len)
 {
   tracepoint(librados, rados_write_op_append_enter, write_op, buffer, len);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->append(bl);
+  to_object_operation(write_op)->append(bl);
   tracepoint(librados, rados_write_op_append_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_append);
 
-extern "C" void _rados_write_op_remove(rados_write_op_t write_op)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_remove)(
+  rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_remove_enter, write_op);
-  ((::ObjectOperation *)write_op)->remove();
+  to_object_operation(write_op)->remove();
   tracepoint(librados, rados_write_op_remove_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_remove);
 
-extern "C" void _rados_write_op_truncate(rados_write_op_t write_op,
-				         uint64_t offset)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_truncate)(
+  rados_write_op_t write_op,
+  uint64_t offset)
 {
   tracepoint(librados, rados_write_op_truncate_enter, write_op, offset);
-  ((::ObjectOperation *)write_op)->truncate(offset);
+  to_object_operation(write_op)->truncate(offset);
   tracepoint(librados, rados_write_op_truncate_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_truncate);
 
-extern "C" void _rados_write_op_zero(rados_write_op_t write_op,
-				     uint64_t offset,
-				     uint64_t len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_zero)(
+  rados_write_op_t write_op,
+  uint64_t offset,
+  uint64_t len)
 {
   tracepoint(librados, rados_write_op_zero_enter, write_op, offset, len);
-  ((::ObjectOperation *)write_op)->zero(offset, len);
+  to_object_operation(write_op)->zero(offset, len);
   tracepoint(librados, rados_write_op_zero_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_zero);
 
-extern "C" void _rados_write_op_exec(rados_write_op_t write_op,
-				     const char *cls,
-				     const char *method,
-				     const char *in_buf,
-				     size_t in_len,
-				     int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_exec)(
+  rados_write_op_t write_op,
+  const char *cls,
+  const char *method,
+  const char *in_buf,
+  size_t in_len,
+  int *prval)
 {
   tracepoint(librados, rados_write_op_exec_enter, write_op, cls, method, in_buf, in_len, prval);
   bufferlist inbl;
   inbl.append(in_buf, in_len);
-  ((::ObjectOperation *)write_op)->call(cls, method, inbl, NULL, NULL, prval);
+  to_object_operation(write_op)->call(cls, method, inbl, NULL, NULL, prval);
   tracepoint(librados, rados_write_op_exec_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_exec);
 
-extern "C" void _rados_write_op_omap_set(rados_write_op_t write_op,
-                                         char const* const* keys,
-                                         char const* const* vals,
-                                         const size_t *lens,
-                                         size_t num)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_set)(
+  rados_write_op_t write_op,
+  char const* const* keys,
+  char const* const* vals,
+  const size_t *lens,
+  size_t num)
 {
   tracepoint(librados, rados_write_op_omap_set_enter, write_op, num);
   std::map<std::string, bufferlist> entries;
@@ -3310,17 +3884,18 @@ extern "C" void _rados_write_op_omap_set(rados_write_op_t write_op,
     bl.append(vals[i], lens[i]);
     entries[keys[i]] = bl;
   }
-  ((::ObjectOperation *)write_op)->omap_set(entries);
+  to_object_operation(write_op)->omap_set(entries);
   tracepoint(librados, rados_write_op_omap_set_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_set);
 
-extern "C" void _rados_write_op_omap_set2(rados_write_op_t write_op,
-                                          char const* const* keys,
-                                          char const* const* vals,
-                                          const size_t *key_lens,
-                                          const size_t *val_lens,
-                                          size_t num)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_set2)(
+  rados_write_op_t write_op,
+  char const* const* keys,
+  char const* const* vals,
+  const size_t *key_lens,
+  const size_t *val_lens,
+  size_t num)
 {
   tracepoint(librados, rados_write_op_omap_set_enter, write_op, num);
   std::map<std::string, bufferlist> entries;
@@ -3330,155 +3905,189 @@ extern "C" void _rados_write_op_omap_set2(rados_write_op_t write_op,
     string key(keys[i], key_lens[i]);
     entries[key] = bl;
   }
-  ((::ObjectOperation *)write_op)->omap_set(entries);
+  to_object_operation(write_op)->omap_set(entries);
   tracepoint(librados, rados_write_op_omap_set_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_set2);
 
-extern "C" void _rados_write_op_omap_rm_keys(rados_write_op_t write_op,
-                                             char const* const* keys,
-                                             size_t keys_len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_keys)(
+  rados_write_op_t write_op,
+  char const* const* keys,
+  size_t keys_len)
 {
   tracepoint(librados, rados_write_op_omap_rm_keys_enter, write_op, keys_len);
   for(size_t i = 0; i < keys_len; i++) {
     tracepoint(librados, rados_write_op_omap_rm_keys_entry, keys[i]);
   }
   std::set<std::string> to_remove(keys, keys + keys_len);
-  ((::ObjectOperation *)write_op)->omap_rm_keys(to_remove);
+  to_object_operation(write_op)->omap_rm_keys(to_remove);
   tracepoint(librados, rados_write_op_omap_rm_keys_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys);
 
-extern "C" void _rados_write_op_omap_rm_keys2(rados_write_op_t write_op,
-                                              char const* const* keys,
-                                              const size_t* key_lens,
-                                              size_t keys_len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_keys2)(
+  rados_write_op_t write_op,
+  char const* const* keys,
+  const size_t* key_lens,
+  size_t keys_len)
 {
   tracepoint(librados, rados_write_op_omap_rm_keys_enter, write_op, keys_len);
   std::set<std::string> to_remove;
   for(size_t i = 0; i < keys_len; i++) {
     to_remove.emplace(keys[i], key_lens[i]);
   }
-  ((::ObjectOperation *)write_op)->omap_rm_keys(to_remove);
+  to_object_operation(write_op)->omap_rm_keys(to_remove);
   tracepoint(librados, rados_write_op_omap_rm_keys_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys2);
 
-extern "C" void _rados_write_op_omap_rm_range2(rados_write_op_t write_op,
-                                               const char *key_begin,
-                                               size_t key_begin_len,
-                                               const char *key_end,
-                                               size_t key_end_len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_range2)(
+  rados_write_op_t write_op,
+  const char *key_begin,
+  size_t key_begin_len,
+  const char *key_end,
+  size_t key_end_len)
 {
   tracepoint(librados, rados_write_op_omap_rm_range_enter,
              write_op, key_begin, key_end);
-  ((::ObjectOperation *)write_op)->omap_rm_range({key_begin, key_begin_len},
-                                                 {key_end, key_end_len});
+  to_object_operation(write_op)->omap_rm_range({key_begin, key_begin_len},
+                                               {key_end, key_end_len});
   tracepoint(librados, rados_write_op_omap_rm_range_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_range2);
 
-extern "C" void _rados_write_op_omap_clear(rados_write_op_t write_op)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_clear)(
+  rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_omap_clear_enter, write_op);
-  ((::ObjectOperation *)write_op)->omap_clear();
+  to_object_operation(write_op)->omap_clear();
   tracepoint(librados, rados_write_op_omap_clear_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_clear);
 
-extern "C" void _rados_write_op_set_alloc_hint(rados_write_op_t write_op,
-                                               uint64_t expected_object_size,
-                                               uint64_t expected_write_size)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_alloc_hint)(
+  rados_write_op_t write_op,
+  uint64_t expected_object_size,
+  uint64_t expected_write_size)
 {
   tracepoint(librados, rados_write_op_set_alloc_hint_enter, write_op, expected_object_size, expected_write_size);
-  ((::ObjectOperation *)write_op)->set_alloc_hint(expected_object_size,
-                                                  expected_write_size, 0);
+  to_object_operation(write_op)->set_alloc_hint(expected_object_size,
+                                                expected_write_size, 0);
   tracepoint(librados, rados_write_op_set_alloc_hint_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_alloc_hint);
 
-extern "C" void _rados_write_op_set_alloc_hint2(rados_write_op_t write_op,
-					        uint64_t expected_object_size,
-					        uint64_t expected_write_size,
-					        uint32_t flags)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_alloc_hint2)(
+  rados_write_op_t write_op,
+  uint64_t expected_object_size,
+  uint64_t expected_write_size,
+  uint32_t flags)
 {
   tracepoint(librados, rados_write_op_set_alloc_hint2_enter, write_op, expected_object_size, expected_write_size, flags);
-  ((::ObjectOperation *)write_op)->set_alloc_hint(expected_object_size,
-                                                  expected_write_size,
-						  flags);
+  to_object_operation(write_op)->set_alloc_hint(expected_object_size,
+                                                expected_write_size,
+						flags);
   tracepoint(librados, rados_write_op_set_alloc_hint2_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_alloc_hint2);
 
-extern "C" int _rados_write_op_operate(rados_write_op_t write_op,
-                                       rados_ioctx_t io,
-                                       const char *oid,
-				       time_t *mtime,
-				       int flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate)(
+  rados_write_op_t write_op,
+  rados_ioctx_t io,
+  const char *oid,
+  time_t *mtime,
+  int flags)
 {
   tracepoint(librados, rados_write_op_operate_enter, write_op, io, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
-  ceph::real_time *prt = NULL;
-  ceph::real_time rt;
-
   if (mtime) {
-    rt = ceph::real_clock::from_time_t(*mtime);
-    prt = &rt;
+    oimpl->rt = ceph::real_clock::from_time_t(*mtime);
+    oimpl->prt = &oimpl->rt;
   }
 
-  int retval = ctx->operate(obj, oo, prt, translate_flags(flags));
+  int retval = ctx->operate(obj, &oimpl->o, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_write_op_operate_exit, retval);
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_operate);
 
-extern "C" int _rados_write_op_operate2(rados_write_op_t write_op,
-                                        rados_ioctx_t io,
-                                        const char *oid,
-                                        struct timespec *ts,
-                                        int flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate2)(
+  rados_write_op_t write_op,
+  rados_ioctx_t io,
+  const char *oid,
+  struct timespec *ts,
+  int flags)
 {
   tracepoint(librados, rados_write_op_operate2_enter, write_op, io, oid, ts, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
-  ceph::real_time *prt = NULL;
-  ceph::real_time rt;
-
   if (ts) {
-    rt = ceph::real_clock::from_timespec(*ts);
-    prt = &rt;
+    oimpl->rt = ceph::real_clock::from_timespec(*ts);
+    oimpl->prt = &oimpl->rt;
   }
 
-  int retval = ctx->operate(obj, oo, prt, translate_flags(flags));
+  int retval = ctx->operate(obj, &oimpl->o, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_write_op_operate_exit, retval);
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_operate2);
 
-extern "C" int _rados_aio_write_op_operate(rados_write_op_t write_op,
-					   rados_ioctx_t io,
-					   rados_completion_t completion,
-					   const char *oid,
-					   time_t *mtime,
-					   int flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
+  rados_write_op_t write_op,
+  rados_ioctx_t io,
+  rados_completion_t completion,
+  const char *oid,
+  time_t *mtime,
+  int flags)
 {
   tracepoint(librados, rados_aio_write_op_operate_enter, write_op, io, completion, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
-  int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, translate_flags(flags));
+
+  if (mtime) {
+    oimpl->rt = ceph::real_clock::from_time_t(*mtime);
+    oimpl->prt = &oimpl->rt;
+  }
+
+  int retval = ctx->aio_operate(obj, &oimpl->o, c, ctx->snapc, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_aio_write_op_operate_exit, retval);
   return retval;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_op_operate);
 
-extern "C" rados_read_op_t _rados_create_read_op()
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate2)(
+  rados_write_op_t write_op,
+  rados_ioctx_t io,
+  rados_completion_t completion,
+  const char *oid,
+  struct timespec *mtime,
+  int flags)
+{
+  tracepoint(librados, rados_aio_write_op_operate2_enter, write_op, io, completion, oid, mtime, flags);
+  object_t obj(oid);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
+
+  if (mtime) {
+    oimpl->rt = ceph::real_clock::from_timespec(*mtime);
+    oimpl->prt = &oimpl->rt;
+  }
+
+  int retval = ctx->aio_operate(obj, &oimpl->o, c, ctx->snapc, oimpl->prt, translate_flags(flags));
+  tracepoint(librados, rados_aio_write_op_operate_exit, retval);
+  return retval;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_op_operate2);
+
+extern "C" rados_read_op_t LIBRADOS_C_API_DEFAULT_F(rados_create_read_op)()
 {
   tracepoint(librados, rados_create_read_op_enter);
   rados_read_op_t retval = new (std::nothrow)::ObjectOperation;
@@ -3487,7 +4096,8 @@ extern "C" rados_read_op_t _rados_create_read_op()
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_create_read_op);
 
-extern "C" void _rados_release_read_op(rados_read_op_t read_op)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_release_read_op)(
+  rados_read_op_t read_op)
 {
   tracepoint(librados, rados_release_read_op_enter, read_op);
   delete (::ObjectOperation *)read_op;
@@ -3495,7 +4105,9 @@ extern "C" void _rados_release_read_op(rados_read_op_t read_op)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_release_read_op);
 
-extern "C" void _rados_read_op_set_flags(rados_read_op_t read_op, int flags)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_set_flags)(
+  rados_read_op_t read_op,
+  int flags)
 {
   tracepoint(librados, rados_read_op_set_flags_enter, read_op, flags);
   ((::ObjectOperation *)read_op)->set_last_op_flags(get_op_flags(flags));
@@ -3503,7 +4115,9 @@ extern "C" void _rados_read_op_set_flags(rados_read_op_t read_op, int flags)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_set_flags);
 
-extern "C" void _rados_read_op_assert_version(rados_read_op_t read_op, uint64_t ver)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_assert_version)(
+  rados_read_op_t read_op,
+  uint64_t ver)
 {
   tracepoint(librados, rados_read_op_assert_version_enter, read_op, ver);
   ((::ObjectOperation *)read_op)->assert_version(ver);
@@ -3511,19 +4125,21 @@ extern "C" void _rados_read_op_assert_version(rados_read_op_t read_op, uint64_t 
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_assert_version);
 
-extern "C" void _rados_read_op_assert_exists(rados_read_op_t read_op)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_assert_exists)(
+  rados_read_op_t read_op)
 {
   tracepoint(librados, rados_read_op_assert_exists_enter, read_op);
-  ((::ObjectOperation *)read_op)->stat(NULL, (ceph::real_time *)NULL, NULL);
+  ((::ObjectOperation *)read_op)->stat(nullptr, nullptr, nullptr);
   tracepoint(librados, rados_read_op_assert_exists_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_assert_exists);
 
-extern "C" void _rados_read_op_cmpext(rados_read_op_t read_op,
-				      const char *cmp_buf,
-				      size_t cmp_len,
-				      uint64_t off,
-				      int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_cmpext)(
+  rados_read_op_t read_op,
+  const char *cmp_buf,
+  size_t cmp_len,
+  uint64_t off,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_cmpext_enter, read_op, cmp_buf,
 	     cmp_len, off, prval);
@@ -3532,11 +4148,12 @@ extern "C" void _rados_read_op_cmpext(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_cmpext);
 
-extern "C" void _rados_read_op_cmpxattr(rados_read_op_t read_op,
-				        const char *name,
-				        uint8_t comparison_operator,
-				        const char *value,
-				        size_t value_len)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_cmpxattr)(
+  rados_read_op_t read_op,
+  const char *name,
+  uint8_t comparison_operator,
+  const char *value,
+  size_t value_len)
 {
   tracepoint(librados, rados_read_op_cmpxattr_enter, read_op, name, comparison_operator, value, value_len);
   bufferlist bl;
@@ -3549,12 +4166,13 @@ extern "C" void _rados_read_op_cmpxattr(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_cmpxattr);
 
-extern "C" void _rados_read_op_omap_cmp(rados_read_op_t read_op,
-                                        const char *key,
-                                        uint8_t comparison_operator,
-                                        const char *val,
-                                        size_t val_len,
-                                        int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_cmp)(
+  rados_read_op_t read_op,
+  const char *key,
+  uint8_t comparison_operator,
+  const char *val,
+  size_t val_len,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_cmp_enter, read_op, key, comparison_operator, val, val_len, prval);
   rados_c_omap_cmp((::ObjectOperation *)read_op, key, comparison_operator,
@@ -3563,13 +4181,14 @@ extern "C" void _rados_read_op_omap_cmp(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_cmp);
 
-extern "C" void _rados_read_op_omap_cmp2(rados_read_op_t read_op,
-                                         const char *key,
-                                         uint8_t comparison_operator,
-                                         const char *val,
-                                         size_t key_len,
-                                         size_t val_len,
-                                         int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_cmp2)(
+  rados_read_op_t read_op,
+  const char *key,
+  uint8_t comparison_operator,
+  const char *val,
+  size_t key_len,
+  size_t val_len,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_cmp_enter, read_op, key, comparison_operator, val, val_len, prval);
   rados_c_omap_cmp((::ObjectOperation *)read_op, key, comparison_operator,
@@ -3578,16 +4197,29 @@ extern "C" void _rados_read_op_omap_cmp2(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_cmp2);
 
-extern "C" void _rados_read_op_stat(rados_read_op_t read_op,
-				    uint64_t *psize,
-				    time_t *pmtime,
-				    int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_stat)(
+  rados_read_op_t read_op,
+  uint64_t *psize,
+  time_t *pmtime,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_stat_enter, read_op, psize, pmtime, prval);
   ((::ObjectOperation *)read_op)->stat(psize, pmtime, prval);
   tracepoint(librados, rados_read_op_stat_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_stat);
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_stat2)(
+  rados_read_op_t read_op,
+  uint64_t *psize,
+  struct timespec *pmtime,
+  int *prval)
+{
+  tracepoint(librados, rados_read_op_stat2_enter, read_op, psize, pmtime, prval);
+  ((::ObjectOperation *)read_op)->stat(psize, pmtime, prval);
+  tracepoint(librados, rados_read_op_stat2_exit);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_stat2);
 
 class C_bl_to_buf : public Context {
   char *out_buf;
@@ -3612,16 +4244,17 @@ public:
     if (bytes_read)
       *bytes_read = out_bl.length();
     if (out_buf && !out_bl.is_provided_buffer(out_buf))
-      out_bl.copy(0, out_bl.length(), out_buf);
+      out_bl.begin().copy(out_bl.length(), out_buf);
   }
 };
 
-extern "C" void _rados_read_op_read(rados_read_op_t read_op,
-				    uint64_t offset,
-				    size_t len,
-				    char *buf,
-				    size_t *bytes_read,
-				    int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_read)(
+  rados_read_op_t read_op,
+  uint64_t offset,
+  size_t len,
+  char *buf,
+  size_t *bytes_read,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_read_enter, read_op, offset, len, buf, bytes_read, prval);
   C_bl_to_buf *ctx = new C_bl_to_buf(buf, len, bytes_read, prval);
@@ -3631,13 +4264,14 @@ extern "C" void _rados_read_op_read(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_read);
 
-extern "C" void _rados_read_op_checksum(rados_read_op_t read_op,
-                                        rados_checksum_type_t type,
-                                        const char *init_value,
-                                        size_t init_value_len,
-                                        uint64_t offset, size_t len,
-                                        size_t chunk_size, char *pchecksum,
-				        size_t checksum_len, int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_checksum)(
+  rados_read_op_t read_op,
+  rados_checksum_type_t type,
+  const char *init_value,
+  size_t init_value_len,
+  uint64_t offset, size_t len,
+  size_t chunk_size, char *pchecksum,
+  size_t checksum_len, int *prval)
 {
   tracepoint(librados, rados_read_op_checksum_enter, read_op, type, init_value,
 	     init_value_len, offset, len, chunk_size);
@@ -3671,14 +4305,15 @@ public:
   }
 };
 
-extern "C" void _rados_read_op_exec(rados_read_op_t read_op,
-				    const char *cls,
-				    const char *method,
-				    const char *in_buf,
-				    size_t in_len,
-				    char **out_buf,
-				    size_t *out_len,
-				    int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_exec)(
+  rados_read_op_t read_op,
+  const char *cls,
+  const char *method,
+  const char *in_buf,
+  size_t in_len,
+  char **out_buf,
+  size_t *out_len,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_exec_enter, read_op, cls, method, in_buf, in_len, out_buf, out_len, prval);
   bufferlist inbl;
@@ -3690,15 +4325,16 @@ extern "C" void _rados_read_op_exec(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_exec);
 
-extern "C" void _rados_read_op_exec_user_buf(rados_read_op_t read_op,
-					     const char *cls,
-					     const char *method,
-					     const char *in_buf,
-					     size_t in_len,
-					     char *out_buf,
-					     size_t out_len,
-					     size_t *used_len,
-					     int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_exec_user_buf)(
+  rados_read_op_t read_op,
+  const char *cls,
+  const char *method,
+  const char *in_buf,
+  size_t in_len,
+  char *out_buf,
+  size_t out_len,
+  size_t *used_len,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_exec_user_buf_enter, read_op, cls, method, in_buf, in_len, out_buf, out_len, used_len, prval);
   C_bl_to_buf *ctx = new C_bl_to_buf(out_buf, out_len, used_len, prval);
@@ -3733,25 +4369,27 @@ public:
   }
 };
 
-extern "C" void _rados_read_op_getxattrs(rados_read_op_t read_op,
-					 rados_xattrs_iter_t *iter,
-					 int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_getxattrs)(
+  rados_read_op_t read_op,
+  rados_xattrs_iter_t *iter,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_getxattrs_enter, read_op, prval);
   librados::RadosXattrsIter *xattrs_iter = new librados::RadosXattrsIter;
   ((::ObjectOperation *)read_op)->getxattrs(&xattrs_iter->attrset, prval);
-  ((::ObjectOperation *)read_op)->add_handler(new C_XattrsIter(xattrs_iter));
+  ((::ObjectOperation *)read_op)->set_handler(new C_XattrsIter(xattrs_iter));
   *iter = xattrs_iter;
   tracepoint(librados, rados_read_op_getxattrs_exit, *iter);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_getxattrs);
 
-extern "C" void _rados_read_op_omap_get_vals(rados_read_op_t read_op,
-					     const char *start_after,
-					     const char *filter_prefix,
-					     uint64_t max_return,
-					     rados_omap_iter_t *iter,
-					     int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_vals)(
+  rados_read_op_t read_op,
+  const char *start_after,
+  const char *filter_prefix,
+  uint64_t max_return,
+  rados_omap_iter_t *iter,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_get_vals_enter, read_op, start_after, filter_prefix, max_return, prval);
   RadosOmapIter *omap_iter = new RadosOmapIter;
@@ -3764,19 +4402,20 @@ extern "C" void _rados_read_op_omap_get_vals(rados_read_op_t read_op,
     &omap_iter->values,
     nullptr,
     prval);
-  ((::ObjectOperation *)read_op)->add_handler(new C_OmapIter(omap_iter));
+  ((::ObjectOperation *)read_op)->set_handler(new C_OmapIter(omap_iter));
   *iter = omap_iter;
   tracepoint(librados, rados_read_op_omap_get_vals_exit, *iter);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_vals);
 
-extern "C" void _rados_read_op_omap_get_vals2(rados_read_op_t read_op,
-					      const char *start_after,
-					      const char *filter_prefix,
-					      uint64_t max_return,
-					      rados_omap_iter_t *iter,
-					      unsigned char *pmore,
-					      int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_vals2)(
+  rados_read_op_t read_op,
+  const char *start_after,
+  const char *filter_prefix,
+  uint64_t max_return,
+  rados_omap_iter_t *iter,
+  unsigned char *pmore,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_get_vals_enter, read_op, start_after, filter_prefix, max_return, prval);
   RadosOmapIter *omap_iter = new RadosOmapIter;
@@ -3789,7 +4428,7 @@ extern "C" void _rados_read_op_omap_get_vals2(rados_read_op_t read_op,
     &omap_iter->values,
     (bool*)pmore,
     prval);
-  ((::ObjectOperation *)read_op)->add_handler(new C_OmapIter(omap_iter));
+  ((::ObjectOperation *)read_op)->set_handler(new C_OmapIter(omap_iter));
   *iter = omap_iter;
   tracepoint(librados, rados_read_op_omap_get_vals_exit, *iter);
 }
@@ -3809,11 +4448,12 @@ struct C_OmapKeysIter : public Context {
   }
 };
 
-extern "C" void _rados_read_op_omap_get_keys(rados_read_op_t read_op,
-					     const char *start_after,
-					     uint64_t max_return,
-					     rados_omap_iter_t *iter,
-					     int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_keys)(
+  rados_read_op_t read_op,
+  const char *start_after,
+  uint64_t max_return,
+  rados_omap_iter_t *iter,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_get_keys_enter, read_op, start_after, max_return, prval);
   RadosOmapIter *omap_iter = new RadosOmapIter;
@@ -3821,18 +4461,19 @@ extern "C" void _rados_read_op_omap_get_keys(rados_read_op_t read_op,
   ((::ObjectOperation *)read_op)->omap_get_keys(
     start_after ? start_after : "",
     max_return, &ctx->keys, nullptr, prval);
-  ((::ObjectOperation *)read_op)->add_handler(ctx);
+  ((::ObjectOperation *)read_op)->set_handler(ctx);
   *iter = omap_iter;
   tracepoint(librados, rados_read_op_omap_get_keys_exit, *iter);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_keys);
 
-extern "C" void _rados_read_op_omap_get_keys2(rados_read_op_t read_op,
-					      const char *start_after,
-					      uint64_t max_return,
-					      rados_omap_iter_t *iter,
-					      unsigned char *pmore,
-					      int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_keys2)(
+  rados_read_op_t read_op,
+  const char *start_after,
+  uint64_t max_return,
+  rados_omap_iter_t *iter,
+  unsigned char *pmore,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_get_keys_enter, read_op, start_after, max_return, prval);
   RadosOmapIter *omap_iter = new RadosOmapIter;
@@ -3841,7 +4482,7 @@ extern "C" void _rados_read_op_omap_get_keys2(rados_read_op_t read_op,
     start_after ? start_after : "",
     max_return, &ctx->keys,
     (bool*)pmore, prval);
-  ((::ObjectOperation *)read_op)->add_handler(ctx);
+  ((::ObjectOperation *)read_op)->set_handler(ctx);
   *iter = omap_iter;
   tracepoint(librados, rados_read_op_omap_get_keys_exit, *iter);
 }
@@ -3856,15 +4497,16 @@ static void internal_rados_read_op_omap_get_vals_by_keys(rados_read_op_t read_op
   ((::ObjectOperation *)read_op)->omap_get_vals_by_keys(to_get,
                                                         &omap_iter->values,
                                                         prval);
-  ((::ObjectOperation *)read_op)->add_handler(new C_OmapIter(omap_iter));
+  ((::ObjectOperation *)read_op)->set_handler(new C_OmapIter(omap_iter));
   *iter = omap_iter;
 }
 
-extern "C" void _rados_read_op_omap_get_vals_by_keys(rados_read_op_t read_op,
-                                                     char const* const* keys,
-                                                     size_t keys_len,
-                                                     rados_omap_iter_t *iter,
-                                                     int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_vals_by_keys)(
+  rados_read_op_t read_op,
+  char const* const* keys,
+  size_t keys_len,
+  rados_omap_iter_t *iter,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_get_vals_by_keys_enter, read_op, keys, keys_len, iter, prval);
   std::set<std::string> to_get(keys, keys + keys_len);
@@ -3873,12 +4515,13 @@ extern "C" void _rados_read_op_omap_get_vals_by_keys(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_vals_by_keys);
 
-extern "C" void _rados_read_op_omap_get_vals_by_keys2(rados_read_op_t read_op,
-                                                      char const* const* keys,
-                                                      size_t num_keys,
-                                                      const size_t* key_lens,
-                                                      rados_omap_iter_t *iter,
-                                                      int *prval)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_read_op_omap_get_vals_by_keys2)(
+  rados_read_op_t read_op,
+  char const* const* keys,
+  size_t num_keys,
+  const size_t* key_lens,
+  rados_omap_iter_t *iter,
+  int *prval)
 {
   tracepoint(librados, rados_read_op_omap_get_vals_by_keys_enter, read_op, keys, num_keys, iter, prval);
   std::set<std::string> to_get;
@@ -3890,11 +4533,12 @@ extern "C" void _rados_read_op_omap_get_vals_by_keys2(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_omap_get_vals_by_keys2);
 
-extern "C" int _rados_omap_get_next2(rados_omap_iter_t iter,
-                                     char **key,
-                                     char **val,
-                                     size_t *key_len,
-                                     size_t *val_len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_omap_get_next2)(
+  rados_omap_iter_t iter,
+  char **key,
+  char **val,
+  size_t *key_len,
+  size_t *val_len)
 {
   tracepoint(librados, rados_omap_get_next_enter, iter);
   RadosOmapIter *it = static_cast<RadosOmapIter *>(iter);
@@ -3924,23 +4568,26 @@ extern "C" int _rados_omap_get_next2(rados_omap_iter_t iter,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_omap_get_next2);
 
-extern "C" int _rados_omap_get_next(rados_omap_iter_t iter,
-                                    char **key,
-                                    char **val,
-                                    size_t *len)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_omap_get_next)(
+  rados_omap_iter_t iter,
+  char **key,
+  char **val,
+  size_t *len)
 {
-  return _rados_omap_get_next2(iter, key, val, nullptr, len);
+  return LIBRADOS_C_API_DEFAULT_F(rados_omap_get_next2)(iter, key, val, nullptr, len);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_omap_get_next);
 
-extern "C" unsigned int _rados_omap_iter_size(rados_omap_iter_t iter)
+extern "C" unsigned int LIBRADOS_C_API_DEFAULT_F(rados_omap_iter_size)(
+  rados_omap_iter_t iter)
 {
   RadosOmapIter *it = static_cast<RadosOmapIter *>(iter);
   return it->values.size();
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_omap_iter_size);
 
-extern "C" void _rados_omap_get_end(rados_omap_iter_t iter)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_omap_get_end)(
+  rados_omap_iter_t iter)
 {
   tracepoint(librados, rados_omap_get_end_enter, iter);
   RadosOmapIter *it = static_cast<RadosOmapIter *>(iter);
@@ -3949,10 +4596,11 @@ extern "C" void _rados_omap_get_end(rados_omap_iter_t iter)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_omap_get_end);
 
-extern "C" int _rados_read_op_operate(rados_read_op_t read_op,
-				      rados_ioctx_t io,
-				      const char *oid,
-				      int flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_read_op_operate)(
+  rados_read_op_t read_op,
+  rados_ioctx_t io,
+  const char *oid,
+  int flags)
 {
   tracepoint(librados, rados_read_op_operate_enter, read_op, io, oid, flags);
   object_t obj(oid);
@@ -3964,11 +4612,12 @@ extern "C" int _rados_read_op_operate(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_operate);
 
-extern "C" int _rados_aio_read_op_operate(rados_read_op_t read_op,
-				  	  rados_ioctx_t io,
-					  rados_completion_t completion,
-					  const char *oid,
-					  int flags)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_read_op_operate)(
+  rados_read_op_t read_op,
+  rados_ioctx_t io,
+  rados_completion_t completion,
+  const char *oid,
+  int flags)
 {
   tracepoint(librados, rados_aio_read_op_operate_enter, read_op, io, completion, oid, flags);
   object_t obj(oid);
@@ -3981,7 +4630,9 @@ extern "C" int _rados_aio_read_op_operate(rados_read_op_t read_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_read_op_operate);
 
-extern "C" int _rados_cache_pin(rados_ioctx_t io, const char *o)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_cache_pin)(
+  rados_ioctx_t io,
+  const char *o)
 {
   tracepoint(librados, rados_cache_pin_enter, io, o);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -3992,7 +4643,9 @@ extern "C" int _rados_cache_pin(rados_ioctx_t io, const char *o)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_cache_pin);
 
-extern "C" int _rados_cache_unpin(rados_ioctx_t io, const char *o)
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_cache_unpin)(
+  rados_ioctx_t io,
+  const char *o)
 {
   tracepoint(librados, rados_cache_unpin_enter, io, o);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -4003,14 +4656,14 @@ extern "C" int _rados_cache_unpin(rados_ioctx_t io, const char *o)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_cache_unpin);
 
-extern "C" void _rados_object_list_slice(
-    rados_ioctx_t io,
-    const rados_object_list_cursor start,
-    const rados_object_list_cursor finish,
-    const size_t n,
-    const size_t m,
-    rados_object_list_cursor *split_start,
-    rados_object_list_cursor *split_finish)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_object_list_slice)(
+  rados_ioctx_t io,
+  const rados_object_list_cursor start,
+  const rados_object_list_cursor finish,
+  const size_t n,
+  const size_t m,
+  rados_object_list_cursor *split_start,
+  rados_object_list_cursor *split_finish)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1,5 +1,6 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
 /*
  * Ceph - scalable distributed file system
  *
@@ -21,6 +22,7 @@
 #include "common/common_init.h"
 #include "common/TracepointProvider.h"
 #include "common/hobject.h"
+#include "common/async/waiter.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/types.h"
@@ -28,6 +30,7 @@
 
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
+#include "librados/ObjectOperationImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/RadosXattrIter.h"
@@ -53,11 +56,13 @@
 #define tracepoint(...)
 #endif
 
-using std::string;
-using std::map;
-using std::set;
-using std::vector;
 using std::list;
+using std::map;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
 
 #define dout_subsys ceph_subsys_rados
 #undef dout_prefix
@@ -84,18 +89,6 @@ static TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tra
  * |          RadosClient                 |
  * +--------------------------------------+
  */
-
-namespace librados {
-
-struct ObjectOperationImpl {
-  ::ObjectOperation o;
-  real_time rt;
-  real_time *prt;
-
-  ObjectOperationImpl() : prt(NULL) {}
-};
-
-}
 
 size_t librados::ObjectOperation::size()
 {
@@ -155,10 +148,11 @@ void librados::ObjectOperation::assert_exists()
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
-  o->stat(NULL, (ceph::real_time*) NULL, NULL);
+  o->stat(nullptr, nullptr, nullptr);
 }
 
-void librados::ObjectOperation::exec(const char *cls, const char *method, bufferlist& inbl)
+void librados::ObjectOperation::exec(const char *cls, const char *method,
+				     bufferlist& inbl)
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
@@ -220,11 +214,13 @@ void librados::ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *p
 
 void librados::ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
 						std::map<uint64_t,uint64_t> *m,
-						bufferlist *data_bl, int *prval)
+						bufferlist *data_bl, int *prval,
+						uint64_t truncate_size,
+						uint32_t truncate_seq)
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
-  o->sparse_read(off, len, m, data_bl, prval);
+  o->sparse_read(off, len, m, data_bl, prval, truncate_size, truncate_seq);
 }
 
 void librados::ObjectReadOperation::checksum(rados_checksum_type_t type,
@@ -587,6 +583,20 @@ void librados::ObjectWriteOperation::copy_from(const std::string& src,
 	       src_ioctx.io_ctx_impl->oloc, src_version, 0, src_fadvise_flags);
 }
 
+void librados::ObjectWriteOperation::copy_from2(const std::string& src,
+					        const IoCtx& src_ioctx,
+					        uint64_t src_version,
+						uint32_t truncate_seq,
+						uint64_t truncate_size,
+					        uint32_t src_fadvise_flags)
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->copy_from2(object_t(src), src_ioctx.io_ctx_impl->snap_seq,
+	        src_ioctx.io_ctx_impl->oloc, src_version, 0,
+	        truncate_seq, truncate_size, src_fadvise_flags);
+}
+
 void librados::ObjectWriteOperation::undirty()
 {
   ceph_assert(impl);
@@ -615,6 +625,20 @@ void librados::ObjectReadOperation::cache_evict()
   o->cache_evict();
 }
 
+void librados::ObjectReadOperation::tier_flush()
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->tier_flush();
+}
+
+void librados::ObjectReadOperation::tier_evict()
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->tier_evict();
+}
+
 void librados::ObjectWriteOperation::set_redirect(const std::string& tgt_obj, 
 						  const IoCtx& tgt_ioctx,
 						  uint64_t tgt_version,
@@ -626,7 +650,7 @@ void librados::ObjectWriteOperation::set_redirect(const std::string& tgt_obj,
 			  tgt_ioctx.io_ctx_impl->oloc, tgt_version, flag);
 }
 
-void librados::ObjectWriteOperation::set_chunk(uint64_t src_offset,
+void librados::ObjectReadOperation::set_chunk(uint64_t src_offset,
 					       uint64_t src_length,
 					       const IoCtx& tgt_ioctx,
 					       string tgt_oid,
@@ -651,13 +675,6 @@ void librados::ObjectWriteOperation::unset_manifest()
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
   o->unset_manifest();
-}
-
-void librados::ObjectWriteOperation::tier_flush()
-{
-  ceph_assert(impl);
-  ::ObjectOperation *o = &impl->o;
-  o->tier_flush();
 }
 
 void librados::ObjectWriteOperation::tmap_update(const bufferlist& cmdbl)
@@ -827,22 +844,24 @@ void librados::NObjectIteratorImpl::set_filter(const bufferlist &bl)
 void librados::NObjectIteratorImpl::get_next()
 {
   const char *entry, *key, *nspace;
+  size_t entry_size, key_size, nspace_size;
   if (ctx->nlc->at_end())
     return;
-  int ret = rados_nobjects_list_next(ctx.get(), &entry, &key, &nspace);
+  int ret = rados_nobjects_list_next2(ctx.get(), &entry, &key, &nspace,
+                                      &entry_size, &key_size, &nspace_size);
   if (ret == -ENOENT) {
     return;
   }
   else if (ret) {
     throw std::system_error(-ret, std::system_category(),
-                            "rados_nobjects_list_next");
+                            "rados_nobjects_list_next2");
   }
 
   if (cur_obj.impl == NULL)
     cur_obj.impl = new ListObjectImpl();
-  cur_obj.impl->nspace = nspace;
-  cur_obj.impl->oid = entry;
-  cur_obj.impl->locator = key ? key : string();
+  cur_obj.impl->nspace = string{nspace, nspace_size};
+  cur_obj.impl->oid = string{entry, entry_size};
+  cur_obj.impl->locator = key ? string(key, key_size) : string();
 }
 
 uint32_t librados::NObjectIteratorImpl::get_pg_hash_position() const
@@ -960,122 +979,137 @@ uint32_t librados::NObjectIterator::get_pg_hash_position() const
 const librados::NObjectIterator librados::NObjectIterator::__EndObjectIterator(NULL);
 
 ///////////////////////////// PoolAsyncCompletion //////////////////////////////
-int librados::PoolAsyncCompletion::PoolAsyncCompletion::set_callback(void *cb_arg,
-								     rados_callback_t cb)
+librados::PoolAsyncCompletion::~PoolAsyncCompletion()
+{
+  auto c = reinterpret_cast<PoolAsyncCompletionImpl *>(pc);
+  c->release();
+}
+
+int librados::PoolAsyncCompletion::set_callback(void *cb_arg, rados_callback_t cb)
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->set_callback(cb_arg, cb);
 }
 
-int librados::PoolAsyncCompletion::PoolAsyncCompletion::wait()
+int librados::PoolAsyncCompletion::wait()
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->wait();
 }
 
-bool librados::PoolAsyncCompletion::PoolAsyncCompletion::is_complete()
+bool librados::PoolAsyncCompletion::is_complete()
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->is_complete();
 }
 
-int librados::PoolAsyncCompletion::PoolAsyncCompletion::get_return_value()
+int librados::PoolAsyncCompletion::get_return_value()
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->get_return_value();
 }
 
-void librados::PoolAsyncCompletion::PoolAsyncCompletion::release()
+void librados::PoolAsyncCompletion::release()
 {
-  PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
-  c->release();
   delete this;
 }
 
 ///////////////////////////// AioCompletion //////////////////////////////
-int librados::AioCompletion::AioCompletion::set_complete_callback(void *cb_arg, rados_callback_t cb)
+librados::AioCompletion::~AioCompletion()
+{
+  auto c = reinterpret_cast<AioCompletionImpl *>(pc);
+  c->release();
+}
+
+int librados::AioCompletion::set_complete_callback(void *cb_arg, rados_callback_t cb)
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->set_complete_callback(cb_arg, cb);
 }
 
-int librados::AioCompletion::AioCompletion::set_safe_callback(void *cb_arg, rados_callback_t cb)
+int librados::AioCompletion::set_safe_callback(void *cb_arg, rados_callback_t cb)
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->set_safe_callback(cb_arg, cb);
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_complete()
+int librados::AioCompletion::wait_for_complete()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_complete();
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_safe()
+int librados::AioCompletion::wait_for_safe()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
-  return c->wait_for_safe();
+  return c->wait_for_complete();
 }
 
-bool librados::AioCompletion::AioCompletion::is_complete()
+bool librados::AioCompletion::is_complete()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_complete();
 }
 
-bool librados::AioCompletion::AioCompletion::is_safe()
+bool librados::AioCompletion::is_safe()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_safe();
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_complete_and_cb()
+int librados::AioCompletion::wait_for_complete_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_complete_and_cb();
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_safe_and_cb()
+int librados::AioCompletion::wait_for_safe_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_safe_and_cb();
 }
 
-bool librados::AioCompletion::AioCompletion::is_complete_and_cb()
+bool librados::AioCompletion::is_complete_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_complete_and_cb();
 }
 
-bool librados::AioCompletion::AioCompletion::is_safe_and_cb()
+bool librados::AioCompletion::is_safe_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_safe_and_cb();
 }
 
-int librados::AioCompletion::AioCompletion::get_return_value()
+int librados::AioCompletion::get_return_value()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->get_return_value();
 }
 
-int librados::AioCompletion::AioCompletion::get_version()
+int librados::AioCompletion::get_version()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->get_version();
 }
 
-uint64_t librados::AioCompletion::AioCompletion::get_version64()
+uint64_t librados::AioCompletion::get_version64()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->get_version();
 }
 
-void librados::AioCompletion::AioCompletion::release()
+void librados::AioCompletion::release()
 {
-  AioCompletionImpl *c = (AioCompletionImpl *)pc;
-  c->release();
   delete this;
+}
+
+int librados::AioCompletion::cancel()
+{
+  if (!pc->io) {
+    return 0; // no operation was started
+  }
+  return pc->io->aio_cancel(pc);
 }
 
 ///////////////////////////// IoCtx //////////////////////////////
@@ -1168,9 +1202,9 @@ bool librados::IoCtx::pool_requires_alignment()
   return io_ctx_impl->client->pool_requires_alignment(get_id());
 }
 
-int librados::IoCtx::pool_requires_alignment2(bool *requires)
+int librados::IoCtx::pool_requires_alignment2(bool *req)
 {
-  return io_ctx_impl->client->pool_requires_alignment2(get_id(), requires);
+  return io_ctx_impl->client->pool_requires_alignment2(get_id(), req);
 }
 
 uint64_t librados::IoCtx::pool_required_alignment()
@@ -1491,12 +1525,36 @@ int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperat
   return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt);
 }
 
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperation *o, int flags)
+{
+  object_t obj(oid);
+  if (unlikely(!o->impl))
+    return -EINVAL;
+  return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt, translate_flags(flags));
+}
+
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperation *o, int flags, const jspan_context* otel_trace)
+{
+  object_t obj(oid);
+  if (unlikely(!o->impl))
+    return -EINVAL;
+  return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt, translate_flags(flags), otel_trace);
+}
+
 int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl)
 {
   object_t obj(oid);
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->operate_read(obj, &o->impl->o, pbl);
+}
+
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl, int flags)
+{
+  object_t obj(oid);
+  if (unlikely(!o->impl))
+    return -EINVAL;
+  return io_ctx_impl->operate_read(obj, &o->impl->o, pbl, translate_flags(flags));
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1506,8 +1564,9 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  io_ctx_impl->snapc, 0);
+				  io_ctx_impl->snapc, o->impl->prt, 0);
 }
+
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 ObjectWriteOperation *o, int flags)
 {
@@ -1515,8 +1574,19 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  io_ctx_impl->snapc,
-				  translate_flags(flags));
+				  io_ctx_impl->snapc, o->impl->prt,
+				  translate_flags(flags), nullptr);
+}
+
+int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+				 ObjectWriteOperation *o, int flags, const jspan_context* otel_trace)
+{
+  object_t obj(oid);
+  if (unlikely(!o->impl))
+    return -EINVAL;
+  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
+				  io_ctx_impl->snapc, o->impl->prt,
+				  translate_flags(flags), nullptr, otel_trace);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1532,7 +1602,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  snapc, 0);
+				  snapc, o->impl->prt, 0);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1549,7 +1619,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-          snapc, 0, trace_info);
+          snapc, o->impl->prt, 0, trace_info);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1565,7 +1635,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   for (size_t i = 0; i < snaps.size(); ++i)
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
-  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc,
+  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc, o->impl->prt,
                                   translate_flags(flags), trace_info);
 }
 
@@ -1716,7 +1786,7 @@ int librados::IoCtx::lock_exclusive(const std::string &oid, const std::string &n
   if (duration)
     dur.set_from_timeval(duration);
 
-  return rados::cls::lock::lock(this, oid, name, LOCK_EXCLUSIVE, cookie, "",
+  return rados::cls::lock::lock(this, oid, name, ClsLockType::EXCLUSIVE, cookie, "",
 		  		description, dur, flags);
 }
 
@@ -1729,7 +1799,7 @@ int librados::IoCtx::lock_shared(const std::string &oid, const std::string &name
   if (duration)
     dur.set_from_timeval(duration);
 
-  return rados::cls::lock::lock(this, oid, name, LOCK_SHARED, cookie, tag,
+  return rados::cls::lock::lock(this, oid, name, ClsLockType::SHARED, cookie, tag,
 		  		description, dur, flags);
 }
 
@@ -1797,7 +1867,7 @@ int librados::IoCtx::list_lockers(const std::string &oid, const std::string &nam
   if (tag)
     *tag = tmp_tag;
   if (exclusive) {
-    if (tmp_type == LOCK_EXCLUSIVE)
+    if (tmp_type == ClsLockType::EXCLUSIVE)
       *exclusive = 1;
     else
       *exclusive = 0;
@@ -1970,7 +2040,7 @@ struct AioGetxattrDataPP {
   AioGetxattrDataPP(librados::AioCompletionImpl *c, bufferlist *_bl) :
     bl(_bl), completion(c) {}
   bufferlist *bl;
-  struct librados::C_AioCompleteAndSafe completion;
+  struct librados::CB_AioCompleteAndSafe completion;
 };
 
 static void rados_aio_getxattr_completepp(rados_completion_t c, void *arg) {
@@ -1979,7 +2049,7 @@ static void rados_aio_getxattr_completepp(rados_completion_t c, void *arg) {
   if (rc >= 0) {
     rc = cdata->bl->length();
   }
-  cdata->completion.finish(rc);
+  cdata->completion(rc);
   delete cdata;
 }
 
@@ -2112,6 +2182,25 @@ int librados::IoCtx::aio_notify(const string& oid, AioCompletion *c,
                                  NULL);
 }
 
+void librados::IoCtx::decode_notify_response(bufferlist &bl,
+                                             std::vector<librados::notify_ack_t> *acks,
+                                             std::vector<librados::notify_timeout_t> *timeouts)
+{
+  map<pair<uint64_t,uint64_t>,bufferlist> acked;
+  set<pair<uint64_t,uint64_t>> missed;
+
+  auto iter = bl.cbegin();
+  decode(acked, iter);
+  decode(missed, iter);
+
+  for (auto &[who, payload] : acked) {
+    acks->emplace_back(librados::notify_ack_t{who.first, who.second, payload});
+  }
+  for (auto &[notifier_id, cookie] : missed) {
+    timeouts->emplace_back(librados::notify_timeout_t{notifier_id, cookie});
+  }
+}
+
 void librados::IoCtx::notify_ack(const std::string& o,
 				 uint64_t notify_id, uint64_t handle,
 				 bufferlist& bl)
@@ -2183,6 +2272,13 @@ void librados::IoCtx::locator_set_key(const string& key)
   io_ctx_impl->oloc.key = key;
 }
 
+void librados::IoCtx::locator_set_hash(int64_t hash)
+{
+  io_ctx_impl->oloc.hash = hash;
+  if (hash >= 0)
+    io_ctx_impl->oloc.key.clear();
+}
+
 void librados::IoCtx::set_namespace(const string& nspace)
 {
   io_ctx_impl->oloc.nspace = nspace;
@@ -2240,12 +2336,27 @@ librados::IoCtx::IoCtx(IoCtxImpl *io_ctx_impl_)
 
 void librados::IoCtx::set_osdmap_full_try()
 {
-  io_ctx_impl->objecter->set_osdmap_full_try();
+  io_ctx_impl->extra_op_flags |= CEPH_OSD_FLAG_FULL_TRY;
 }
 
 void librados::IoCtx::unset_osdmap_full_try()
 {
-  io_ctx_impl->objecter->unset_osdmap_full_try();
+  io_ctx_impl->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;
+}
+
+bool librados::IoCtx::get_pool_full_try()
+{
+  return (io_ctx_impl->extra_op_flags & CEPH_OSD_FLAG_FULL_TRY) != 0;
+}
+
+void librados::IoCtx::set_pool_full_try()
+{
+  io_ctx_impl->extra_op_flags |= CEPH_OSD_FLAG_FULL_TRY;
+}
+
+void librados::IoCtx::unset_pool_full_try()
+{
+  io_ctx_impl->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;
 }
 
 ///////////////////////////// Rados //////////////////////////////
@@ -2268,6 +2379,16 @@ librados::Rados::Rados(IoCtx &ioctx)
 librados::Rados::~Rados()
 {
   shutdown();
+}
+
+void librados::Rados::from_rados_t(rados_t cluster, Rados &rados) {
+  if (rados.client) {
+    rados.client->put();
+  }
+  rados.client = static_cast<RadosClient*>(cluster);
+  if (rados.client) {
+    rados.client->get();
+  }
 }
 
 int librados::Rados::init(const char * const id)
@@ -2501,36 +2622,30 @@ int64_t librados::Rados::pool_lookup(const char *name)
 
 int librados::Rados::pool_reverse_lookup(int64_t id, std::string *name)
 {
-  return client->pool_get_name(id, name);
+  return client->pool_get_name(id, name, true);
 }
 
-int librados::Rados::mon_command(string cmd, const bufferlist& inbl,
+int librados::Rados::mon_command(std::string&& cmd, bufferlist&& inbl,
 				 bufferlist *outbl, string *outs)
 {
-  vector<string> cmdvec;
-  cmdvec.push_back(cmd);
-  return client->mon_command(cmdvec, inbl, outbl, outs);
+  return client->mon_command({std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
-int librados::Rados::osd_command(int osdid, std::string cmd, const bufferlist& inbl,
+int librados::Rados::osd_command(int osdid, std::string&& cmd, bufferlist&& inbl,
                                  bufferlist *outbl, std::string *outs)
 {
-  vector<string> cmdvec;
-  cmdvec.push_back(cmd);
-  return client->osd_command(osdid, cmdvec, inbl, outbl, outs);
+  return client->osd_command(osdid, {std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
-int librados::Rados::mgr_command(std::string cmd, const bufferlist& inbl,
+int librados::Rados::mgr_command(std::string&& cmd, bufferlist&& inbl,
                                  bufferlist *outbl, std::string *outs)
 {
-  vector<string> cmdvec;
-  cmdvec.push_back(cmd);
-  return client->mgr_command(cmdvec, inbl, outbl, outs);
+  return client->mgr_command({std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
 
 
-int librados::Rados::pg_command(const char *pgstr, std::string cmd, const bufferlist& inbl,
+int librados::Rados::pg_command(const char *pgstr, std::string&& cmd, bufferlist&& inbl,
                                 bufferlist *outbl, std::string *outs)
 {
   vector<string> cmdvec;
@@ -2540,7 +2655,7 @@ int librados::Rados::pg_command(const char *pgstr, std::string cmd, const buffer
   if (!pgid.parse(pgstr))
     return -EINVAL;
 
-  return client->pg_command(pgid, cmdvec, inbl, outbl, outs);
+  return client->pg_command(pgid, std::move(cmdvec), std::move(inbl), outbl, outs);
 }
 
 int librados::Rados::ioctx_create(const char *name, IoCtx &io)
@@ -2565,9 +2680,9 @@ int librados::Rados::ioctx_create2(int64_t pool_id, IoCtx &io)
   return 0;
 }
 
-void librados::Rados::test_blacklist_self(bool set)
+void librados::Rados::test_blocklist_self(bool set)
 {
-  client->blacklist_self(set);
+  client->blocklist_self(set);
 }
 
 int librados::Rados::get_pool_stats(std::list<string>& v,
@@ -2633,9 +2748,16 @@ int librados::Rados::get_pool_stats(std::list<string>& v,
   return -EOPNOTSUPP;
 }
 
+// deprecated, use pool_is_in_selfmanaged_snaps_mode() instead
 bool librados::Rados::get_pool_is_selfmanaged_snaps_mode(const std::string& pool)
 {
-  return client->get_pool_is_selfmanaged_snaps_mode(pool);
+  // errors are ignored, prone to false negative results
+  return client->pool_is_in_selfmanaged_snaps_mode(pool) > 0;
+}
+
+int librados::Rados::pool_is_in_selfmanaged_snaps_mode(const std::string& pool)
+{
+  return client->pool_is_in_selfmanaged_snaps_mode(pool);
 }
 
 int librados::Rados::cluster_stat(cluster_stat_t& result)
@@ -2750,10 +2872,14 @@ int librados::Rados::wait_for_latest_osdmap()
   return client->wait_for_latest_osdmap();
 }
 
-int librados::Rados::blacklist_add(const std::string& client_address,
+int librados::Rados::blocklist_add(const std::string& client_address,
 				   uint32_t expire_seconds)
 {
-  return client->blacklist_add(client_address, expire_seconds);
+  return client->blocklist_add(client_address, expire_seconds);
+}
+
+std::string librados::Rados::get_addrs() const {
+  return client->get_addrs();
 }
 
 librados::PoolAsyncCompletion *librados::Rados::pool_async_create_completion()
@@ -2774,6 +2900,15 @@ librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
 {
   AioCompletionImpl *c;
   int r = rados_aio_create_completion(cb_arg, cb_complete, cb_safe, (void**)&c);
+  ceph_assert(r == 0);
+  return new AioCompletion(c);
+}
+
+librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
+								callback_t cb_complete)
+{
+  AioCompletionImpl *c;
+  int r = rados_aio_create_completion2(cb_arg, cb_complete, (void**)&c);
   ceph_assert(r == 0);
   return new AioCompletion(c);
 }
@@ -2973,29 +3108,27 @@ int librados::IoCtx::object_list(const ObjectCursor &start,
   ceph_assert(next != nullptr);
   result->clear();
 
-  C_SaferCond cond;
-  hobject_t next_hash;
-  std::list<librados::ListObjectImpl> obj_result;
-  io_ctx_impl->objecter->enumerate_objects(
+  ceph::async::waiter<boost::system::error_code,
+		      std::vector<librados::ListObjectImpl>,
+		      hobject_t>  w;
+  io_ctx_impl->objecter->enumerate_objects<librados::ListObjectImpl>(
       io_ctx_impl->poolid,
       io_ctx_impl->oloc.nspace,
       *((hobject_t*)start.c_cursor),
       *((hobject_t*)finish.c_cursor),
       result_item_count,
       filter,
-      &obj_result,
-      &next_hash,
-      &cond);
+      w);
 
-  int r = cond.wait();
-  if (r < 0) {
+  auto [ec, obj_result, next_hash] = w.wait();
+  if (ec) {
     next->set((rados_object_list_cursor)(new hobject_t(hobject_t::get_max())));
-    return r;
+    return ceph::from_error_code(ec);
   }
 
   next->set((rados_object_list_cursor)(new hobject_t(next_hash)));
 
-  for (std::list<librados::ListObjectImpl>::iterator i = obj_result.begin();
+  for (auto i = obj_result.begin();
        i != obj_result.end(); ++i) {
     ObjectItem oi;
     oi.oid = i->oid;
@@ -3070,4 +3203,9 @@ int librados::IoCtx::application_metadata_list(const std::string& app_name,
                                                std::map<std::string, std::string> *values)
 {
   return io_ctx_impl->application_metadata_list(app_name, values);
+}
+
+void librados::IoCtx::set_no_version_on_read(bool value)
+{
+  io_ctx_impl->set_no_version_on_read(value);
 }

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -1,5 +1,5 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*
+// vim: ts=8 sw=2 sts=2 expandtab
 
 #include <climits>
 
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include "gtest/gtest.h"
+#include "crimson_utils.h"
 
 using std::string;
 
@@ -27,7 +28,7 @@ TEST_F(LibRadosIo, SimpleWrite) {
 }
 
 TEST_F(LibRadosIo, TooBig) {
-  char buf[1];
+  char buf[1] = { 0 };
   ASSERT_EQ(-E2BIG, rados_write(ioctx, "A", buf, UINT_MAX, 0));
   ASSERT_EQ(-E2BIG, rados_append(ioctx, "A", buf, UINT_MAX));
   ASSERT_EQ(-E2BIG, rados_write_full(ioctx, "A", buf, UINT_MAX));
@@ -46,7 +47,8 @@ TEST_F(LibRadosIo, ReadTimeout) {
     ASSERT_EQ(0, rados_create(&cluster, "admin"));
     ASSERT_EQ(0, rados_conf_read_file(cluster, NULL));
     ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
-    ASSERT_EQ(0, rados_conf_set(cluster, "rados_osd_op_timeout", "0.00001")); // use any small value that will result in a timeout
+    ASSERT_EQ(0, rados_conf_set(cluster, "rados_osd_op_timeout", "1")); // use any small value that will result in a timeout
+    ASSERT_EQ(0, rados_conf_set(cluster, "ms_inject_internal_delays", "2")); // create a 2 second delay
     ASSERT_EQ(0, rados_connect(cluster));
     ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
     rados_ioctx_set_namespace(ioctx, nspace.c_str());
@@ -111,8 +113,8 @@ TEST_F(LibRadosIo, Checksum) {
 
   uint32_t expected_crc = ceph_crc32c(-1, reinterpret_cast<const uint8_t*>(buf),
                                       sizeof(buf));
-  uint32_t init_value = -1;
-  uint32_t crc[2];
+  ceph_le32 init_value(-1);
+  ceph_le32 crc[2];
   ASSERT_EQ(0, rados_checksum(ioctx, "foo", LIBRADOS_CHECKSUM_TYPE_CRC32C,
 			      reinterpret_cast<char*>(&init_value),
 			      sizeof(init_value), sizeof(buf), 0, 0,
@@ -160,6 +162,14 @@ TEST_F(LibRadosIo, AppendRoundTrip) {
   ASSERT_EQ((int)sizeof(buf3), rados_read(ioctx, "foo", buf3, sizeof(buf3), 0));
   ASSERT_EQ(0, memcmp(buf3, buf, sizeof(buf)));
   ASSERT_EQ(0, memcmp(buf3 + sizeof(buf), buf2, sizeof(buf2)));
+}
+
+TEST_F(LibRadosIo, ZeroLenZero) {
+  rados_write_op_t op = rados_create_write_op();
+  ASSERT_TRUE(op);
+  rados_write_op_zero(op, 0, 0);
+  ASSERT_EQ(0, rados_write_op_operate(op, ioctx, "foo", NULL, 0));
+  rados_release_write_op(op);
 }
 
 TEST_F(LibRadosIo, TruncTest) {
@@ -260,6 +270,7 @@ TEST_F(LibRadosIo, XattrIter) {
 }
 
 TEST_F(LibRadosIoEC, SimpleWrite) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -268,6 +279,7 @@ TEST_F(LibRadosIoEC, SimpleWrite) {
 }
 
 TEST_F(LibRadosIoEC, RoundTrip) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[128];
   memset(buf, 0xcc, sizeof(buf));
@@ -281,6 +293,7 @@ TEST_F(LibRadosIoEC, RoundTrip) {
 }
 
 TEST_F(LibRadosIoEC, OverlappingWriteRoundTrip) {
+  SKIP_IF_CRIMSON();
   int bsize = alignment;
   int dbsize = bsize * 2;
   char *buf = (char *)new char[dbsize];
@@ -303,6 +316,7 @@ TEST_F(LibRadosIoEC, OverlappingWriteRoundTrip) {
 }
 
 TEST_F(LibRadosIoEC, WriteFullRoundTrip) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[64];
   char buf3[128];
@@ -316,6 +330,7 @@ TEST_F(LibRadosIoEC, WriteFullRoundTrip) {
 }
 
 TEST_F(LibRadosIoEC, AppendRoundTrip) {
+  SKIP_IF_CRIMSON();
   char *buf = (char *)new char[alignment];
   char *buf2 = (char *)new char[alignment];
   char *buf3 = (char *)new char[alignment *2];
@@ -342,6 +357,7 @@ TEST_F(LibRadosIoEC, AppendRoundTrip) {
 }
 
 TEST_F(LibRadosIoEC, TruncTest) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[sizeof(buf)];
   memset(buf, 0xaa, sizeof(buf));
@@ -355,6 +371,7 @@ TEST_F(LibRadosIoEC, TruncTest) {
 }
 
 TEST_F(LibRadosIoEC, RemoveTest) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[sizeof(buf)];
   memset(buf, 0xaa, sizeof(buf));
@@ -365,6 +382,7 @@ TEST_F(LibRadosIoEC, RemoveTest) {
 }
 
 TEST_F(LibRadosIoEC, XattrsRoundTrip) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -378,6 +396,7 @@ TEST_F(LibRadosIoEC, XattrsRoundTrip) {
 }
 
 TEST_F(LibRadosIoEC, RmXattr) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -401,6 +420,7 @@ TEST_F(LibRadosIoEC, RmXattr) {
 }
 
 TEST_F(LibRadosIoEC, XattrIter) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -1,5 +1,5 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*
+// vim: ts=8 sw=2 sts=2 expandtab
 
 #include <climits>
 #include <errno.h>
@@ -12,6 +12,8 @@
 #include "include/scope_guard.h"
 #include "test/librados/test_cxx.h"
 #include "test/librados/testcase_cxx.h"
+
+#include "crimson_utils.h"
 
 using namespace librados;
 using std::string;
@@ -201,6 +203,52 @@ TEST_F(LibRadosIoPP, SparseReadOpPP) {
     ASSERT_EQ(0, rval);
     assert_eq_sparse(bl, extents, read_bl);
   }
+  {
+    bufferlist bl;
+    bl.append(buf, sizeof(buf) / 2);
+
+    std::map<uint64_t, uint64_t> extents;
+    bufferlist read_bl;
+    int rval = -1;
+    ObjectReadOperation op;
+    op.sparse_read(0, sizeof(buf), &extents, &read_bl, &rval, sizeof(buf) / 2, 1);
+    ASSERT_EQ(0, ioctx.operate("foo", &op, nullptr));
+    ASSERT_EQ(0, rval);
+    assert_eq_sparse(bl, extents, read_bl);
+  }
+}
+
+TEST_F(LibRadosIoPP, SparseReadExtentArrayOpPP) {
+  int buf_len = 32;
+  char buf[buf_len], zbuf[buf_len];
+  memset(buf, 0xcc, buf_len);
+  memset(zbuf, 0, buf_len);
+  bufferlist bl;
+  int i, len = 1024, skip = 5;
+  bl.append(buf, buf_len);
+  for (i = 0; i < len; i++) {
+    if (!(i % skip) || i == (len - 1)) {
+      ASSERT_EQ(0, ioctx.write("sparse-read", bl, bl.length(), i * buf_len));
+    }
+  }
+
+  bufferlist expect_bl;
+  for (i = 0; i < len; i++) {
+    if (!(i % skip) || i == (len - 1)) {
+      expect_bl.append(buf, buf_len);
+    } else {
+      expect_bl.append(zbuf, buf_len);
+    }
+  }
+
+  std::map<uint64_t, uint64_t> extents;
+  bufferlist read_bl;
+  int rval = -1;
+  ObjectReadOperation op;
+  op.sparse_read(0, len * buf_len, &extents, &read_bl, &rval);
+  ASSERT_EQ(0, ioctx.operate("sparse-read", &op, nullptr));
+  ASSERT_EQ(0, rval);
+  assert_eq_sparse(expect_bl, extents, read_bl);
 }
 
 TEST_F(LibRadosIoPP, RoundTripPP) {
@@ -447,7 +495,20 @@ TEST_F(LibRadosIoPP, XattrListPP) {
   }
 }
 
+TEST_F(LibRadosIoPP, CrcZeroWrite) {
+  char buf[128];
+  bufferlist bl;
+
+  ASSERT_EQ(0, ioctx.write("foo", bl, 0, 0));
+  ASSERT_EQ(0, ioctx.write("foo", bl, 0, sizeof(buf)));
+
+  ObjectReadOperation read;
+  read.read(0, bl.length(), NULL, NULL);
+  ASSERT_EQ(0, ioctx.operate("foo", &read, &bl));
+}
+
 TEST_F(LibRadosIoECPP, SimpleWritePP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
@@ -458,6 +519,7 @@ TEST_F(LibRadosIoECPP, SimpleWritePP) {
 }
 
 TEST_F(LibRadosIoECPP, ReadOpPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
@@ -604,6 +666,7 @@ TEST_F(LibRadosIoECPP, ReadOpPP) {
 }
 
 TEST_F(LibRadosIoECPP, SparseReadOpPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
@@ -623,6 +686,7 @@ TEST_F(LibRadosIoECPP, SparseReadOpPP) {
 }
 
 TEST_F(LibRadosIoECPP, RoundTripPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   Rados cluster;
   memset(buf, 0xcc, sizeof(buf));
@@ -636,6 +700,7 @@ TEST_F(LibRadosIoECPP, RoundTripPP) {
 
 TEST_F(LibRadosIoECPP, RoundTripPP2)
 {
+  SKIP_IF_CRIMSON();
   bufferlist bl;
   bl.append("ceph");
   ObjectWriteOperation write;
@@ -651,6 +716,7 @@ TEST_F(LibRadosIoECPP, RoundTripPP2)
 }
 
 TEST_F(LibRadosIoECPP, OverlappingWriteRoundTripPP) {
+  SKIP_IF_CRIMSON();
   int bsize = alignment;
   int dbsize = bsize * 2;
   char *buf = (char *)new char[dbsize];
@@ -675,6 +741,7 @@ TEST_F(LibRadosIoECPP, OverlappingWriteRoundTripPP) {
 }
 
 TEST_F(LibRadosIoECPP, WriteFullRoundTripPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char buf2[64];
   memset(buf, 0xcc, sizeof(buf));
@@ -692,6 +759,7 @@ TEST_F(LibRadosIoECPP, WriteFullRoundTripPP) {
 
 TEST_F(LibRadosIoECPP, WriteFullRoundTripPP2)
 {
+  SKIP_IF_CRIMSON();
   bufferlist bl;
   bl.append("ceph");
   ObjectWriteOperation write;
@@ -707,6 +775,7 @@ TEST_F(LibRadosIoECPP, WriteFullRoundTripPP2)
 }
 
 TEST_F(LibRadosIoECPP, AppendRoundTripPP) {
+  SKIP_IF_CRIMSON();
   char *buf = (char *)new char[alignment];
   char *buf2 = (char *)new char[alignment];
   auto cleanup = [&] {
@@ -731,6 +800,7 @@ TEST_F(LibRadosIoECPP, AppendRoundTripPP) {
 }
 
 TEST_F(LibRadosIoECPP, TruncTestPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xaa, sizeof(buf));
   bufferlist bl;
@@ -745,6 +815,7 @@ TEST_F(LibRadosIoECPP, TruncTestPP) {
 }
 
 TEST_F(LibRadosIoECPP, RemoveTestPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   memset(buf, 0xaa, sizeof(buf));
   bufferlist bl1;
@@ -756,6 +827,7 @@ TEST_F(LibRadosIoECPP, RemoveTestPP) {
 }
 
 TEST_F(LibRadosIoECPP, XattrsRoundTripPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -775,6 +847,7 @@ TEST_F(LibRadosIoECPP, XattrsRoundTripPP) {
 }
 
 TEST_F(LibRadosIoECPP, RmXattrPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -804,7 +877,24 @@ TEST_F(LibRadosIoECPP, RmXattrPP) {
   ASSERT_EQ(-ENOENT, ioctx.rmxattr("foo_rmxattr", attr2));
 }
 
+TEST_F(LibRadosIoECPP, CrcZeroWrite) {
+  SKIP_IF_CRIMSON();
+  set_allow_ec_overwrites();
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  ASSERT_EQ(0, ioctx.write("foo", bl, 0, 0));
+  ASSERT_EQ(0, ioctx.write("foo", bl, 0, sizeof(buf)));
+
+  ObjectReadOperation read;
+  read.read(0, bl.length(), NULL, NULL);
+  ASSERT_EQ(0, ioctx.operate("foo", &read, &bl));
+}
+
 TEST_F(LibRadosIoECPP, XattrListPP) {
+  SKIP_IF_CRIMSON();
   char buf[128];
   char attr1[] = "attr1";
   char attr1_buf[] = "foo bar baz";
@@ -897,6 +987,7 @@ TEST_F(LibRadosIoPP, CmpExtMismatchPP) {
 }
 
 TEST_F(LibRadosIoECPP, CmpExtPP) {
+  SKIP_IF_CRIMSON();
   bufferlist bl;
   bl.append("ceph");
   ObjectWriteOperation write1;
@@ -917,6 +1008,7 @@ TEST_F(LibRadosIoECPP, CmpExtPP) {
 }
 
 TEST_F(LibRadosIoECPP, CmpExtDNEPP) {
+  SKIP_IF_CRIMSON();
   bufferlist bl;
   bl.append(std::string(4, '\0'));
 
@@ -934,6 +1026,7 @@ TEST_F(LibRadosIoECPP, CmpExtDNEPP) {
 }
 
 TEST_F(LibRadosIoECPP, CmpExtMismatchPP) {
+  SKIP_IF_CRIMSON();
   bufferlist bl;
   bl.append("ceph");
   ObjectWriteOperation write1;


### PR DESCRIPTION
벡터 데이터 처리 가능하도록 클라이언트가 벡터, 메타데이터를 저장할 수 있는 public API(`vector_put`)를 새로 정의하고 구현했습니다

**주요 변경 사항**
- API 선언: `librados.h`, `librados.hpp`에 C/C++ `vector_put` 시그니처 및 타입(Float32), 거리 측정 방식(Cosine, Euclidean, Dot) enum 추가
- 로직 구현: `IoCtxImpl::vector_put`에 차원 및 길이 검증 로직 추가 및 `write_full`을 이용한 객체 저장 로직 구현
- 래퍼 연결: C/C++ API 요청을 `IoCtxImpl`로 넘겨주는 포워딩 로직 추가 (`librados_c.cc`, `librados_cxx.cc`)
- 테스트: `io.cc`, `io_cxx.cc`에 정상 처리 및 엣지 케이스(잘못된 차원, 빈 인덱스 등) 검증 테스트 추가

**내부 구현**
클라이언트의 요청은 래퍼(`librados_c.cc`, `librados_cxx.cc`)를 거치고 `IoCtxImpl::vector_put`에서 처리됨
처리되는 과정은
1. 파라미터 검증
   - 버킷명, 인덱스명, 키 값의 누락 여부 확인
   - Dimension 크기 검증 (0초과, `LIBRADOS_VECTOR_MAX_DIMENSION` 이하)
   - 지원하는 Distance Metric 및 Data Type인지 검사하고, 차원 수에 따른 예상 버퍼 길이(expected_len)와 실제 입력된 데이터 길이가 일치하는지 확인
2. 인코딩
   - `bufferlist`에 인코딩을 시작
   - 메타데이터 및 벡터 정보를 `[version] -> [bucket_name] -> [index_name] -> [key] -> [data_type] -> [distance_metric] -> [dimension] -> [vector_data] -> [metadata]`순서로 순차 인코딩

3. 저장
   - 인코딩된 `payload`는 내부 네이밍 규칙인 `.rados.vector/[bucket]/[index]/[key]` 포맷의 OID를 가진 RADOS 객체로 생성
   - 단일 객체에 전체 페이로드를 밀어 넣기 위해 `write_full`을 호출하여 저장완료


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug