### PR TITLE
librados, osd: add vector_put public API 

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -752,6 +752,11 @@ OpsExecuter::do_execute_op(OSDOp& osd_op)
       return backend.tmapget(os, osd_op, delta_stats);
     });
 
+  case CEPH_OSD_OP_PUT_VECTOR:
+    return do_write_op([this, &osd_op](auto& backend, auto& os, auto& txn) {
+      return backend.put_vector(os, osd_op, txn, *osd_op_params, delta_stats);
+    });
+
   // OMAP
   case CEPH_OSD_OP_OMAPGETKEYS:
     return do_read_op([this, &osd_op](auto& backend, const auto& os) {

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -2,14 +2,17 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "pg_backend.h"
+#include "include/rados/vector_ops.h"
 
 #include <charconv>
+#include <cstdio>
 #include <optional>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include "include/ceph_hash.h"
 #include "include/err.h" // for MAX_ERRNO
 #include "include/utime_fmt.h"
 #include <seastar/core/print.hh>
@@ -48,6 +51,65 @@ using std::string_view;
 using crimson::common::local_conf;
 
 namespace crimson::osd {
+
+static string vector_hex_u32(uint32_t value)
+{
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%08x", value);
+  return string(buf);
+}
+
+static string vector_entry_id(const ceph::rados::put_vector_request_t& req)
+{
+  string value;
+  value.reserve(req.bucket_name.length() + req.index_name.length() +
+                req.key.length() + 2);
+  value.append(req.bucket_name);
+  value.push_back('\0');
+  value.append(req.index_name);
+  value.push_back('\0');
+  value.append(req.key);
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+template <typename T>
+static void vector_omap_set(std::map<std::string, ceph::bufferlist> *omap,
+                            const string& key,
+                            const T& value)
+{
+  ceph::bufferlist bl;
+  encode(value, bl);
+  (*omap)[key] = bl;
+}
+
+static std::map<std::string, ceph::bufferlist> put_vector_omap(
+    const ceph::rados::put_vector_request_t& req,
+    const string& entry_id)
+{
+  const string prefix = "vector." + entry_id + ".";
+  std::map<std::string, ceph::bufferlist> omap;
+
+  vector_omap_set(&omap, "vector.entry." + entry_id, req.key);
+  vector_omap_set(&omap, prefix + "bucket_name", req.bucket_name);
+  vector_omap_set(&omap, prefix + "index_name", req.index_name);
+  vector_omap_set(&omap, prefix + "key", req.key);
+  vector_omap_set(&omap, prefix + "data_type", req.data_type);
+  vector_omap_set(&omap, prefix + "distance_metric", req.distance_metric);
+  vector_omap_set(&omap, prefix + "dimension", req.dimension);
+  vector_omap_set(&omap, prefix + "layout_version",
+                  ceph::rados::vector_layout_version);
+  vector_omap_set(&omap, prefix + "placement_algorithm",
+                  req.placement_algorithm);
+  vector_omap_set(&omap, prefix + "placement_key", req.placement_key);
+  vector_omap_set(&omap, prefix + "vector_hash", req.vector_hash);
+  omap[prefix + "data"] = req.vector_data;
+  if (req.metadata.length() > 0) {
+    omap[prefix + "metadata"] = req.metadata;
+  }
+
+  return omap;
+}
 
 std::unique_ptr<PGBackend>
 PGBackend::create(pg_t pgid,
@@ -1682,6 +1744,67 @@ PGBackend::omap_get_vals_by_keys(
       }),
       ll_read_errorator::pass_further{}
     );
+}
+
+PGBackend::interruptible_future<>
+PGBackend::put_vector(
+  ObjectState& os,
+  const OSDOp& osd_op,
+  ceph::os::Transaction& txn,
+  osd_op_params_t& osd_op_params,
+  object_stat_sum_t& delta_stats)
+{
+  ceph::rados::put_vector_request_t req;
+
+  try {
+    auto p = osd_op.indata.cbegin();
+    decode(req, p);
+    if (!p.end()) {
+      throw crimson::osd::invalid_argument{};
+    }
+  } catch (const ceph::buffer::error&) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  if (req.bucket_name.empty() ||
+      req.index_name.empty() ||
+      req.key.empty() ||
+      req.vector_hash.empty() ||
+      req.dimension == 0 ||
+      req.dimension > ceph::rados::vector_max_dimension) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  size_t element_size = 0;
+  int r = ceph::rados::vector_data_type_size(req.data_type, &element_size);
+  if (r < 0) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  if (!ceph::rados::vector_distance_metric_supported(req.distance_metric)) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  const size_t expected_len =
+    static_cast<size_t>(req.dimension) * element_size;
+
+  if (req.vector_data.length() != expected_len) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  const string entry_id = vector_entry_id(req);
+  std::map<std::string, ceph::bufferlist> omap =
+    put_vector_omap(req, entry_id);
+
+  OSDOp omap_op{CEPH_OSD_OP_OMAPSETVALS};
+  encode(omap, omap_op.indata);
+
+  return omap_set_vals(
+    os,
+    omap_op,
+    txn,
+    osd_op_params,
+    delta_stats);
 }
 
 PGBackend::interruptible_future<>

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -380,6 +380,12 @@ public:
     ceph::os::Transaction& trans,
     osd_op_params_t& osd_op_params,
     object_stat_sum_t& delta_stats);
+  interruptible_future<> put_vector(
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& txn,
+    osd_op_params_t& osd_op_params,
+    object_stat_sum_t& delta_stats);
   ll_read_ierrorator::future<ceph::bufferlist> omap_get_header(
     const crimson::os::CollectionRef& c,
     const ghobject_t& oid,

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -304,6 +304,9 @@ extern const char *ceph_osd_state_name(int s);
 	f(OMAPRMKEYRANGE, __CEPH_OSD_OP(WR, DATA, 44),	"omap-rm-key-range") \
 	f(OMAP_CMP,	__CEPH_OSD_OP(RD, DATA, 25),	"omap-cmp")	    \
 									    \
+	/* vector */							    \
+	f(PUT_VECTOR,	__CEPH_OSD_OP(WR, DATA, 46),	"put-vector")	    \
+									    \
 	/* tiering */							    \
 	f(COPY_FROM,	__CEPH_OSD_OP(WR, DATA, 26),	"copy-from")	    \
 	f(COPY_FROM2,	__CEPH_OSD_OP(WR, DATA, 45),	"copy-from2")	    \

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -53,6 +53,18 @@ extern "C" {
 #define LIBRADOS_SUPPORTS_GETADDRS 1
 #define LIBRADOS_SUPPORTS_APP_METADATA 1
 
+#define LIBRADOS_VECTOR_MAX_DIMENSION 4096
+
+typedef enum {
+  LIBRADOS_VECTOR_DATA_TYPE_FLOAT32 = 1,
+} rados_vector_data_type_t;
+
+typedef enum {
+  LIBRADOS_VECTOR_DISTANCE_METRIC_EUCLIDEAN = 1,
+  LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE = 2,
+  LIBRADOS_VECTOR_DISTANCE_METRIC_DOT = 3,
+} rados_vector_distance_metric_t;
+
 /* RADOS lock flags
  * They are also defined in cls_lock_types.h. Keep them in sync!
  */
@@ -1517,6 +1529,32 @@ CEPH_RADOS_API uint64_t rados_get_last_version(rados_ioctx_t io);
  */
 CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
                                const char *buf, size_t len, uint64_t off);
+
+/**
+ * Store one vector entry in a vector bucket/index.
+ *
+ * Metadata is optional and may contain an application-defined related object
+ * id or serialized metadata document.
+ *
+ * @param io the io context in which the vector PUT will occur
+ * @param vector_bucket_name vector bucket name
+ * @param index_name vector index name
+ * @param key vector key
+ * @param data_type vector element data type
+ * @param distance_metric distance metric configured for this vector
+ * @param dimension number of vector dimensions
+ * @param vector_data vector data bytes
+ * @param vector_data_len length of vector_data, in bytes
+ * @param metadata optional metadata bytes
+ * @param metadata_len length of metadata, in bytes
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_put_vector(
+    rados_ioctx_t io, const char *vector_bucket_name, const char *index_name,
+    const char *key, rados_vector_data_type_t data_type,
+    rados_vector_distance_metric_t distance_metric, uint32_t dimension,
+    const void *vector_data, size_t vector_data_len, const char *metadata,
+    size_t metadata_len);
 
 /**
  * Write *len* bytes from *buf* into the *oid* object. The value of

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -910,6 +910,18 @@ inline namespace v14_2_0 {
      */
     int write(const std::string& oid, bufferlist& bl, size_t len, uint64_t off);
     /**
+     * store one vector entry in a vector bucket/index
+     */
+    int put_vector(const std::string& vector_bucket_name,
+		   const std::string& index_name,
+		   const std::string& key,
+		   rados_vector_data_type_t data_type,
+		   rados_vector_distance_metric_t distance_metric,
+		   uint32_t dimension,
+		   const void *vector_data,
+		   size_t vector_data_len,
+		   const bufferlist& metadata);
+    /**
      * append bytes to an object
      *
      * NOTE: this call steals the contents of @param bl.
@@ -1699,4 +1711,3 @@ inline namespace v14_2_0 {
 } // namespace librados
 
 #endif
-

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_RADOS_VECTOR_OPS_H
+#define CEPH_RADOS_VECTOR_OPS_H
+
+#include <cstddef>
+#include <cstdint>
+#include <errno.h>
+#include <string>
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+
+namespace ceph {
+namespace rados {
+
+inline constexpr uint32_t vector_layout_version = 1;
+inline constexpr uint32_t vector_max_dimension = 4096;
+
+inline constexpr uint32_t vector_data_type_float32 = 1;
+
+inline constexpr uint32_t vector_distance_metric_euclidean = 1;
+inline constexpr uint32_t vector_distance_metric_cosine = 2;
+inline constexpr uint32_t vector_distance_metric_dot = 3;
+
+inline int vector_data_type_size(uint32_t data_type, size_t *size)
+{
+  switch (data_type) {
+  case vector_data_type_float32:
+    *size = sizeof(float);
+    return 0;
+  default:
+    return -EOPNOTSUPP;
+  }
+}
+
+inline bool vector_distance_metric_supported(uint32_t distance_metric)
+{
+  switch (distance_metric) {
+  case vector_distance_metric_euclidean:
+  case vector_distance_metric_cosine:
+  case vector_distance_metric_dot:
+    return true;
+  default:
+    return false;
+  }
+}
+
+struct put_vector_request_t {
+  std::string bucket_name;
+  std::string index_name;
+  std::string key;
+  uint32_t data_type = 0;
+  uint32_t distance_metric = 0;
+  uint32_t dimension = 0;
+  ceph::bufferlist vector_data;
+  ceph::bufferlist metadata;
+  std::string placement_algorithm;
+  std::string placement_key;
+  std::string vector_hash;
+
+  void encode(ceph::bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(bucket_name, bl);
+    encode(index_name, bl);
+    encode(key, bl);
+    encode(data_type, bl);
+    encode(distance_metric, bl);
+    encode(dimension, bl);
+    encode(vector_data, bl);
+    encode(metadata, bl);
+    encode(placement_algorithm, bl);
+    encode(placement_key, bl);
+    encode(vector_hash, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(bucket_name, p);
+    decode(index_name, p);
+    decode(key, p);
+    decode(data_type, p);
+    decode(distance_metric, p);
+    decode(dimension, p);
+    decode(vector_data, p);
+    decode(metadata, p);
+    decode(placement_algorithm, p);
+    decode(placement_key, p);
+    decode(vector_hash, p);
+    DECODE_FINISH(p);
+  }
+};
+
+} // namespace rados
+} // namespace ceph
+
+WRITE_CLASS_ENCODER(ceph::rados::put_vector_request_t)
+
+#endif

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -22,6 +22,9 @@
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "include/ceph_assert.h"
+#include "include/ceph_hash.h"
+#include "include/encoding.h"
+#include "include/rados/vector_ops.h"
 #include "common/valgrind.h"
 #include "common/EventTrace.h"
 
@@ -236,6 +239,63 @@ struct C_aio_selfmanaged_snap_create_Complete : public C_aio_selfmanaged_snap_op
 
 } // anonymous namespace
 } // namespace librados
+
+namespace {
+
+static constexpr const char *vector_placement_algorithm = "hash-v0";
+
+static_assert(LIBRADOS_VECTOR_MAX_DIMENSION ==
+              ceph::rados::vector_max_dimension);
+static_assert(LIBRADOS_VECTOR_DATA_TYPE_FLOAT32 ==
+              ceph::rados::vector_data_type_float32);
+static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_EUCLIDEAN ==
+              ceph::rados::vector_distance_metric_euclidean);
+static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE ==
+              ceph::rados::vector_distance_metric_cosine);
+static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_DOT ==
+              ceph::rados::vector_distance_metric_dot);
+
+std::string vector_hex_u32(uint32_t value)
+{
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%08x", value);
+  return std::string(buf);
+}
+
+std::string vector_hash_string(const std::string& value)
+{
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+struct vector_placement_result {
+  object_t oid;
+  std::string placement_key;
+  std::string vector_hash;
+};
+
+vector_placement_result vector_compute_hash_placement(
+    const std::string& vector_bucket_name,
+    const std::string& index_name,
+    const std::string& key,
+    const bufferlist& vector_data)
+{
+  (void)key;
+  // Provisional vector-derived placement. The final LSH/hybrid policy should
+  // replace this helper without changing the public API or storage op shape.
+  const std::string vector_hash =
+    vector_hex_u32(vector_data.crc32c(static_cast<uint32_t>(-1)));
+  const std::string placement_key = vector_hash.substr(0, 4);
+  const std::string oid =
+    ".rados.vector/v1/" + std::string(vector_placement_algorithm) + "/" +
+    vector_hash_string(vector_bucket_name) + "/" +
+    vector_hash_string(index_name) + "/" +
+    placement_key;
+
+  return {object_t(oid), placement_key, vector_hash};
+}
+
+} // anonymous namespace
 
 librados::IoCtxImpl::IoCtxImpl() = default;
 
@@ -605,6 +665,68 @@ int librados::IoCtxImpl::write(const object_t& oid, bufferlist& bl,
   mybl.substr_of(bl, 0, len);
   op.write(off, mybl);
   return operate(oid, &op, NULL);
+}
+
+int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
+				    const std::string& index_name,
+				    const std::string& key,
+				    rados_vector_data_type_t data_type,
+				    rados_vector_distance_metric_t distance_metric,
+				    uint32_t dimension,
+				    const bufferlist& vector_data,
+				    const bufferlist& metadata)
+{
+  if (vector_bucket_name.empty() || index_name.empty() || key.empty()) {
+    return -EINVAL;
+  }
+
+  if (dimension == 0 || dimension > LIBRADOS_VECTOR_MAX_DIMENSION) {
+    return -EINVAL;
+  }
+
+  size_t element_size = 0;
+  const uint32_t encoded_data_type = static_cast<uint32_t>(data_type);
+  int r = ceph::rados::vector_data_type_size(encoded_data_type, &element_size);
+  if (r < 0) {
+    return r;
+  }
+
+  const uint32_t encoded_distance_metric =
+    static_cast<uint32_t>(distance_metric);
+  if (!ceph::rados::vector_distance_metric_supported(
+        encoded_distance_metric)) {
+    return -EOPNOTSUPP;
+  }
+
+  const size_t expected_len = static_cast<size_t>(dimension) * element_size;
+  if (vector_data.length() != expected_len) {
+    return -EINVAL;
+  }
+
+  const auto placement = vector_compute_hash_placement(
+      vector_bucket_name, index_name, key, vector_data);
+
+  ::ObjectOperation op;
+  prepare_assert_ops(&op);
+
+  ceph::rados::put_vector_request_t req;
+  req.bucket_name = vector_bucket_name;
+  req.index_name = index_name;
+  req.key = key;
+  req.data_type = encoded_data_type;
+  req.distance_metric = encoded_distance_metric;
+  req.dimension = dimension;
+  req.vector_data = vector_data;
+  req.metadata = metadata;
+  req.placement_algorithm = vector_placement_algorithm;
+  req.placement_key = placement.placement_key;
+  req.vector_hash = placement.vector_hash;
+
+  bufferlist payload;
+  encode(req, payload);
+  op.put_vector(payload);
+
+  return operate(placement.oid, &op, NULL);
 }
 
 int librados::IoCtxImpl::append(const object_t& oid, bufferlist& bl, size_t len)
@@ -2258,4 +2380,3 @@ int librados::IoCtxImpl::application_metadata_list(const std::string& app_name,
     });
   return r;
 }
-

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -130,6 +130,14 @@ struct librados::IoCtxImpl {
 
   int create(const object_t& oid, bool exclusive);
   int write(const object_t& oid, bufferlist& bl, size_t len, uint64_t off);
+  int put_vector(const std::string& vector_bucket_name,
+		 const std::string& index_name,
+		 const std::string& key,
+		 rados_vector_data_type_t data_type,
+		 rados_vector_distance_metric_t distance_metric,
+		 uint32_t dimension,
+		 const bufferlist& vector_data,
+		 const bufferlist& metadata);
   int append(const object_t& oid, bufferlist& bl, size_t len);
   int write_full(const object_t& oid, bufferlist& bl);
   int writesame(const object_t& oid, bufferlist& bl,

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -1317,6 +1317,38 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write)(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write);
 
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_put_vector)(
+  rados_ioctx_t io,
+  const char *vector_bucket_name,
+  const char *index_name,
+  const char *key,
+  rados_vector_data_type_t data_type,
+  rados_vector_distance_metric_t distance_metric,
+  uint32_t dimension,
+  const void *vector_data,
+  size_t vector_data_len,
+  const char *metadata,
+  size_t metadata_len)
+{
+  if (io == nullptr || vector_bucket_name == nullptr ||
+      index_name == nullptr || key == nullptr || vector_data == nullptr ||
+      (metadata_len > 0 && metadata == nullptr)) {
+    return -EINVAL;
+  }
+
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  bufferlist vector_bl;
+  vector_bl.append(static_cast<const char *>(vector_data), vector_data_len);
+  bufferlist metadata_bl;
+  if (metadata_len > 0) {
+    metadata_bl.append(metadata, metadata_len);
+  }
+  return ctx->put_vector(vector_bucket_name, index_name, key,
+			 data_type, distance_metric, dimension,
+			 vector_bl, metadata_bl);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_put_vector);
+
 extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_append)(
   rados_ioctx_t io,
   const char *o,

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1263,6 +1263,27 @@ int librados::IoCtx::write(const std::string& oid, bufferlist& bl, size_t len, u
   return io_ctx_impl->write(obj, bl, len, off);
 }
 
+int librados::IoCtx::put_vector(const std::string& vector_bucket_name,
+				const std::string& index_name,
+				const std::string& key,
+				rados_vector_data_type_t data_type,
+				rados_vector_distance_metric_t distance_metric,
+				uint32_t dimension,
+				const void *vector_data,
+				size_t vector_data_len,
+				const bufferlist& metadata)
+{
+  if (vector_data == nullptr) {
+    return -EINVAL;
+  }
+
+  bufferlist vector_bl;
+  vector_bl.append(static_cast<const char *>(vector_data), vector_data_len);
+  return io_ctx_impl->put_vector(vector_bucket_name, index_name, key,
+				 data_type, distance_metric, dimension,
+				 vector_bl, metadata);
+}
+
 int librados::IoCtx::append(const std::string& oid, bufferlist& bl, size_t len)
 {
   object_t obj(oid);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -18,6 +18,7 @@
 #include <errno.h>
 
 #include <charconv>
+#include <cstdio>
 #include <sstream>
 #include <utility>
 
@@ -30,12 +31,14 @@
 #include "common/CDC.h"
 #include "common/debug.h"
 #include "common/EventTrace.h"
+#include "include/ceph_hash.h"
 #include "common/ceph_crypto.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "common/scrub_types.h"
 #include "include/compat.h"
+#include "include/rados/vector_ops.h"
 #include "json_spirit/json_spirit_reader.h"
 #include "json_spirit/json_spirit_value.h"
 #include "messages/MCommandReply.h"
@@ -112,6 +115,65 @@ using ceph::encode_destructively;
 using namespace ceph::osd::scheduler;
 using TOPNSPC::common::cmd_getval;
 using TOPNSPC::common::cmd_getval_or;
+
+static string vector_hex_u32(uint32_t value)
+{
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%08x", value);
+  return string(buf);
+}
+
+static string vector_entry_id(const ceph::rados::put_vector_request_t& req)
+{
+  string value;
+  value.reserve(req.bucket_name.length() + req.index_name.length() +
+                req.key.length() + 2);
+  value.append(req.bucket_name);
+  value.push_back('\0');
+  value.append(req.index_name);
+  value.push_back('\0');
+  value.append(req.key);
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+template <typename T>
+static void vector_omap_set(map<string, bufferlist> *omap,
+                            const string& key,
+                            const T& value)
+{
+  bufferlist bl;
+  encode(value, bl);
+  (*omap)[key] = bl;
+}
+
+static map<string, bufferlist> put_vector_omap(
+    const ceph::rados::put_vector_request_t& req,
+    const string& entry_id)
+{
+  const string prefix = "vector." + entry_id + ".";
+  map<string, bufferlist> omap;
+
+  vector_omap_set(&omap, "vector.entry." + entry_id, req.key);
+  vector_omap_set(&omap, prefix + "bucket_name", req.bucket_name);
+  vector_omap_set(&omap, prefix + "index_name", req.index_name);
+  vector_omap_set(&omap, prefix + "key", req.key);
+  vector_omap_set(&omap, prefix + "data_type", req.data_type);
+  vector_omap_set(&omap, prefix + "distance_metric", req.distance_metric);
+  vector_omap_set(&omap, prefix + "dimension", req.dimension);
+  vector_omap_set(&omap, prefix + "layout_version",
+                  ceph::rados::vector_layout_version);
+  vector_omap_set(&omap, prefix + "placement_algorithm",
+                  req.placement_algorithm);
+  vector_omap_set(&omap, prefix + "placement_key", req.placement_key);
+  vector_omap_set(&omap, prefix + "vector_hash", req.vector_hash);
+  omap[prefix + "data"] = req.vector_data;
+  if (req.metadata.length() > 0) {
+    omap[prefix + "metadata"] = req.metadata;
+  }
+
+  return omap;
+}
 
 template <typename T>
 static ostream& _prefix(std::ostream *_dout, T *pg) {
@@ -6995,6 +7057,90 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
           std::max((uint64_t)op.extent.length, oi.size));
 	write_update_size_and_usage(ctx->delta_stats, oi, ctx->modified_ranges,
 	    0, op.extent.length, true);
+      }
+      break;
+
+    case CEPH_OSD_OP_PUT_VECTOR:
+      ++ctx->num_write;
+      result = 0;
+      {
+	if (!pool.info.supports_omap()) {
+	  result = -EOPNOTSUPP;
+	  break;
+	}
+	if (op.extent.length == 0 ||
+	    op.extent.length != osd_op.indata.length()) {
+	  result = -EINVAL;
+	  break;
+	}
+
+	ceph::rados::put_vector_request_t req;
+	try {
+	  auto reqp = osd_op.indata.cbegin();
+	  decode(req, reqp);
+	  if (!reqp.end()) {
+	    result = -EINVAL;
+	    break;
+	  }
+	} catch (const ceph::buffer::error&) {
+	  result = -EINVAL;
+	  break;
+	}
+
+	if (req.bucket_name.empty() || req.index_name.empty() ||
+	    req.key.empty()) {
+	  result = -EINVAL;
+	  break;
+	}
+	if (req.placement_algorithm.empty() || req.placement_key.empty() ||
+	    req.vector_hash.empty()) {
+	  result = -EINVAL;
+	  break;
+	}
+	if (req.dimension == 0 ||
+	    req.dimension > ceph::rados::vector_max_dimension) {
+	  result = -EINVAL;
+	  break;
+	}
+
+	size_t element_size = 0;
+	result = ceph::rados::vector_data_type_size(
+	  req.data_type, &element_size);
+	if (result < 0) {
+	  break;
+	}
+	if (!ceph::rados::vector_distance_metric_supported(
+	      req.distance_metric)) {
+	  result = -EOPNOTSUPP;
+	  break;
+	}
+
+	const size_t expected_len =
+	  static_cast<size_t>(req.dimension) * element_size;
+	if (req.vector_data.length() != expected_len) {
+	  result = -EINVAL;
+	  break;
+	}
+
+	maybe_create_new_object(ctx);
+
+	const string entry_id = vector_entry_id(req);
+	map<string, bufferlist> omap = put_vector_omap(req, entry_id);
+	bufferlist to_set_bl;
+	encode(omap, to_set_bl);
+	t->omap_setkeys(soid, to_set_bl);
+
+	if (req.metadata.length() == 0) {
+	  set<string> to_remove;
+	  to_remove.insert("vector." + entry_id + ".metadata");
+	  t->omap_rmkeys(soid, to_remove);
+	}
+
+	ctx->clean_regions.mark_omap_dirty();
+	ctx->delta_stats.num_wr++;
+	ctx->delta_stats.num_wr_kb += shift_round_up(to_set_bl.length(), 10);
+	obs.oi.set_flag(object_info_t::FLAG_OMAP);
+	obs.oi.clear_omap_digest();
       }
       break;
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -7449,6 +7449,7 @@ ostream& operator<<(ostream& out, const OSDOp& op)
     case CEPH_OSD_OP_SYNC_READ:
     case CEPH_OSD_OP_WRITE:
     case CEPH_OSD_OP_WRITEFULL:
+    case CEPH_OSD_OP_PUT_VECTOR:
     case CEPH_OSD_OP_ZERO:
     case CEPH_OSD_OP_APPEND:
     case CEPH_OSD_OP_MAPEXT:

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2467,6 +2467,7 @@ void Objecter::_send_op_account(Op *op)
     case CEPH_OSD_OP_OMAP_CMP: code = l_osdc_osdop_omap_rd; break;
 
     // OMAP write operations
+    case CEPH_OSD_OP_PUT_VECTOR:
     case CEPH_OSD_OP_OMAPSETVALS:
     case CEPH_OSD_OP_OMAPSETHEADER: code = l_osdc_osdop_omap_wr; break;
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -593,6 +593,12 @@ struct ObjectOperation {
   void write_full(ceph::buffer::list&& bl) {
     add_data(CEPH_OSD_OP_WRITEFULL, 0, bl.length(), bl);
   }
+  void put_vector(ceph::buffer::list& bl) {
+    add_data(CEPH_OSD_OP_PUT_VECTOR, 0, bl.length(), bl);
+  }
+  void put_vector(ceph::buffer::list&& bl) {
+    add_data(CEPH_OSD_OP_PUT_VECTOR, 0, bl.length(), bl);
+  }
   void writesame(uint64_t off, uint64_t write_len, ceph::buffer::list& bl) {
     add_writesame(CEPH_OSD_OP_WRITESAME, off, write_len, bl);
   }

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -2,8 +2,10 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include <climits>
+#include <cstdio>
 
 #include "include/rados/librados.h"
+#include "include/ceph_hash.h"
 #include "include/encoding.h"
 #include "include/err.h"
 #include "include/scope_guard.h"
@@ -19,12 +21,128 @@ using std::string;
 typedef RadosTest LibRadosIo;
 typedef RadosTestEC LibRadosIoEC;
 
+static string vector_hex_u32(uint32_t value)
+{
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%08x", value);
+  return string(buf);
+}
+
+static string vector_hash_string(const string& value)
+{
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+static string vector_test_oid(const string& bucket, const string& index,
+                              const string& key, const void *vector_data,
+                              size_t vector_data_len)
+{
+  (void)key;
+  bufferlist bl;
+  bl.append(static_cast<const char *>(vector_data), vector_data_len);
+  const string vector_hash =
+    vector_hex_u32(bl.crc32c(static_cast<uint32_t>(-1)));
+  const string placement_key = vector_hash.substr(0, 4);
+  return ".rados.vector/v1/hash-v0/" + vector_hash_string(bucket) + "/" +
+    vector_hash_string(index) + "/" + placement_key;
+}
+
+static string vector_entry_id(const string& bucket, const string& index,
+                              const string& key)
+{
+  string value;
+  value.reserve(bucket.length() + index.length() + key.length() + 2);
+  value.append(bucket);
+  value.push_back('\0');
+  value.append(index);
+  value.push_back('\0');
+  value.append(key);
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
 TEST_F(LibRadosIo, SimpleWrite) {
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
   rados_ioctx_set_namespace(ioctx, "nspace");
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
+}
+
+TEST_F(LibRadosIo, PutVector) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  const char metadata[] = "related-object";
+
+  ASSERT_EQ(0, rados_put_vector(
+      ioctx, "bucket", "index", "vec-1",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata, sizeof(metadata)));
+
+  const string oid = vector_test_oid("bucket", "index", "vec-1",
+                                     vector, sizeof(vector));
+  const string entry_id = vector_entry_id("bucket", "index", "vec-1");
+  const string data_key = "vector." + entry_id + ".data";
+  const char *keys[] = {data_key.c_str()};
+  rados_omap_iter_t iter;
+  int prval = 0;
+  rados_read_op_t op = rados_create_read_op();
+  rados_read_op_omap_get_vals_by_keys(op, keys, 1, &iter, &prval);
+  ASSERT_EQ(0, rados_read_op_operate(op, ioctx, oid.c_str(), 0));
+  rados_release_read_op(op);
+  ASSERT_EQ(0, prval);
+  ASSERT_EQ(1u, rados_omap_iter_size(iter));
+  char *stored_key = nullptr;
+  char *stored_vector = nullptr;
+  size_t stored_vector_len = 0;
+  ASSERT_EQ(0, rados_omap_get_next(
+      iter, &stored_key, &stored_vector, &stored_vector_len));
+  ASSERT_STREQ(data_key.c_str(), stored_key);
+  ASSERT_EQ(sizeof(vector), stored_vector_len);
+  ASSERT_EQ(0, memcmp(stored_vector, vector, sizeof(vector)));
+  ASSERT_EQ(0, rados_omap_get_next(
+      iter, &stored_key, &stored_vector, &stored_vector_len));
+  ASSERT_EQ((char*)NULL, stored_key);
+  ASSERT_EQ((char*)NULL, stored_vector);
+  ASSERT_EQ(0u, stored_vector_len);
+  rados_omap_get_end(iter);
+
+  ASSERT_EQ(-EINVAL, rados_put_vector(
+      ioctx, "bucket", "index", "bad-dim",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      0, vector, sizeof(vector), metadata, sizeof(metadata)));
+
+  ASSERT_EQ(-EINVAL, rados_put_vector(
+      ioctx, "bucket", "index", "null-vector",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, nullptr, sizeof(vector), metadata, sizeof(metadata)));
+
+  ASSERT_EQ(-EINVAL, rados_put_vector(
+      ioctx, "bucket", "", "empty-index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata, sizeof(metadata)));
+
+  ASSERT_EQ(-EINVAL, rados_put_vector(
+      ioctx, "bucket", "index", "",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata, sizeof(metadata)));
+
+  ASSERT_EQ(-EOPNOTSUPP, rados_put_vector(
+      ioctx, "bucket", "index", "bad-type",
+      static_cast<rados_vector_data_type_t>(999),
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata, sizeof(metadata)));
+
+  ASSERT_EQ(-EOPNOTSUPP, rados_put_vector(
+      ioctx, "bucket", "index", "bad-metric",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      static_cast<rados_vector_distance_metric_t>(999),
+      4, vector, sizeof(vector), metadata, sizeof(metadata)));
 }
 
 TEST_F(LibRadosIo, TooBig) {

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -2,11 +2,13 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include <climits>
+#include <cstdio>
 #include <errno.h>
 
 #include "gtest/gtest.h"
 
 #include "include/rados/librados.hpp"
+#include "include/ceph_hash.h"
 #include "include/encoding.h"
 #include "include/err.h"
 #include "include/scope_guard.h"
@@ -20,6 +22,45 @@ using std::string;
 
 typedef RadosTestPP LibRadosIoPP;
 typedef RadosTestECPP LibRadosIoECPP;
+
+static string vector_hex_u32(uint32_t value)
+{
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%08x", value);
+  return string(buf);
+}
+
+static string vector_hash_string(const string& value)
+{
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+static string vector_test_oid(const string& bucket, const string& index,
+                              const string& key,
+                              const bufferlist& vector_data)
+{
+  (void)key;
+  const string vector_hash =
+    vector_hex_u32(vector_data.crc32c(static_cast<uint32_t>(-1)));
+  const string placement_key = vector_hash.substr(0, 4);
+  return ".rados.vector/v1/hash-v0/" + vector_hash_string(bucket) + "/" +
+    vector_hash_string(index) + "/" + placement_key;
+}
+
+static string vector_entry_id(const string& bucket, const string& index,
+                              const string& key)
+{
+  string value;
+  value.reserve(bucket.length() + index.length() + key.length() + 2);
+  value.append(bucket);
+  value.push_back('\0');
+  value.append(index);
+  value.push_back('\0');
+  value.append(key);
+  return vector_hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
 
 TEST_F(LibRadosIoPP, TooBigPP) {
   IoCtx ioctx;
@@ -38,6 +79,122 @@ TEST_F(LibRadosIoPP, SimpleWritePP) {
   ASSERT_EQ(0, ioctx.write("foo", bl, sizeof(buf), 0));
   ioctx.set_namespace("nspace");
   ASSERT_EQ(0, ioctx.write("foo", bl, sizeof(buf), 0));
+}
+
+TEST_F(LibRadosIoPP, PutVectorPP) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+  bufferlist metadata;
+  metadata.append("related-object", sizeof("related-object"));
+  bufferlist updated_metadata;
+  updated_metadata.append("updated-object", sizeof("updated-object"));
+
+  ASSERT_EQ(0, ioctx.put_vector(
+      "bucket", "index", "vec-pp",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+  ASSERT_EQ(0, ioctx.put_vector(
+      "bucket", "index", "vec-pp",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), updated_metadata));
+  ASSERT_EQ(0, ioctx.put_vector(
+      "bucket", "index", "vec-pp-2",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+
+  const string oid = vector_test_oid("bucket", "index", "vec-pp", vector_bl);
+  const string entry_id = vector_entry_id("bucket", "index", "vec-pp");
+  const string entry_id2 = vector_entry_id("bucket", "index", "vec-pp-2");
+  const string prefix = "vector." + entry_id + ".";
+  const string prefix2 = "vector." + entry_id2 + ".";
+  std::set<string> keys = {
+    "vector.entry." + entry_id,
+    "vector.entry." + entry_id2,
+    prefix + "data",
+    prefix + "dimension",
+    prefix + "key",
+    prefix + "metadata",
+    prefix + "vector_hash",
+    prefix2 + "key",
+  };
+  std::map<string, bufferlist> vals;
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys(oid, keys, &vals));
+  ASSERT_EQ(keys.size(), vals.size());
+
+  auto key_iter = vals[prefix + "key"].cbegin();
+  string stored_key;
+  decode(stored_key, key_iter);
+  ASSERT_EQ("vec-pp", stored_key);
+
+  auto entry_iter = vals["vector.entry." + entry_id].cbegin();
+  string indexed_key;
+  decode(indexed_key, entry_iter);
+  ASSERT_EQ("vec-pp", indexed_key);
+
+  auto key2_iter = vals[prefix2 + "key"].cbegin();
+  string stored_key2;
+  decode(stored_key2, key2_iter);
+  ASSERT_EQ("vec-pp-2", stored_key2);
+
+  auto dimension_iter = vals[prefix + "dimension"].cbegin();
+  uint32_t stored_dimension = 0;
+  decode(stored_dimension, dimension_iter);
+  ASSERT_EQ(4u, stored_dimension);
+
+  auto vector_hash_iter = vals[prefix + "vector_hash"].cbegin();
+  string stored_vector_hash;
+  decode(stored_vector_hash, vector_hash_iter);
+  ASSERT_EQ(vector_hex_u32(vector_bl.crc32c(static_cast<uint32_t>(-1))),
+            stored_vector_hash);
+
+  ASSERT_EQ(vector_bl.length(), vals[prefix + "data"].length());
+  ASSERT_EQ(0, memcmp(vector_bl.c_str(), vals[prefix + "data"].c_str(),
+                      vector_bl.length()));
+
+  ASSERT_EQ(updated_metadata.length(), vals[prefix + "metadata"].length());
+  ASSERT_EQ(0, memcmp(updated_metadata.c_str(),
+                      vals[prefix + "metadata"].c_str(),
+                      updated_metadata.length()));
+
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
+      "bucket", "index", "bad-dim",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      0, vector, sizeof(vector), metadata));
+
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
+      "bucket", "index", "null-vector",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, nullptr, sizeof(vector), metadata));
+
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
+      "bucket", "", "empty-index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
+      "bucket", "index", "",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+
+  ASSERT_EQ(-EOPNOTSUPP, ioctx.put_vector(
+      "bucket", "index", "bad-type",
+      static_cast<rados_vector_data_type_t>(999),
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+
+  ASSERT_EQ(-EOPNOTSUPP, ioctx.put_vector(
+      "bucket", "index", "bad-metric",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      static_cast<rados_vector_distance_metric_t>(999),
+      4, vector, sizeof(vector), metadata));
 }
 
 TEST_F(LibRadosIoPP, ReadOpPP) {


### PR DESCRIPTION
벡터 데이터 처리 가능하도록 클라이언트가 벡터, 메타데이터를 저장할 수 있는 public API(`vector_put`)를 새로 정의하고 구현했습니다

**주요 변경 사항**
- API 선언
`librados.h`, `librados.hpp`에 C/C++ `vector_put` 시그니처 및 타입(Float32), 거리 측정 방식(Cosine, Euclidean, Dot) enum 추가
- 로직 구현
`IoCtxImpl::vector_put`에 차원 및 길이 검증 로직 추가 및 `write_full`을 이용한 객체 저장 로직 구현
- 래퍼 연결
C/C++ API 요청을 `IoCtxImpl`로 넘겨주는 포워딩 로직 추가 (`librados_c.cc`, `librados_cxx.cc`)
- 테스트
`io.cc`, `io_cxx.cc`에 정상 처리 및 엣지 케이스(잘못된 차원, 빈 인덱스 등) 검증 테스트 추가

**내부 구현**
클라이언트의 요청은 래퍼(`librados_c.cc`, `librados_cxx.cc`)를 거치고 `IoCtxImpl::vector_put`에서 처리됨
처리되는 과정은
1. 파라미터 검증
   - 버킷명, 인덱스명, 키 값의 누락 여부 확인
   - Dimension 크기 검증 (0초과, `LIBRADOS_VECTOR_MAX_DIMENSION` 이하)
   - 지원하는 Distance Metric 및 Data Type인지 검사하고, 차원 수에 따른 예상 버퍼 길이(expected_len)와 실제 입력된 데이터 길이가 일치하는지 확인
2. 인코딩
   - `bufferlist`에 인코딩을 시작
   - 메타데이터 및 벡터 정보를 `[version] -> [bucket_name] -> [index_name] -> [key] -> [data_type] -> [distance_metric] -> [dimension] -> [vector_data] -> [metadata]`순서로 순차 인코딩

3. 저장
   - 인코딩된 `payload`는 내부 네이밍 규칙인 `.rados.vector/[bucket]/[index]/[key]` 포맷의 OID를 가진 RADOS 객체로 생성
   - 단일 객체에 전체 페이로드를 밀어 넣기 위해 `write_full`을 호출하여 저장완료


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug