### PR TITLE
crimson/osd: connect put_vector to seastore and update key schema

### DIFF
--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -696,6 +696,7 @@ seastar::future<> CyanStore::Shard::do_transaction_no_callbacks(
       }
       break;
       case Transaction::OP_OMAP_SETKEYS:
+      case Transaction::OP_PUT_VECTOR:
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -70,10 +70,10 @@ template <> struct fmt::formatter<crimson::os::seastore::op_type_t>
       name = "put_vectors";
       break;
     case op_type_t::OMAP_GET_VECTORS:
-      name = "put_vectors";
+      name = "get_vectors";
       break;
     case op_type_t::OMAP_QUERY_VECTORS:
-      name = "put_vectors";
+      name = "query_vectors";
       break;
     case op_type_t::MAX:
       name = "unknown";

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -2166,6 +2166,7 @@ SeaStore::Shard::_do_transaction_step(
           op->op == Transaction::OP_SETATTRS ||
           op->op == Transaction::OP_RMATTR ||
           op->op == Transaction::OP_OMAP_SETKEYS ||
+          op->op == Transaction::OP_PUT_VECTOR ||
           op->op == Transaction::OP_OMAP_RMKEYS ||
           op->op == Transaction::OP_OMAP_RMKEYRANGE ||
           op->op == Transaction::OP_OMAP_SETHEADER) {

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -3143,7 +3143,7 @@ SeaStore::Shard::omaptree_query_vectors(
     co_return ret;
   }
 
-  // TODO: search neighbors 
+  // TODO: search neighbors
   ObjectStore::omap_iter_seek_t start_from = ObjectStore::omap_iter_seek_t::min_lower_bound();
   ceph::bufferlist result;
   BtreeOMapManager manager(*transaction_manager);
@@ -3453,13 +3453,11 @@ SeaStore::Shard::omaptree_put_vectors(
 	  root = new_root;
 	});
       }
-      // TODO
       for (auto &p : kvs) {
-	// This is optionally set by upper layer
-	assert(!p.first.stars_with("_CONTENT_"));
+	ceph_assert(!p.first.empty());
 #if 0
 	if (p.first.empty()) {
-	  p.first = "_CONTENT_" + 
+	  p.first = "_CONTENT_" +
 	    TOPNSPC::crypto::digest<TOPNSPC::crypto::SHA256>(
 	    p.second
 	    ).to_str();

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -159,6 +159,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
       case ceph::os::Transaction::OP_OMAP_CLEAR:
 	t_pg->omap_clear(i.get_oid(op->oid).hobj);
       case ceph::os::Transaction::OP_OMAP_SETKEYS:
+      case ceph::os::Transaction::OP_PUT_VECTOR:
 	{
 	std::map<std::string, ceph::bufferlist> aset;
 	i.decode_attrset(aset);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1796,15 +1796,20 @@ PGBackend::put_vector(
   std::map<std::string, ceph::bufferlist> omap =
     put_vector_omap(req, entry_id);
 
-  OSDOp omap_op{CEPH_OSD_OP_OMAPSETVALS};
-  encode(omap, omap_op.indata);
+  ceph::bufferlist encoded_omap;
+  encode(omap, encoded_omap);
 
-  return omap_set_vals(
-    os,
-    omap_op,
-    txn,
-    osd_op_params,
-    delta_stats);
+  maybe_create_new_object(os, txn, delta_stats);
+  txn.put_vector(coll->get_cid(), ghobject_t{os.oi.soid}, omap);
+  osd_op_params.clean_regions.mark_omap_dirty();
+  delta_stats.num_wr++;
+  delta_stats.num_wr_kb += shift_round_up(encoded_omap.length(), 10);
+  if (!os.oi.is_omap()) {
+    os.oi.set_flag(object_info_t::FLAG_OMAP);
+    delta_stats.num_objects_omap++;
+  }
+  os.oi.clear_omap_digest();
+  return seastar::now();
 }
 
 PGBackend::interruptible_future<>

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -61,6 +61,7 @@ static string vector_hex_u32(uint32_t value)
 
 static string vector_entry_id(const ceph::rados::put_vector_request_t& req)
 {
+  // entry_id is a compact hash of one logical bucket/index/user key binding.
   string value;
   value.reserve(req.bucket_name.length() + req.index_name.length() +
                 req.key.length() + 2);
@@ -87,25 +88,28 @@ static std::map<std::string, ceph::bufferlist> put_vector_omap(
     const ceph::rados::put_vector_request_t& req,
     const string& entry_id)
 {
-  const string prefix = "vector." + entry_id + ".";
+  // _CONTENT_<vector_hash> stores the raw vector bytes.
+  // _ENTRY_<entry_id>.* stores metadata for one logical vector entry.
+  const string content_key = "_CONTENT_" + req.vector_hash;
+  const string entry_prefix = "_ENTRY_" + entry_id + ".";
   std::map<std::string, ceph::bufferlist> omap;
 
-  vector_omap_set(&omap, "vector.entry." + entry_id, req.key);
-  vector_omap_set(&omap, prefix + "bucket_name", req.bucket_name);
-  vector_omap_set(&omap, prefix + "index_name", req.index_name);
-  vector_omap_set(&omap, prefix + "key", req.key);
-  vector_omap_set(&omap, prefix + "data_type", req.data_type);
-  vector_omap_set(&omap, prefix + "distance_metric", req.distance_metric);
-  vector_omap_set(&omap, prefix + "dimension", req.dimension);
-  vector_omap_set(&omap, prefix + "layout_version",
+  omap[content_key] = req.vector_data;
+  vector_omap_set(&omap, entry_prefix + "bucket_name", req.bucket_name);
+  vector_omap_set(&omap, entry_prefix + "index_name", req.index_name);
+  vector_omap_set(&omap, entry_prefix + "user_key", req.key);
+  vector_omap_set(&omap, entry_prefix + "content_key", content_key);
+  vector_omap_set(&omap, entry_prefix + "data_type", req.data_type);
+  vector_omap_set(&omap, entry_prefix + "distance_metric", req.distance_metric);
+  vector_omap_set(&omap, entry_prefix + "dimension", req.dimension);
+  vector_omap_set(&omap, entry_prefix + "layout_version",
                   ceph::rados::vector_layout_version);
-  vector_omap_set(&omap, prefix + "placement_algorithm",
+  vector_omap_set(&omap, entry_prefix + "placement_algorithm",
                   req.placement_algorithm);
-  vector_omap_set(&omap, prefix + "placement_key", req.placement_key);
-  vector_omap_set(&omap, prefix + "vector_hash", req.vector_hash);
-  omap[prefix + "data"] = req.vector_data;
+  vector_omap_set(&omap, entry_prefix + "placement_key", req.placement_key);
+  vector_omap_set(&omap, entry_prefix + "vector_hash", req.vector_hash);
   if (req.metadata.length() > 0) {
-    omap[prefix + "metadata"] = req.metadata;
+    omap[entry_prefix + "metadata"] = req.metadata;
   }
 
   return omap;

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -401,6 +401,24 @@ void Transaction::dump(ceph::Formatter *f)
       }
       break;
 
+    case Transaction::OP_PUT_VECTOR:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	map<string, bufferlist> aset;
+	i.decode_attrset(aset);
+	f->dump_string("op_name", "put_vector");
+	f->dump_stream("collection") << cid;
+	f->dump_stream("oid") << oid;
+	f->open_object_section("attr_lens");
+	for (map<string, bufferlist>::iterator p = aset.begin();
+	    p != aset.end(); ++p) {
+	  f->dump_unsigned(p->first.c_str(), p->second.length());
+	}
+	f->close_section();
+      }
+      break;
+
     case Transaction::OP_OMAP_RMKEYS:
       {
         coll_t cid = i.get_cid(op->cid);

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -430,6 +430,7 @@ public:
     case OP_COLL_REMOVE:
     case OP_OMAP_CLEAR:
     case OP_OMAP_SETKEYS:
+    case OP_PUT_VECTOR:
     case OP_OMAP_RMKEYS:
     case OP_OMAP_RMKEYRANGE:
     case OP_OMAP_SETHEADER:
@@ -1188,6 +1189,35 @@ public:
     ) {
     Op* _op = _get_next_op();
     _op->op = OP_OMAP_SETKEYS;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
+    data_misaligned_bl.append(attrset_bl);
+    data.ops = data.ops + 1;
+  }
+
+  /// Put vector-native keys on oid omap.
+  void put_vector(
+    const coll_t& cid,                           ///< [in] Collection containing oid
+    const ghobject_t &oid,                       ///< [in] Object to update
+    const std::map<std::string, ceph::buffer::list> &attrset ///< [in] Vector keys and values
+    ) {
+    using ceph::encode;
+    Op* _op = _get_next_op();
+    _op->op = OP_PUT_VECTOR;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
+    encode(attrset, data_misaligned_bl);
+    data.ops = data.ops + 1;
+  }
+
+  /// Put vector-native keys on oid omap (ceph::buffer::list variant).
+  void put_vector(
+    const coll_t &cid,                           ///< [in] Collection containing oid
+    const ghobject_t &oid,                       ///< [in] Object to update
+    const ceph::buffer::list &attrset_bl         ///< [in] Vector keys and values
+    ) {
+    Op* _op = _get_next_op();
+    _op->op = OP_PUT_VECTOR;
     _op->cid = _get_coll_id(cid);
     _op->oid = _get_object_id(oid);
     data_misaligned_bl.append(attrset_bl);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -125,6 +125,7 @@ static string vector_hex_u32(uint32_t value)
 
 static string vector_entry_id(const ceph::rados::put_vector_request_t& req)
 {
+  // entry_id is a compact hash of one logical bucket/index/user key binding.
   string value;
   value.reserve(req.bucket_name.length() + req.index_name.length() +
                 req.key.length() + 2);
@@ -151,25 +152,28 @@ static map<string, bufferlist> put_vector_omap(
     const ceph::rados::put_vector_request_t& req,
     const string& entry_id)
 {
-  const string prefix = "vector." + entry_id + ".";
+  // _CONTENT_<vector_hash> stores the raw vector bytes.
+  // _ENTRY_<entry_id>.* stores metadata for one logical vector entry.
+  const string content_key = "_CONTENT_" + req.vector_hash;
+  const string entry_prefix = "_ENTRY_" + entry_id + ".";
   map<string, bufferlist> omap;
 
-  vector_omap_set(&omap, "vector.entry." + entry_id, req.key);
-  vector_omap_set(&omap, prefix + "bucket_name", req.bucket_name);
-  vector_omap_set(&omap, prefix + "index_name", req.index_name);
-  vector_omap_set(&omap, prefix + "key", req.key);
-  vector_omap_set(&omap, prefix + "data_type", req.data_type);
-  vector_omap_set(&omap, prefix + "distance_metric", req.distance_metric);
-  vector_omap_set(&omap, prefix + "dimension", req.dimension);
-  vector_omap_set(&omap, prefix + "layout_version",
+  omap[content_key] = req.vector_data;
+  vector_omap_set(&omap, entry_prefix + "bucket_name", req.bucket_name);
+  vector_omap_set(&omap, entry_prefix + "index_name", req.index_name);
+  vector_omap_set(&omap, entry_prefix + "user_key", req.key);
+  vector_omap_set(&omap, entry_prefix + "content_key", content_key);
+  vector_omap_set(&omap, entry_prefix + "data_type", req.data_type);
+  vector_omap_set(&omap, entry_prefix + "distance_metric", req.distance_metric);
+  vector_omap_set(&omap, entry_prefix + "dimension", req.dimension);
+  vector_omap_set(&omap, entry_prefix + "layout_version",
                   ceph::rados::vector_layout_version);
-  vector_omap_set(&omap, prefix + "placement_algorithm",
+  vector_omap_set(&omap, entry_prefix + "placement_algorithm",
                   req.placement_algorithm);
-  vector_omap_set(&omap, prefix + "placement_key", req.placement_key);
-  vector_omap_set(&omap, prefix + "vector_hash", req.vector_hash);
-  omap[prefix + "data"] = req.vector_data;
+  vector_omap_set(&omap, entry_prefix + "placement_key", req.placement_key);
+  vector_omap_set(&omap, entry_prefix + "vector_hash", req.vector_hash);
   if (req.metadata.length() > 0) {
-    omap[prefix + "metadata"] = req.metadata;
+    omap[entry_prefix + "metadata"] = req.metadata;
   }
 
   return omap;
@@ -7132,7 +7136,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
 	if (req.metadata.length() == 0) {
 	  set<string> to_remove;
-	  to_remove.insert("vector." + entry_id + ".metadata");
+	  to_remove.insert("_ENTRY_" + entry_id + ".metadata");
 	  t->omap_rmkeys(soid, to_remove);
 	}
 

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -48,20 +48,6 @@ static string vector_test_oid(const string& bucket, const string& index,
     vector_hash_string(index) + "/" + placement_key;
 }
 
-static string vector_entry_id(const string& bucket, const string& index,
-                              const string& key)
-{
-  string value;
-  value.reserve(bucket.length() + index.length() + key.length() + 2);
-  value.append(bucket);
-  value.push_back('\0');
-  value.append(index);
-  value.push_back('\0');
-  value.append(key);
-  return vector_hex_u32(ceph_str_hash_rjenkins(
-      value.c_str(), static_cast<unsigned>(value.length())));
-}
-
 TEST_F(LibRadosIo, SimpleWrite) {
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
@@ -82,8 +68,11 @@ TEST_F(LibRadosIo, PutVector) {
 
   const string oid = vector_test_oid("bucket", "index", "vec-1",
                                      vector, sizeof(vector));
-  const string entry_id = vector_entry_id("bucket", "index", "vec-1");
-  const string data_key = "vector." + entry_id + ".data";
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+  const string vector_hash =
+    vector_hex_u32(vector_bl.crc32c(static_cast<uint32_t>(-1)));
+  const string data_key = "_CONTENT_" + vector_hash;
   const char *keys[] = {data_key.c_str()};
   rados_omap_iter_t iter;
   int prval = 0;

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -109,33 +109,40 @@ TEST_F(LibRadosIoPP, PutVectorPP) {
   const string oid = vector_test_oid("bucket", "index", "vec-pp", vector_bl);
   const string entry_id = vector_entry_id("bucket", "index", "vec-pp");
   const string entry_id2 = vector_entry_id("bucket", "index", "vec-pp-2");
-  const string prefix = "vector." + entry_id + ".";
-  const string prefix2 = "vector." + entry_id2 + ".";
+  const string vector_hash =
+    vector_hex_u32(vector_bl.crc32c(static_cast<uint32_t>(-1)));
+  // Vector omap layout example:
+  //   _CONTENT_<vector_hash> stores the raw vector payload.
+  //   _ENTRY_<entry_id>.* stores metadata for one logical vector entry,
+  //   e.g. _ENTRY_abcd1234.user_key and _ENTRY_abcd1234.content_key.
+  // The content_key field points back to _CONTENT_<vector_hash>.
+  const string content_key = "_CONTENT_" + vector_hash;
+  const string prefix = "_ENTRY_" + entry_id + ".";
+  const string prefix2 = "_ENTRY_" + entry_id2 + ".";
   std::set<string> keys = {
-    "vector.entry." + entry_id,
-    "vector.entry." + entry_id2,
-    prefix + "data",
+    content_key,
+    prefix + "content_key",
     prefix + "dimension",
-    prefix + "key",
     prefix + "metadata",
+    prefix + "user_key",
     prefix + "vector_hash",
-    prefix2 + "key",
+    prefix2 + "user_key",
   };
   std::map<string, bufferlist> vals;
   ASSERT_EQ(0, ioctx.omap_get_vals_by_keys(oid, keys, &vals));
   ASSERT_EQ(keys.size(), vals.size());
 
-  auto key_iter = vals[prefix + "key"].cbegin();
+  auto key_iter = vals[prefix + "user_key"].cbegin();
   string stored_key;
   decode(stored_key, key_iter);
   ASSERT_EQ("vec-pp", stored_key);
 
-  auto entry_iter = vals["vector.entry." + entry_id].cbegin();
-  string indexed_key;
-  decode(indexed_key, entry_iter);
-  ASSERT_EQ("vec-pp", indexed_key);
+  auto content_key_iter = vals[prefix + "content_key"].cbegin();
+  string stored_content_key;
+  decode(stored_content_key, content_key_iter);
+  ASSERT_EQ(content_key, stored_content_key);
 
-  auto key2_iter = vals[prefix2 + "key"].cbegin();
+  auto key2_iter = vals[prefix2 + "user_key"].cbegin();
   string stored_key2;
   decode(stored_key2, key2_iter);
   ASSERT_EQ("vec-pp-2", stored_key2);
@@ -148,11 +155,10 @@ TEST_F(LibRadosIoPP, PutVectorPP) {
   auto vector_hash_iter = vals[prefix + "vector_hash"].cbegin();
   string stored_vector_hash;
   decode(stored_vector_hash, vector_hash_iter);
-  ASSERT_EQ(vector_hex_u32(vector_bl.crc32c(static_cast<uint32_t>(-1))),
-            stored_vector_hash);
+  ASSERT_EQ(vector_hash, stored_vector_hash);
 
-  ASSERT_EQ(vector_bl.length(), vals[prefix + "data"].length());
-  ASSERT_EQ(0, memcmp(vector_bl.c_str(), vals[prefix + "data"].c_str(),
+  ASSERT_EQ(vector_bl.length(), vals[content_key].length());
+  ASSERT_EQ(0, memcmp(vector_bl.c_str(), vals[content_key].c_str(),
                       vector_bl.length()));
 
   ASSERT_EQ(updated_metadata.length(), vals[prefix + "metadata"].length());


### PR DESCRIPTION
* PGBackend::put_vector()가 txn.put_vector()를 직접 호출하도록 변경했습니다
--> ransaction::OP_PUT_VECTOR가 생성되고 SeaStore::_do_transaction_step()에서 omaptree_put_vectors() 분기를 타도록 연결함

**Key Schema**
**CONTENT.<vector_hash>**
-  실제 vector bytes 저장
- vector 데이터 자체는 vector hash 기준으로 관리

**ENTRY.<entry_id>.***
- 해당 vector entry의 bucket_name, index_name, user_key, vector_hash, data_type, distance_metric, dimension, metadata 등을 저장
- ENTRY는 logical object/user key와 실제 vector content를 연결하는 metadata 역할

--> 실제 벡터 데이터는 CONTENT.<vector_hash>에 두고 object / bucket / index / user_key 등 entry 정보는 ENTRY.<entry_id>.* 아래에 분리해서 저장

+ Transaction에 put_vector() helper 추가
+ OP_PUT_VECTOR가 transaction update/remap 과정에서 처리
+ Crimson PGBackend::put_vector()가 txn.put_vector() 호출
+ OP_PUT_VECTOR를 omaptree_put_vectors()로 연결
+ key schema 정리 (+테스트도 그렇게 수정)