### PR TITLE
librados: add query_vectors API skeleton and validation

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -65,6 +65,16 @@ typedef enum {
   LIBRADOS_VECTOR_DISTANCE_METRIC_DOT = 3,
 } rados_vector_distance_metric_t;
 
+typedef struct {
+  char *key;
+  float distance;
+} rados_query_vectors_result_entry_t;
+
+typedef struct {
+  rados_query_vectors_result_entry_t *entries;
+  size_t entries_len;
+} rados_query_vectors_result_t;
+
 /* RADOS lock flags
  * They are also defined in cls_lock_types.h. Keep them in sync!
  */
@@ -1555,6 +1565,41 @@ CEPH_RADOS_API int rados_put_vector(
     rados_vector_distance_metric_t distance_metric, uint32_t dimension,
     const void *vector_data, size_t vector_data_len, const char *metadata,
     size_t metadata_len);
+
+/**
+ * Query vectors from a vector bucket/index.
+ *
+ * This API currently validates the request and returns -EOPNOTSUPP until the
+ * vector query planner and backend execution paths are implemented.
+ *
+ * @param io the io context in which the vector query will occur
+ * @param vector_bucket_name vector bucket name
+ * @param index_name vector index name
+ * @param data_type query vector element data type
+ * @param distance_metric distance metric configured for this vector query
+ * @param dimension number of vector dimensions
+ * @param query_vector query vector data bytes
+ * @param query_vector_len length of query_vector, in bytes
+ * @param top_k number of nearest vectors requested
+ * @param return_distance whether result distances should be returned
+ * @param result query result output, released with
+ *        rados_query_vectors_result_release()
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_query_vectors(
+    rados_ioctx_t io, const char *vector_bucket_name, const char *index_name,
+    rados_vector_data_type_t data_type,
+    rados_vector_distance_metric_t distance_metric, uint32_t dimension,
+    const void *query_vector, size_t query_vector_len, uint32_t top_k,
+    int return_distance, rados_query_vectors_result_t *result);
+
+/**
+ * Release memory owned by a vector query result.
+ *
+ * @param result result returned by rados_query_vectors()
+ */
+CEPH_RADOS_API void rados_query_vectors_result_release(
+    rados_query_vectors_result_t *result);
 
 /**
  * Write *len* bytes from *buf* into the *oid* object. The value of

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -27,6 +27,11 @@ namespace librados {
 
 using ceph::bufferlist;
 
+struct query_vectors_result_entry {
+  std::string key;
+  float distance = 0;
+};
+
 struct AioCompletionImpl;
 struct IoCtxImpl;
 struct ListObjectImpl;
@@ -921,6 +926,19 @@ inline namespace v14_2_0 {
 		   const void *vector_data,
 		   size_t vector_data_len,
 		   const bufferlist& metadata);
+    /**
+     * query vectors in a vector bucket/index
+     */
+    int query_vectors(const std::string& vector_bucket_name,
+		      const std::string& index_name,
+		      rados_vector_data_type_t data_type,
+		      rados_vector_distance_metric_t distance_metric,
+		      uint32_t dimension,
+		      const void *query_vector,
+		      size_t query_vector_len,
+		      uint32_t top_k,
+		      bool return_distance,
+		      std::vector<query_vectors_result_entry> *results);
     /**
      * append bytes to an object
      *

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <errno.h>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "include/buffer.h"
 #include "include/encoding.h"
@@ -23,6 +25,9 @@ inline constexpr uint32_t vector_data_type_float32 = 1;
 inline constexpr uint32_t vector_distance_metric_euclidean = 1;
 inline constexpr uint32_t vector_distance_metric_cosine = 2;
 inline constexpr uint32_t vector_distance_metric_dot = 3;
+
+inline constexpr uint32_t vector_query_algorithm_flat = 1;
+inline constexpr uint32_t vector_query_algorithm_version_0 = 0;
 
 inline int vector_data_type_size(uint32_t data_type, size_t *size)
 {
@@ -95,9 +100,110 @@ struct put_vector_request_t {
   }
 };
 
+struct query_vectors_request_t {
+  std::string bucket_name;
+  std::string index_name;
+  uint32_t data_type = 0;
+  uint32_t distance_metric = 0;
+  uint32_t dimension = 0;
+  uint32_t top_k = 0;
+  bool return_distance = false;
+  ceph::bufferlist query_vector;
+  uint32_t algorithm_id = 0;
+  uint32_t algorithm_version = 0;
+  ceph::bufferlist algorithm_params;
+
+  void encode(ceph::bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(bucket_name, bl);
+    encode(index_name, bl);
+    encode(data_type, bl);
+    encode(distance_metric, bl);
+    encode(dimension, bl);
+    encode(top_k, bl);
+    encode(return_distance, bl);
+    encode(query_vector, bl);
+    encode(algorithm_id, bl);
+    encode(algorithm_version, bl);
+    encode(algorithm_params, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(bucket_name, p);
+    decode(index_name, p);
+    decode(data_type, p);
+    decode(distance_metric, p);
+    decode(dimension, p);
+    decode(top_k, p);
+    decode(return_distance, p);
+    decode(query_vector, p);
+    decode(algorithm_id, p);
+    decode(algorithm_version, p);
+    decode(algorithm_params, p);
+    DECODE_FINISH(p);
+  }
+};
+
+struct query_vectors_result_entry_t {
+  std::string key;
+  float distance = 0;
+
+  void encode(ceph::bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(key, bl);
+    encode(distance, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(key, p);
+    decode(distance, p);
+    DECODE_FINISH(p);
+  }
+};
+
+struct query_vectors_result_t {
+  std::vector<query_vectors_result_entry_t> entries;
+
+  void encode(ceph::bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(static_cast<uint32_t>(entries.size()), bl);
+    for (const auto& entry : entries) {
+      entry.encode(bl);
+    }
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    uint32_t entries_len = 0;
+    decode(entries_len, p);
+    entries.clear();
+    entries.reserve(entries_len);
+    for (uint32_t i = 0; i < entries_len; ++i) {
+      query_vectors_result_entry_t entry;
+      entry.decode(p);
+      entries.push_back(std::move(entry));
+    }
+    DECODE_FINISH(p);
+  }
+};
+
 } // namespace rados
 } // namespace ceph
 
 WRITE_CLASS_ENCODER(ceph::rados::put_vector_request_t)
+WRITE_CLASS_ENCODER(ceph::rados::query_vectors_request_t)
+WRITE_CLASS_ENCODER(ceph::rados::query_vectors_result_entry_t)
+WRITE_CLASS_ENCODER(ceph::rados::query_vectors_result_t)
 
 #endif

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -729,6 +729,72 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   return operate(placement.oid, &op, NULL);
 }
 
+int librados::IoCtxImpl::query_vectors(
+    const std::string& vector_bucket_name,
+    const std::string& index_name,
+    rados_vector_data_type_t data_type,
+    rados_vector_distance_metric_t distance_metric,
+    uint32_t dimension,
+    const bufferlist& query_vector,
+    uint32_t top_k,
+    bool return_distance,
+    std::vector<librados::query_vectors_result_entry> *results)
+{
+  if (results == nullptr) {
+    return -EINVAL;
+  }
+  results->clear();
+
+  if (vector_bucket_name.empty() || index_name.empty()) {
+    return -EINVAL;
+  }
+
+  if (dimension == 0 || dimension > LIBRADOS_VECTOR_MAX_DIMENSION) {
+    return -EINVAL;
+  }
+
+  if (top_k == 0) {
+    return -EINVAL;
+  }
+
+  size_t element_size = 0;
+  const uint32_t encoded_data_type = static_cast<uint32_t>(data_type);
+  int r = ceph::rados::vector_data_type_size(encoded_data_type, &element_size);
+  if (r < 0) {
+    return -EINVAL;
+  }
+
+  const uint32_t encoded_distance_metric =
+    static_cast<uint32_t>(distance_metric);
+  if (!ceph::rados::vector_distance_metric_supported(
+        encoded_distance_metric)) {
+    return -EINVAL;
+  }
+
+  const size_t expected_len = static_cast<size_t>(dimension) * element_size;
+  if (query_vector.length() != expected_len) {
+    return -EINVAL;
+  }
+
+  ceph::rados::query_vectors_request_t req;
+  req.bucket_name = vector_bucket_name;
+  req.index_name = index_name;
+  req.data_type = encoded_data_type;
+  req.distance_metric = encoded_distance_metric;
+  req.dimension = dimension;
+  req.top_k = top_k;
+  req.return_distance = return_distance;
+  req.query_vector = query_vector;
+  req.algorithm_id = ceph::rados::vector_query_algorithm_flat;
+  req.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+
+  bufferlist payload;
+  encode(req, payload);
+  // Query planning and backend execution are intentionally added in follow-up
+  // PRs. PR1 only validates the public API and prepares the request format.
+  return -EOPNOTSUPP;
+}
+
 int librados::IoCtxImpl::append(const object_t& oid, bufferlist& bl, size_t len)
 {
   if (len > UINT_MAX/2)

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -138,6 +138,15 @@ struct librados::IoCtxImpl {
 		 uint32_t dimension,
 		 const bufferlist& vector_data,
 		 const bufferlist& metadata);
+  int query_vectors(const std::string& vector_bucket_name,
+		    const std::string& index_name,
+		    rados_vector_data_type_t data_type,
+		    rados_vector_distance_metric_t distance_metric,
+		    uint32_t dimension,
+		    const bufferlist& query_vector,
+		    uint32_t top_k,
+		    bool return_distance,
+		    std::vector<librados::query_vectors_result_entry> *results);
   int append(const object_t& oid, bufferlist& bl, size_t len);
   int write_full(const object_t& oid, bufferlist& bl);
   int writesame(const object_t& oid, bufferlist& bl,

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -20,6 +20,7 @@
 #include "librados/ListObjectImpl.h"
 #include "librados/librados_util.h"
 
+#include <cstdlib>
 #include <string>
 #include <map>
 #include <set>
@@ -1348,6 +1349,56 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_put_vector)(
 			 vector_bl, metadata_bl);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_put_vector);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_query_vectors)(
+  rados_ioctx_t io,
+  const char *vector_bucket_name,
+  const char *index_name,
+  rados_vector_data_type_t data_type,
+  rados_vector_distance_metric_t distance_metric,
+  uint32_t dimension,
+  const void *query_vector,
+  size_t query_vector_len,
+  uint32_t top_k,
+  int return_distance,
+  rados_query_vectors_result_t *result)
+{
+  if (result != nullptr) {
+    result->entries = nullptr;
+    result->entries_len = 0;
+  }
+  if (io == nullptr || vector_bucket_name == nullptr ||
+      index_name == nullptr || query_vector == nullptr ||
+      result == nullptr) {
+    return -EINVAL;
+  }
+
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  bufferlist query_bl;
+  query_bl.append(static_cast<const char *>(query_vector), query_vector_len);
+  std::vector<librados::query_vectors_result_entry> entries;
+  return ctx->query_vectors(vector_bucket_name, index_name,
+			    data_type, distance_metric, dimension,
+			    query_bl, top_k, return_distance != 0,
+			    &entries);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_query_vectors);
+
+extern "C" void LIBRADOS_C_API_DEFAULT_F(
+    rados_query_vectors_result_release)(
+  rados_query_vectors_result_t *result)
+{
+  if (result == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < result->entries_len; ++i) {
+    free(result->entries[i].key);
+  }
+  free(result->entries);
+  result->entries = nullptr;
+  result->entries_len = 0;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_query_vectors_result_release);
 
 extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_append)(
   rados_ioctx_t io,

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1284,6 +1284,29 @@ int librados::IoCtx::put_vector(const std::string& vector_bucket_name,
 				 vector_bl, metadata);
 }
 
+int librados::IoCtx::query_vectors(
+    const std::string& vector_bucket_name,
+    const std::string& index_name,
+    rados_vector_data_type_t data_type,
+    rados_vector_distance_metric_t distance_metric,
+    uint32_t dimension,
+    const void *query_vector,
+    size_t query_vector_len,
+    uint32_t top_k,
+    bool return_distance,
+    std::vector<librados::query_vectors_result_entry> *results)
+{
+  if (query_vector == nullptr || results == nullptr) {
+    return -EINVAL;
+  }
+
+  bufferlist query_bl;
+  query_bl.append(static_cast<const char *>(query_vector), query_vector_len);
+  return io_ctx_impl->query_vectors(vector_bucket_name, index_name,
+				    data_type, distance_metric, dimension,
+				    query_bl, top_k, return_distance, results);
+}
+
 int librados::IoCtx::append(const std::string& oid, bufferlist& bl, size_t len)
 {
   object_t obj(oid);

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -145,6 +145,62 @@ TEST_F(LibRadosIo, PutVector) {
       4, vector, sizeof(vector), metadata, sizeof(metadata)));
 }
 
+TEST_F(LibRadosIo, QueryVectorsValidation) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  rados_query_vectors_result_t result = {};
+
+  ASSERT_EQ(-EOPNOTSUPP, rados_query_vectors(
+      ioctx, "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, 1, &result));
+  ASSERT_EQ(nullptr, result.entries);
+  ASSERT_EQ(0u, result.entries_len);
+  rados_query_vectors_result_release(&result);
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      0, vector, sizeof(vector), 10, 1, &result));
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 0, 1, &result));
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, 1, &result));
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "bucket", "",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, 1, &result));
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "bucket", "index",
+      static_cast<rados_vector_data_type_t>(999),
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, 1, &result));
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      static_cast<rados_vector_distance_metric_t>(999),
+      4, vector, sizeof(vector), 10, 1, &result));
+
+  ASSERT_EQ(-EINVAL, rados_query_vectors(
+      ioctx, "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector) - 1, 10, 1, &result));
+}
+
 TEST_F(LibRadosIo, TooBig) {
   char buf[1] = { 0 };
   ASSERT_EQ(-E2BIG, rados_write(ioctx, "A", buf, UINT_MAX, 0));

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -197,6 +197,60 @@ TEST_F(LibRadosIoPP, PutVectorPP) {
       4, vector, sizeof(vector), metadata));
 }
 
+TEST_F(LibRadosIoPP, QueryVectorsValidationPP) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  std::vector<query_vectors_result_entry> results;
+
+  ASSERT_EQ(-EOPNOTSUPP, ioctx.query_vectors(
+      "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, true, &results));
+  ASSERT_TRUE(results.empty());
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      0, vector, sizeof(vector), 10, true, &results));
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 0, true, &results));
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, true, &results));
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "bucket", "",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, true, &results));
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "bucket", "index",
+      static_cast<rados_vector_data_type_t>(999),
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, true, &results));
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      static_cast<rados_vector_distance_metric_t>(999),
+      4, vector, sizeof(vector), 10, true, &results));
+
+  ASSERT_EQ(-EINVAL, ioctx.query_vectors(
+      "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector) - 1, 10, true, &results));
+}
+
 TEST_F(LibRadosIoPP, ReadOpPP) {
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));


### PR DESCRIPTION
기존 vector API 참고해서 public API 형태, 내부 request/result encoding 구조를 잡은 pr입니다

**변경 사항**
**1. C/C++ public API 추가**
- rados_query_vectors() C API
- rados_query_vectors_result_release() C API
- IoCtx::query_vectors() C++ API

**2. query result type 추가** --> key + distance 중심으로 정의하였음, 추후 확장하겠습니다

**3. request/result encoding 구조 추가**
- query_vectors_request_t
- query_vectors_result_entry_t
- query_vectors_result_t

**5. validation 추가** --> IoCtxImpl::query_vectors()에서 기본 parameter validation 수행

**6. 테스트 추가** 


**후속 PR 계획**

- PR2: query planner + request routing (query vector를 기반으로 probe 대상 후보 생성하는 client-side planner 구조 추가)
- PR3: OSD / Crimson / SeaStore query execution (OSD backend execution path를 연결)