### PR TITLE
librados, osd: add query_vectors 

### DIFF
--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -34,11 +34,6 @@ struct omap_entry_t {
   uint32_t data_type = 0;
   uint32_t distance_metric = 0;
   uint32_t dimension = 0;
-  bool has_bucket_name = false;
-  bool has_index_name = false;
-  bool has_user_key = false;
-  bool has_content_key = false;
-  bool has_placement_key = false;
   bool has_data_type = false;
   bool has_distance_metric = false;
   bool has_dimension = false;
@@ -55,6 +50,92 @@ inline bool starts_with(std::string_view value, std::string_view prefix)
     value.substr(0, prefix.size()) == prefix;
 }
 
+inline bool is_lower_hex(char c)
+{
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+}
+
+inline bool is_lower_hex_string(std::string_view value, size_t len)
+{
+  if (value.size() != len) {
+    return false;
+  }
+  for (char c : value) {
+    if (!is_lower_hex(c)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool is_hash_v0_placement_key(std::string_view placement_key)
+{
+  return is_lower_hex_string(
+      placement_key, vector_hash_v0_placement_key_len);
+}
+
+inline bool is_hash_v0_vector_hash(std::string_view vector_hash)
+{
+  return is_lower_hex_string(vector_hash, vector_hash_v0_vector_hash_len);
+}
+
+inline int validate_vector_payload(uint32_t data_type,
+                                   uint32_t distance_metric,
+                                   uint32_t dimension,
+                                   const ceph::bufferlist& vector_data,
+                                   size_t *element_size = nullptr)
+{
+  if (dimension == 0 || dimension > vector_max_dimension) {
+    return -EINVAL;
+  }
+
+  size_t type_size = 0;
+  int r = vector_data_type_size(data_type, &type_size);
+  if (r < 0) {
+    return -EINVAL;
+  }
+  if (!vector_distance_metric_supported(distance_metric)) {
+    return -EINVAL;
+  }
+
+  const size_t expected_len = static_cast<size_t>(dimension) * type_size;
+  if (vector_data.length() != expected_len) {
+    return -EINVAL;
+  }
+
+  if (element_size != nullptr) {
+    *element_size = type_size;
+  }
+  return 0;
+}
+
+inline int validate_put_request(const put_vector_request_t& req,
+                                bool require_routed_fields,
+                                size_t *element_size = nullptr)
+{
+  if (req.bucket_name.empty() || req.index_name.empty() || req.key.empty()) {
+    return -EINVAL;
+  }
+
+  int r = validate_vector_payload(req.data_type, req.distance_metric,
+                                  req.dimension, req.vector_data,
+                                  element_size);
+  if (r < 0) {
+    return r;
+  }
+
+  if (!require_routed_fields) {
+    return 0;
+  }
+
+  if (req.placement_algorithm != vector_placement_algorithm_hash_v0 ||
+      !is_hash_v0_placement_key(req.placement_key) ||
+      !is_hash_v0_vector_hash(req.vector_hash)) {
+    return -EINVAL;
+  }
+  return 0;
+}
+
 inline ceph::bufferlist bufferlist_from_view(std::string_view value)
 {
   ceph::bufferlist bl;
@@ -66,11 +147,24 @@ template <typename T>
 inline bool decode_omap_value(const ceph::bufferlist& bl, T *out)
 {
   try {
+    T decoded;
     auto p = bl.cbegin();
-    decode(*out, p);
-    return p.end();
+    decode(decoded, p);
+    if (!p.end()) {
+      return false;
+    }
+    *out = decoded;
+    return true;
   } catch (const ceph::buffer::error&) {
     return false;
+  }
+}
+
+inline void decode_omap_string_value(const ceph::bufferlist& bl,
+                                     std::string *out)
+{
+  if (!decode_omap_value(bl, out)) {
+    out->clear();
   }
 }
 
@@ -97,15 +191,11 @@ inline bool parse_entry_key(std::string_view key,
 
 inline void consume_omap_key_value(std::string_view key,
                                    std::string_view value,
-                                   omap_scan_state_t *state)
+                                   omap_scan_state_t& state)
 {
-  if (state == nullptr) {
-    return;
-  }
-
   constexpr std::string_view content_prefix = "_CONTENT_";
   if (starts_with(key, content_prefix)) {
-    state->contents[std::string(key)] = bufferlist_from_view(value);
+    state.contents[std::string(key)] = bufferlist_from_view(value);
     return;
   }
 
@@ -116,19 +206,19 @@ inline void consume_omap_key_value(std::string_view key,
   }
 
   ceph::bufferlist bl = bufferlist_from_view(value);
-  auto& entry = state->entries[entry_id];
+  auto& entry = state.entries[entry_id];
   entry.entry_id = entry_id;
 
   if (field == "bucket_name") {
-    entry.has_bucket_name = decode_omap_value(bl, &entry.bucket_name);
+    decode_omap_string_value(bl, &entry.bucket_name);
   } else if (field == "index_name") {
-    entry.has_index_name = decode_omap_value(bl, &entry.index_name);
+    decode_omap_string_value(bl, &entry.index_name);
   } else if (field == "user_key") {
-    entry.has_user_key = decode_omap_value(bl, &entry.user_key);
+    decode_omap_string_value(bl, &entry.user_key);
   } else if (field == "content_key") {
-    entry.has_content_key = decode_omap_value(bl, &entry.content_key);
+    decode_omap_string_value(bl, &entry.content_key);
   } else if (field == "placement_key") {
-    entry.has_placement_key = decode_omap_value(bl, &entry.placement_key);
+    decode_omap_string_value(bl, &entry.placement_key);
   } else if (field == "data_type") {
     entry.has_data_type = decode_omap_value(bl, &entry.data_type);
   } else if (field == "distance_metric") {
@@ -143,27 +233,21 @@ inline int validate_query_request(const query_vectors_request_t& req,
                                   size_t *element_size = nullptr)
 {
   if (req.bucket_name.empty() || req.index_name.empty() ||
-      req.dimension == 0 || req.dimension > vector_max_dimension ||
-      req.top_k == 0) {
+      req.local_top_k == 0) {
     return -EINVAL;
   }
 
-  size_t type_size = 0;
-  int r = vector_data_type_size(req.data_type, &type_size);
+  int r = validate_vector_payload(req.data_type, req.distance_metric,
+                                  req.dimension, req.query_vector,
+                                  element_size);
   if (r < 0) {
-    return -EINVAL;
-  }
-  if (!vector_distance_metric_supported(req.distance_metric)) {
-    return -EINVAL;
+    return r;
   }
 
-  const size_t expected_len = static_cast<size_t>(req.dimension) * type_size;
-  if (req.query_vector.length() != expected_len) {
-    return -EINVAL;
-  }
-
-  if (element_size != nullptr) {
-    *element_size = type_size;
+  for (const auto& prefix : req.probe_prefixes) {
+    if (!is_hash_v0_placement_key(prefix)) {
+      return -EINVAL;
+    }
   }
   return 0;
 }
@@ -174,7 +258,7 @@ inline bool probe_matches(const query_vectors_request_t& req,
   if (req.probe_prefixes.empty()) {
     return true;
   }
-  if (!entry.has_placement_key) {
+  if (entry.placement_key.empty()) {
     return false;
   }
   return std::find(req.probe_prefixes.begin(), req.probe_prefixes.end(),
@@ -184,10 +268,10 @@ inline bool probe_matches(const query_vectors_request_t& req,
 inline bool entry_matches_query(const query_vectors_request_t& req,
                                 const omap_entry_t& entry)
 {
-  return entry.has_bucket_name &&
-    entry.has_index_name &&
-    entry.has_user_key &&
-    entry.has_content_key &&
+  return !entry.bucket_name.empty() &&
+    !entry.index_name.empty() &&
+    !entry.user_key.empty() &&
+    !entry.content_key.empty() &&
     entry.has_data_type &&
     entry.has_distance_metric &&
     entry.has_dimension &&
@@ -312,14 +396,6 @@ inline void sort_and_trim_results(std::vector<query_vectors_result_entry_t> *ent
   }
 }
 
-inline uint32_t local_topk_limit(const query_vectors_request_t& req)
-{
-  if (req.routing_policy.local_topk != 0) {
-    return req.routing_policy.local_topk;
-  }
-  return req.top_k;
-}
-
 inline int build_local_results(const query_vectors_request_t& req,
                                const omap_scan_state_t& scan,
                                query_vectors_result_t *result)
@@ -357,7 +433,7 @@ inline int build_local_results(const query_vectors_request_t& req,
     merge_result_entry(&result->entries, result_entry);
   }
 
-  sort_and_trim_results(&result->entries, local_topk_limit(req));
+  sort_and_trim_results(&result->entries, req.local_top_k);
   return 0;
 }
 

--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -1,0 +1,368 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_COMMON_VECTOR_QUERY_EXEC_H
+#define CEPH_COMMON_VECTOR_QUERY_EXEC_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <errno.h>
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+#include "include/rados/vector_ops.h"
+
+namespace ceph {
+namespace rados {
+namespace vector_query_exec {
+
+struct omap_entry_t {
+  std::string entry_id;
+  std::string bucket_name;
+  std::string index_name;
+  std::string user_key;
+  std::string content_key;
+  std::string placement_key;
+  uint32_t data_type = 0;
+  uint32_t distance_metric = 0;
+  uint32_t dimension = 0;
+  bool has_bucket_name = false;
+  bool has_index_name = false;
+  bool has_user_key = false;
+  bool has_content_key = false;
+  bool has_placement_key = false;
+  bool has_data_type = false;
+  bool has_distance_metric = false;
+  bool has_dimension = false;
+};
+
+struct omap_scan_state_t {
+  std::map<std::string, omap_entry_t> entries;
+  std::map<std::string, ceph::bufferlist> contents;
+};
+
+inline bool starts_with(std::string_view value, std::string_view prefix)
+{
+  return value.size() >= prefix.size() &&
+    value.substr(0, prefix.size()) == prefix;
+}
+
+inline ceph::bufferlist bufferlist_from_view(std::string_view value)
+{
+  ceph::bufferlist bl;
+  bl.append(value.data(), value.size());
+  return bl;
+}
+
+template <typename T>
+inline bool decode_omap_value(const ceph::bufferlist& bl, T *out)
+{
+  try {
+    auto p = bl.cbegin();
+    decode(*out, p);
+    return p.end();
+  } catch (const ceph::buffer::error&) {
+    return false;
+  }
+}
+
+inline bool parse_entry_key(std::string_view key,
+                            std::string *entry_id,
+                            std::string *field)
+{
+  constexpr std::string_view entry_prefix = "_ENTRY_";
+  if (!starts_with(key, entry_prefix)) {
+    return false;
+  }
+
+  const size_t dot_pos = key.find('.', entry_prefix.size());
+  if (dot_pos == std::string_view::npos || dot_pos == entry_prefix.size() ||
+      dot_pos + 1 >= key.size()) {
+    return false;
+  }
+
+  *entry_id = std::string(
+      key.substr(entry_prefix.size(), dot_pos - entry_prefix.size()));
+  *field = std::string(key.substr(dot_pos + 1));
+  return true;
+}
+
+inline void consume_omap_key_value(std::string_view key,
+                                   std::string_view value,
+                                   omap_scan_state_t *state)
+{
+  if (state == nullptr) {
+    return;
+  }
+
+  constexpr std::string_view content_prefix = "_CONTENT_";
+  if (starts_with(key, content_prefix)) {
+    state->contents[std::string(key)] = bufferlist_from_view(value);
+    return;
+  }
+
+  std::string entry_id;
+  std::string field;
+  if (!parse_entry_key(key, &entry_id, &field)) {
+    return;
+  }
+
+  ceph::bufferlist bl = bufferlist_from_view(value);
+  auto& entry = state->entries[entry_id];
+  entry.entry_id = entry_id;
+
+  if (field == "bucket_name") {
+    entry.has_bucket_name = decode_omap_value(bl, &entry.bucket_name);
+  } else if (field == "index_name") {
+    entry.has_index_name = decode_omap_value(bl, &entry.index_name);
+  } else if (field == "user_key") {
+    entry.has_user_key = decode_omap_value(bl, &entry.user_key);
+  } else if (field == "content_key") {
+    entry.has_content_key = decode_omap_value(bl, &entry.content_key);
+  } else if (field == "placement_key") {
+    entry.has_placement_key = decode_omap_value(bl, &entry.placement_key);
+  } else if (field == "data_type") {
+    entry.has_data_type = decode_omap_value(bl, &entry.data_type);
+  } else if (field == "distance_metric") {
+    entry.has_distance_metric =
+      decode_omap_value(bl, &entry.distance_metric);
+  } else if (field == "dimension") {
+    entry.has_dimension = decode_omap_value(bl, &entry.dimension);
+  }
+}
+
+inline int validate_query_request(const query_vectors_request_t& req,
+                                  size_t *element_size = nullptr)
+{
+  if (req.bucket_name.empty() || req.index_name.empty() ||
+      req.dimension == 0 || req.dimension > vector_max_dimension ||
+      req.top_k == 0) {
+    return -EINVAL;
+  }
+
+  size_t type_size = 0;
+  int r = vector_data_type_size(req.data_type, &type_size);
+  if (r < 0) {
+    return -EINVAL;
+  }
+  if (!vector_distance_metric_supported(req.distance_metric)) {
+    return -EINVAL;
+  }
+
+  const size_t expected_len = static_cast<size_t>(req.dimension) * type_size;
+  if (req.query_vector.length() != expected_len) {
+    return -EINVAL;
+  }
+
+  if (element_size != nullptr) {
+    *element_size = type_size;
+  }
+  return 0;
+}
+
+inline bool probe_matches(const query_vectors_request_t& req,
+                          const omap_entry_t& entry)
+{
+  if (req.probe_prefixes.empty()) {
+    return true;
+  }
+  if (!entry.has_placement_key) {
+    return false;
+  }
+  return std::find(req.probe_prefixes.begin(), req.probe_prefixes.end(),
+                   entry.placement_key) != req.probe_prefixes.end();
+}
+
+inline bool entry_matches_query(const query_vectors_request_t& req,
+                                const omap_entry_t& entry)
+{
+  return entry.has_bucket_name &&
+    entry.has_index_name &&
+    entry.has_user_key &&
+    entry.has_content_key &&
+    entry.has_data_type &&
+    entry.has_distance_metric &&
+    entry.has_dimension &&
+    entry.bucket_name == req.bucket_name &&
+    entry.index_name == req.index_name &&
+    entry.data_type == req.data_type &&
+    entry.distance_metric == req.distance_metric &&
+    entry.dimension == req.dimension &&
+    probe_matches(req, entry);
+}
+
+inline float read_float32(const char *data, size_t index)
+{
+  float value = 0;
+  std::memcpy(&value, data + index * sizeof(float), sizeof(float));
+  return value;
+}
+
+inline void copy_bufferlist_bytes(const ceph::bufferlist& bl,
+                                  char *out,
+                                  size_t len)
+{
+  auto p = bl.cbegin();
+  p.copy(len, out);
+}
+
+inline int compute_float32_distance(const query_vectors_request_t& req,
+                                    const ceph::bufferlist& candidate,
+                                    float *distance)
+{
+  if (distance == nullptr) {
+    return -EINVAL;
+  }
+  const size_t expected_len =
+    static_cast<size_t>(req.dimension) * sizeof(float);
+  if (req.data_type != vector_data_type_float32 ||
+      req.query_vector.length() != expected_len ||
+      candidate.length() != expected_len) {
+    return -EINVAL;
+  }
+
+  std::vector<char> query_data(expected_len);
+  std::vector<char> candidate_data(expected_len);
+  copy_bufferlist_bytes(req.query_vector, query_data.data(), expected_len);
+  copy_bufferlist_bytes(candidate, candidate_data.data(), expected_len);
+  double dot = 0;
+  double query_norm = 0;
+  double candidate_norm = 0;
+  double sum_sq = 0;
+  for (uint32_t i = 0; i < req.dimension; ++i) {
+    const double q = read_float32(query_data.data(), i);
+    const double c = read_float32(candidate_data.data(), i);
+    dot += q * c;
+    query_norm += q * q;
+    candidate_norm += c * c;
+    const double diff = q - c;
+    sum_sq += diff * diff;
+  }
+
+  switch (req.distance_metric) {
+  case vector_distance_metric_euclidean:
+    *distance = static_cast<float>(std::sqrt(sum_sq));
+    return 0;
+  case vector_distance_metric_cosine:
+    if (query_norm == 0 || candidate_norm == 0) {
+      *distance = std::numeric_limits<float>::infinity();
+    } else {
+      *distance = static_cast<float>(
+          1.0 - dot / (std::sqrt(query_norm) * std::sqrt(candidate_norm)));
+    }
+    return 0;
+  case vector_distance_metric_dot:
+    *distance = static_cast<float>(-dot);
+    return 0;
+  default:
+    return -EINVAL;
+  }
+}
+
+inline const std::string& result_entry_identity(
+    const query_vectors_result_entry_t& entry)
+{
+  return entry.entry_id.empty() ? entry.key : entry.entry_id;
+}
+
+inline bool result_entry_better(const query_vectors_result_entry_t& lhs,
+                                const query_vectors_result_entry_t& rhs)
+{
+  if (lhs.distance != rhs.distance) {
+    return lhs.distance < rhs.distance;
+  }
+  return lhs.key < rhs.key;
+}
+
+inline void merge_result_entry(std::vector<query_vectors_result_entry_t> *entries,
+                               const query_vectors_result_entry_t& candidate)
+{
+  if (entries == nullptr) {
+    return;
+  }
+  const std::string& candidate_id = result_entry_identity(candidate);
+  for (auto& entry : *entries) {
+    if (result_entry_identity(entry) == candidate_id) {
+      if (result_entry_better(candidate, entry)) {
+        entry = candidate;
+      }
+      return;
+    }
+  }
+  entries->push_back(candidate);
+}
+
+inline void sort_and_trim_results(std::vector<query_vectors_result_entry_t> *entries,
+                                  uint32_t top_k)
+{
+  if (entries == nullptr) {
+    return;
+  }
+  std::sort(entries->begin(), entries->end(), result_entry_better);
+  if (top_k != 0 && entries->size() > top_k) {
+    entries->resize(top_k);
+  }
+}
+
+inline uint32_t local_topk_limit(const query_vectors_request_t& req)
+{
+  if (req.routing_policy.local_topk != 0) {
+    return req.routing_policy.local_topk;
+  }
+  return req.top_k;
+}
+
+inline int build_local_results(const query_vectors_request_t& req,
+                               const omap_scan_state_t& scan,
+                               query_vectors_result_t *result)
+{
+  if (result == nullptr) {
+    return -EINVAL;
+  }
+  result->entries.clear();
+
+  int r = validate_query_request(req);
+  if (r < 0) {
+    return r;
+  }
+
+  for (const auto& [entry_id, entry] : scan.entries) {
+    (void)entry_id;
+    if (!entry_matches_query(req, entry)) {
+      continue;
+    }
+    const auto content = scan.contents.find(entry.content_key);
+    if (content == scan.contents.end()) {
+      continue;
+    }
+
+    float distance = 0;
+    r = compute_float32_distance(req, content->second, &distance);
+    if (r < 0) {
+      continue;
+    }
+
+    query_vectors_result_entry_t result_entry;
+    result_entry.key = entry.user_key;
+    result_entry.distance = distance;
+    result_entry.entry_id = entry.entry_id;
+    merge_result_entry(&result->entries, result_entry);
+  }
+
+  sort_and_trim_results(&result->entries, local_topk_limit(req));
+  return 0;
+}
+
+} // namespace vector_query_exec
+} // namespace rados
+} // namespace ceph
+
+#endif

--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -354,7 +354,12 @@ inline int compute_float32_distance(const query_vectors_request_t& req,
 inline const std::string& result_entry_identity(
     const query_vectors_result_entry_t& entry)
 {
-  return entry.entry_id.empty() ? entry.key : entry.entry_id;
+  return entry.entry_id;
+}
+
+inline bool result_entry_valid(const query_vectors_result_entry_t& entry)
+{
+  return !entry.key.empty() && !entry.entry_id.empty();
 }
 
 inline bool result_entry_better(const query_vectors_result_entry_t& lhs,
@@ -373,6 +378,10 @@ inline void merge_result_entry(std::vector<query_vectors_result_entry_t> *entrie
     return;
   }
   const std::string& candidate_id = result_entry_identity(candidate);
+  if (candidate_id.empty()) {
+    entries->push_back(candidate);
+    return;
+  }
   for (auto& entry : *entries) {
     if (result_entry_identity(entry) == candidate_id) {
       if (result_entry_better(candidate, entry)) {

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -756,6 +756,10 @@ OpsExecuter::do_execute_op(OSDOp& osd_op)
     return do_write_op([this, &osd_op](auto& backend, auto& os, auto& txn) {
       return backend.put_vector(os, osd_op, txn, *osd_op_params, delta_stats);
     });
+  case CEPH_OSD_OP_QUERY_VECTORS:
+    return do_read_op([this, &osd_op](auto& backend, const auto& os) {
+      return backend.query_vectors(os, osd_op, delta_stats);
+    });
 
   // OMAP
   case CEPH_OSD_OP_OMAPGETKEYS:

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -3,6 +3,7 @@
 
 #include "pg_backend.h"
 #include "include/rados/vector_ops.h"
+#include "common/vector_query_exec.h"
 
 #include <charconv>
 #include <cstdio>
@@ -1814,6 +1815,65 @@ PGBackend::put_vector(
   }
   os.oi.clear_omap_digest();
   return seastar::now();
+}
+
+PGBackend::ll_read_ierrorator::future<>
+PGBackend::query_vectors(
+  const ObjectState& os,
+  OSDOp& osd_op,
+  object_stat_sum_t& delta_stats) const
+{
+  ceph::rados::query_vectors_request_t req;
+
+  try {
+    auto p = osd_op.indata.cbegin();
+    decode(req, p);
+    if (!p.end()) {
+      throw crimson::osd::invalid_argument{};
+    }
+  } catch (const ceph::buffer::error&) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  int r = ceph::rados::vector_query_exec::validate_query_request(req);
+  if (r < 0) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  ceph::rados::vector_query_exec::omap_scan_state_t scan;
+  if (os.exists && !os.oi.is_whiteout() && os.oi.is_omap()) {
+    ObjectStore::omap_iter_seek_t start_from =
+      ObjectStore::omap_iter_seek_t::min_lower_bound();
+    omap_iterate_cb_t callback =
+      [&scan](std::string_view key, std::string_view value) {
+        ceph::rados::vector_query_exec::consume_omap_key_value(
+            key, value, &scan);
+        return ObjectStore::omap_iter_ret_t::NEXT;
+      };
+
+    co_await maybe_do_omap_iterate(
+      store, coll, os.oi, start_from, callback
+    ).safe_then([](auto) {
+      return seastar::now();
+    }).handle_error(
+      crimson::ct_error::enodata::handle([] {
+        return ll_read_errorator::now();
+      }),
+      ll_read_errorator::pass_further{}
+    );
+  }
+
+  ceph::rados::query_vectors_result_t query_result;
+  r = ceph::rados::vector_query_exec::build_local_results(
+      req, scan, &query_result);
+  if (r < 0) {
+    throw crimson::osd::invalid_argument{};
+  }
+
+  encode(query_result, osd_op.outdata);
+  delta_stats.num_rd_kb += shift_round_up(osd_op.outdata.length(), 10);
+  delta_stats.num_rd++;
+  co_return;
 }
 
 PGBackend::interruptible_future<>

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1771,29 +1771,8 @@ PGBackend::put_vector(
     throw crimson::osd::invalid_argument{};
   }
 
-  if (req.bucket_name.empty() ||
-      req.index_name.empty() ||
-      req.key.empty() ||
-      req.vector_hash.empty() ||
-      req.dimension == 0 ||
-      req.dimension > ceph::rados::vector_max_dimension) {
-    throw crimson::osd::invalid_argument{};
-  }
-
-  size_t element_size = 0;
-  int r = ceph::rados::vector_data_type_size(req.data_type, &element_size);
+  int r = ceph::rados::vector_query_exec::validate_put_request(req, true);
   if (r < 0) {
-    throw crimson::osd::invalid_argument{};
-  }
-
-  if (!ceph::rados::vector_distance_metric_supported(req.distance_metric)) {
-    throw crimson::osd::invalid_argument{};
-  }
-
-  const size_t expected_len =
-    static_cast<size_t>(req.dimension) * element_size;
-
-  if (req.vector_data.length() != expected_len) {
     throw crimson::osd::invalid_argument{};
   }
 
@@ -1847,7 +1826,7 @@ PGBackend::query_vectors(
     omap_iterate_cb_t callback =
       [&scan](std::string_view key, std::string_view value) {
         ceph::rados::vector_query_exec::consume_omap_key_value(
-            key, value, &scan);
+            key, value, scan);
         return ObjectStore::omap_iter_ret_t::NEXT;
       };
 

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -386,6 +386,10 @@ public:
     ceph::os::Transaction& txn,
     osd_op_params_t& osd_op_params,
     object_stat_sum_t& delta_stats);
+  ll_read_ierrorator::future<> query_vectors(
+    const ObjectState& os,
+    OSDOp& osd_op,
+    object_stat_sum_t& delta_stats) const;
   ll_read_ierrorator::future<ceph::bufferlist> omap_get_header(
     const crimson::os::CollectionRef& c,
     const ghobject_t& oid,

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -306,6 +306,7 @@ extern const char *ceph_osd_state_name(int s);
 									    \
 	/* vector */							    \
 	f(PUT_VECTOR,	__CEPH_OSD_OP(WR, DATA, 46),	"put-vector")	    \
+	f(QUERY_VECTORS, __CEPH_OSD_OP(RD, DATA, 47),	"query-vectors")    \
 									    \
 	/* tiering */							    \
 	f(COPY_FROM,	__CEPH_OSD_OP(WR, DATA, 26),	"copy-from")	    \

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1544,7 +1544,8 @@ CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
  * Store one vector entry in a vector bucket/index.
  *
  * Metadata is optional and may contain an application-defined related object
- * id or serialized metadata document.
+ * id or serialized metadata document. The vector key is the caller-visible
+ * logical key; OSDs derive the internal entry_id from bucket/index/key.
  *
  * @param io the io context in which the vector PUT will occur
  * @param vector_bucket_name vector bucket name
@@ -1557,7 +1558,8 @@ CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
  * @param vector_data_len length of vector_data, in bytes
  * @param metadata optional metadata bytes
  * @param metadata_len length of metadata, in bytes
- * @returns 0 on success, negative error code on failure
+ * @returns 0 on success, -EINVAL for invalid input, or another negative error
+ *          code on failure
  */
 CEPH_RADOS_API int rados_put_vector(
     rados_ioctx_t io, const char *vector_bucket_name, const char *index_name,
@@ -1571,6 +1573,9 @@ CEPH_RADOS_API int rados_put_vector(
  *
  * The client planner routes this request to vector objects, OSDs compute local
  * top-k results, and librados merges them into the final top-k result.
+ * Missing target objects, missing probe prefixes, and no matches are successful
+ * empty results. Duplicate partial results for the same logical vector are
+ * merged by entry_id, keeping the best distance.
  *
  * @param io the io context in which the vector query will occur
  * @param vector_bucket_name vector bucket name
@@ -1584,7 +1589,8 @@ CEPH_RADOS_API int rados_put_vector(
  * @param return_distance whether result distances should be returned
  * @param result query result output, released with
  *        rados_query_vectors_result_release()
- * @returns 0 on success, negative error code on failure
+ * @returns 0 on success, -EINVAL for invalid input, or another negative error
+ *          code on failure
  */
 CEPH_RADOS_API int rados_query_vectors(
     rados_ioctx_t io, const char *vector_bucket_name, const char *index_name,

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1569,8 +1569,8 @@ CEPH_RADOS_API int rados_put_vector(
 /**
  * Query vectors from a vector bucket/index.
  *
- * This API currently validates the request and returns -EOPNOTSUPP until the
- * vector query planner and backend execution paths are implemented.
+ * The client planner routes this request to vector objects, OSDs compute local
+ * top-k results, and librados merges them into the final top-k result.
  *
  * @param io the io context in which the vector query will occur
  * @param vector_bucket_name vector bucket name

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -916,6 +916,9 @@ inline namespace v14_2_0 {
     int write(const std::string& oid, bufferlist& bl, size_t len, uint64_t off);
     /**
      * store one vector entry in a vector bucket/index
+     *
+     * The key is the caller-visible logical key; OSDs derive the internal
+     * entry_id from bucket/index/key. Invalid input returns -EINVAL.
      */
     int put_vector(const std::string& vector_bucket_name,
 		   const std::string& index_name,
@@ -928,6 +931,10 @@ inline namespace v14_2_0 {
 		   const bufferlist& metadata);
     /**
      * query vectors in a vector bucket/index
+     *
+     * Missing target objects, missing probe prefixes, and no matches return an
+     * empty result. Duplicate partial results are merged by entry_id, keeping
+     * the best distance. Invalid input returns -EINVAL.
      */
     int query_vectors(const std::string& vector_bucket_name,
 		      const std::string& index_name,

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -26,8 +26,86 @@ inline constexpr uint32_t vector_distance_metric_euclidean = 1;
 inline constexpr uint32_t vector_distance_metric_cosine = 2;
 inline constexpr uint32_t vector_distance_metric_dot = 3;
 
-inline constexpr uint32_t vector_query_algorithm_flat = 1;
+inline constexpr uint32_t vector_query_algorithm_hash = 1;
 inline constexpr uint32_t vector_query_algorithm_version_0 = 0;
+
+struct vector_routing_policy_t {
+  // Number of placement targets to write for each vector entry.
+  uint32_t write_pgs = 1;
+  // Number of placement targets to probe for each vector query.
+  uint32_t probe_pgs = 1;
+  // Per-target result limit before the client merges results; 0 uses top_k.
+  uint32_t local_topk = 0;
+  // Algorithm-specific candidate limit; 0 means no explicit limit.
+  uint32_t max_candidates = 0;
+
+  void encode(ceph::bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(write_pgs, bl);
+    encode(probe_pgs, bl);
+    encode(local_topk, bl);
+    encode(max_candidates, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(write_pgs, p);
+    decode(probe_pgs, p);
+    decode(local_topk, p);
+    decode(max_candidates, p);
+    DECODE_FINISH(p);
+  }
+};
+
+struct vector_index_config_t {
+  // Vector element data type accepted by this index; 0 accepts the request type.
+  uint32_t data_type = 0;
+  // Distance metric accepted by this index; 0 accepts the request metric.
+  uint32_t distance_metric = 0;
+  // Number of vector dimensions in this index; 0 accepts the request dimension.
+  uint32_t dimension = 0;
+  // Vector query algorithm identifier used by the index planner.
+  uint32_t algorithm_id = vector_query_algorithm_hash;
+  // Version of the query algorithm and algorithm-specific parameters.
+  uint32_t algorithm_version = vector_query_algorithm_version_0;
+  // Placement algorithm name used to map vectors and probes to RADOS objects.
+  std::string placement_algorithm;
+  // Routing fanout and per-target query limits for this index.
+  vector_routing_policy_t routing_policy;
+  // Opaque algorithm-specific configuration parameters.
+  ceph::bufferlist algorithm_params;
+
+  void encode(ceph::bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(data_type, bl);
+    encode(distance_metric, bl);
+    encode(dimension, bl);
+    encode(algorithm_id, bl);
+    encode(algorithm_version, bl);
+    encode(placement_algorithm, bl);
+    routing_policy.encode(bl);
+    encode(algorithm_params, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(data_type, p);
+    decode(distance_metric, p);
+    decode(dimension, p);
+    decode(algorithm_id, p);
+    decode(algorithm_version, p);
+    decode(placement_algorithm, p);
+    routing_policy.decode(p);
+    decode(algorithm_params, p);
+    DECODE_FINISH(p);
+  }
+};
 
 inline int vector_data_type_size(uint32_t data_type, size_t *size)
 {
@@ -53,17 +131,32 @@ inline bool vector_distance_metric_supported(uint32_t distance_metric)
 }
 
 struct put_vector_request_t {
+  // Logical vector bucket name.
   std::string bucket_name;
+  // Logical vector index name within the bucket.
   std::string index_name;
+  // User-provided vector key.
   std::string key;
+  // Vector element data type.
   uint32_t data_type = 0;
+  // Distance metric used when comparing this vector.
   uint32_t distance_metric = 0;
+  // Number of vector dimensions.
   uint32_t dimension = 0;
+  // Raw vector payload bytes.
   ceph::bufferlist vector_data;
+  // Optional application-defined metadata stored with the entry.
   ceph::bufferlist metadata;
+  // Placement algorithm selected by the client planner.
   std::string placement_algorithm;
+  // Placement key for the target object receiving this write.
   std::string placement_key;
+  // Hash of vector_data used for placement and content storage keys.
   std::string vector_hash;
+  // Opaque algorithm-specific parameters copied from the index config.
+  ceph::bufferlist algorithm_params;
+  // Effective routing policy copied from the index config.
+  vector_routing_policy_t routing_policy;
 
   void encode(ceph::bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
@@ -79,6 +172,8 @@ struct put_vector_request_t {
     encode(placement_algorithm, bl);
     encode(placement_key, bl);
     encode(vector_hash, bl);
+    encode(algorithm_params, bl);
+    routing_policy.encode(bl);
     ENCODE_FINISH(bl);
   }
 
@@ -96,22 +191,41 @@ struct put_vector_request_t {
     decode(placement_algorithm, p);
     decode(placement_key, p);
     decode(vector_hash, p);
+    decode(algorithm_params, p);
+    routing_policy.decode(p);
     DECODE_FINISH(p);
   }
 };
 
 struct query_vectors_request_t {
+  // Logical vector bucket name.
   std::string bucket_name;
+  // Logical vector index name within the bucket.
   std::string index_name;
+  // Query vector element data type.
   uint32_t data_type = 0;
+  // Distance metric used to rank candidate vectors.
   uint32_t distance_metric = 0;
+  // Number of query vector dimensions.
   uint32_t dimension = 0;
+  // Number of nearest vectors requested in the merged result.
   uint32_t top_k = 0;
+  // Whether distances should be returned to the caller.
   bool return_distance = false;
+  // Raw query vector payload bytes.
   ceph::bufferlist query_vector;
+  // Vector query algorithm identifier selected for this request.
   uint32_t algorithm_id = 0;
+  // Version of the selected query algorithm.
   uint32_t algorithm_version = 0;
+  // Placement algorithm used to route query probes.
+  std::string placement_algorithm;
+  // Effective routing policy used by the query planner and OSD.
+  vector_routing_policy_t routing_policy;
+  // Opaque algorithm-specific parameters copied from the index config.
   ceph::bufferlist algorithm_params;
+  // Placement keys that this routed probe should scan; empty scans all keys.
+  std::vector<std::string> probe_prefixes;
 
   void encode(ceph::bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
@@ -126,7 +240,10 @@ struct query_vectors_request_t {
     encode(query_vector, bl);
     encode(algorithm_id, bl);
     encode(algorithm_version, bl);
+    encode(placement_algorithm, bl);
+    routing_policy.encode(bl);
     encode(algorithm_params, bl);
+    encode(probe_prefixes, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -143,7 +260,10 @@ struct query_vectors_request_t {
     decode(query_vector, p);
     decode(algorithm_id, p);
     decode(algorithm_version, p);
+    decode(placement_algorithm, p);
+    routing_policy.decode(p);
     decode(algorithm_params, p);
+    decode(probe_prefixes, p);
     DECODE_FINISH(p);
   }
 };
@@ -201,6 +321,8 @@ struct query_vectors_result_t {
 } // namespace rados
 } // namespace ceph
 
+WRITE_CLASS_ENCODER(ceph::rados::vector_routing_policy_t)
+WRITE_CLASS_ENCODER(ceph::rados::vector_index_config_t)
 WRITE_CLASS_ENCODER(ceph::rados::put_vector_request_t)
 WRITE_CLASS_ENCODER(ceph::rados::query_vectors_request_t)
 WRITE_CLASS_ENCODER(ceph::rados::query_vectors_result_entry_t)

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -28,13 +28,16 @@ inline constexpr uint32_t vector_distance_metric_dot = 3;
 
 inline constexpr uint32_t vector_query_algorithm_hash = 1;
 inline constexpr uint32_t vector_query_algorithm_version_0 = 0;
+inline constexpr const char *vector_placement_algorithm_hash_v0 = "hash-v0";
+inline constexpr uint32_t vector_hash_v0_placement_key_len = 4;
+inline constexpr uint32_t vector_hash_v0_vector_hash_len = 8;
 
 struct vector_routing_policy_t {
   // Number of placement targets to write for each vector entry.
   uint32_t write_pgs = 1;
   // Number of placement targets to probe for each vector query.
   uint32_t probe_pgs = 1;
-  // Per-target result limit before the client merges results; 0 uses top_k.
+  // Per-target partial result upper bound; 0 inherits query top_k.
   uint32_t local_topk = 0;
   // Algorithm-specific candidate limit; 0 means no explicit limit.
   uint32_t max_candidates = 0;
@@ -67,11 +70,12 @@ struct vector_index_config_t {
   uint32_t distance_metric = 0;
   // Number of vector dimensions in this index; 0 accepts the request dimension.
   uint32_t dimension = 0;
-  // Vector query algorithm identifier used by the index planner.
+  // Planner algorithm family. The current baseline is hash-v0.
   uint32_t algorithm_id = vector_query_algorithm_hash;
-  // Version of the query algorithm and algorithm-specific parameters.
+  // Planner/layout variant within algorithm_id. Version 0 is the hash-v0
+  // baseline and is intentionally replaceable by future planners.
   uint32_t algorithm_version = vector_query_algorithm_version_0;
-  // Placement algorithm name used to map vectors and probes to RADOS objects.
+  // Placement algorithm used to map put vectors and query probes to objects.
   std::string placement_algorithm;
   // Routing fanout and per-target query limits for this index.
   vector_routing_policy_t routing_policy;
@@ -135,7 +139,8 @@ struct put_vector_request_t {
   std::string bucket_name;
   // Logical vector index name within the bucket.
   std::string index_name;
-  // User-provided vector key.
+  // User-provided logical vector key. OSDs derive entry_id from
+  // bucket_name/index_name/key and use it as the logical vector identity.
   std::string key;
   // Vector element data type.
   uint32_t data_type = 0;
@@ -147,7 +152,8 @@ struct put_vector_request_t {
   ceph::bufferlist vector_data;
   // Optional application-defined metadata stored with the entry.
   ceph::bufferlist metadata;
-  // Placement algorithm selected by the client planner.
+  // Placement algorithm selected by the client planner. hash-v0 stores vectors
+  // under an object name derived from bucket/index and a vector-hash prefix.
   std::string placement_algorithm;
   // Placement key for the target object receiving this write.
   std::string placement_key;
@@ -155,7 +161,7 @@ struct put_vector_request_t {
   std::string vector_hash;
 
   void encode(ceph::bufferlist& bl) const {
-    ENCODE_START(2, 2, bl);
+    ENCODE_START(1, 1, bl);
     using ceph::encode;
     encode(bucket_name, bl);
     encode(index_name, bl);
@@ -172,7 +178,7 @@ struct put_vector_request_t {
   }
 
   void decode(ceph::bufferlist::const_iterator& p) {
-    DECODE_START(2, p);
+    DECODE_START(1, p);
     using ceph::decode;
     decode(bucket_name, p);
     decode(index_name, p);
@@ -185,14 +191,6 @@ struct put_vector_request_t {
     decode(placement_algorithm, p);
     decode(placement_key, p);
     decode(vector_hash, p);
-    if (struct_v >= 2) {
-      // No planner-only fields are encoded in v2.
-    } else {
-      ceph::bufferlist ignored_algorithm_params;
-      vector_routing_policy_t ignored_routing_policy;
-      decode(ignored_algorithm_params, p);
-      ignored_routing_policy.decode(p);
-    }
     DECODE_FINISH(p);
   }
 };
@@ -218,7 +216,7 @@ struct query_vectors_request_t {
   std::vector<std::string> probe_prefixes;
 
   void encode(ceph::bufferlist& bl) const {
-    ENCODE_START(2, 2, bl);
+    ENCODE_START(1, 1, bl);
     using ceph::encode;
     encode(bucket_name, bl);
     encode(index_name, bl);
@@ -232,39 +230,16 @@ struct query_vectors_request_t {
   }
 
   void decode(ceph::bufferlist::const_iterator& p) {
-    DECODE_START(2, p);
+    DECODE_START(1, p);
     using ceph::decode;
     decode(bucket_name, p);
     decode(index_name, p);
     decode(data_type, p);
     decode(distance_metric, p);
     decode(dimension, p);
-    if (struct_v >= 2) {
-      decode(local_top_k, p);
-      decode(query_vector, p);
-      decode(probe_prefixes, p);
-    } else {
-      uint32_t top_k = 0;
-      bool ignored_return_distance = false;
-      uint32_t ignored_algorithm_id = 0;
-      uint32_t ignored_algorithm_version = 0;
-      std::string ignored_placement_algorithm;
-      vector_routing_policy_t old_routing_policy;
-      ceph::bufferlist ignored_algorithm_params;
-
-      decode(top_k, p);
-      decode(ignored_return_distance, p);
-      decode(query_vector, p);
-      decode(ignored_algorithm_id, p);
-      decode(ignored_algorithm_version, p);
-      decode(ignored_placement_algorithm, p);
-      old_routing_policy.decode(p);
-      decode(ignored_algorithm_params, p);
-      decode(probe_prefixes, p);
-
-      local_top_k = old_routing_policy.local_topk != 0 ?
-        old_routing_policy.local_topk : top_k;
-    }
+    decode(local_top_k, p);
+    decode(query_vector, p);
+    decode(probe_prefixes, p);
     DECODE_FINISH(p);
   }
 };
@@ -274,7 +249,8 @@ struct query_vectors_result_entry_t {
   std::string key;
   // Distance between the query vector and this result entry.
   float distance = 0;
-  // Internal entry identity used to merge duplicate routed results.
+  // Logical vector identity. Clients merge duplicate partial results by this
+  // field and keep the best distance for each entry_id.
   std::string entry_id;
 
   void encode(ceph::bufferlist& bl) const {

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -153,13 +153,9 @@ struct put_vector_request_t {
   std::string placement_key;
   // Hash of vector_data used for placement and content storage keys.
   std::string vector_hash;
-  // Opaque algorithm-specific parameters copied from the index config.
-  ceph::bufferlist algorithm_params;
-  // Effective routing policy copied from the index config.
-  vector_routing_policy_t routing_policy;
 
   void encode(ceph::bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     using ceph::encode;
     encode(bucket_name, bl);
     encode(index_name, bl);
@@ -172,13 +168,11 @@ struct put_vector_request_t {
     encode(placement_algorithm, bl);
     encode(placement_key, bl);
     encode(vector_hash, bl);
-    encode(algorithm_params, bl);
-    routing_policy.encode(bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::bufferlist::const_iterator& p) {
-    DECODE_START(1, p);
+    DECODE_START(2, p);
     using ceph::decode;
     decode(bucket_name, p);
     decode(index_name, p);
@@ -191,8 +185,14 @@ struct put_vector_request_t {
     decode(placement_algorithm, p);
     decode(placement_key, p);
     decode(vector_hash, p);
-    decode(algorithm_params, p);
-    routing_policy.decode(p);
+    if (struct_v >= 2) {
+      // No planner-only fields are encoded in v2.
+    } else {
+      ceph::bufferlist ignored_algorithm_params;
+      vector_routing_policy_t ignored_routing_policy;
+      decode(ignored_algorithm_params, p);
+      ignored_routing_policy.decode(p);
+    }
     DECODE_FINISH(p);
   }
 };
@@ -208,75 +208,81 @@ struct query_vectors_request_t {
   uint32_t distance_metric = 0;
   // Number of query vector dimensions.
   uint32_t dimension = 0;
-  // Number of nearest vectors requested in the merged result.
-  uint32_t top_k = 0;
-  // Whether distances should be returned to the caller.
-  bool return_distance = false;
+  // Maximum number of local results this OSD should return for this routed
+  // probe. librados owns global fanout and final top_k trimming.
+  uint32_t local_top_k = 0;
   // Raw query vector payload bytes.
   ceph::bufferlist query_vector;
-  // Vector query algorithm identifier selected for this request.
-  uint32_t algorithm_id = 0;
-  // Version of the selected query algorithm.
-  uint32_t algorithm_version = 0;
-  // Placement algorithm used to route query probes.
-  std::string placement_algorithm;
-  // Effective routing policy used by the query planner and OSD.
-  vector_routing_policy_t routing_policy;
-  // Opaque algorithm-specific parameters copied from the index config.
-  ceph::bufferlist algorithm_params;
-  // Placement keys that this routed probe should scan; empty scans all keys.
+  // Placement keys that this routed probe should scan; empty scans all keys in
+  // the target object. Missing prefixes are normal empty-result probes.
   std::vector<std::string> probe_prefixes;
 
   void encode(ceph::bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     using ceph::encode;
     encode(bucket_name, bl);
     encode(index_name, bl);
     encode(data_type, bl);
     encode(distance_metric, bl);
     encode(dimension, bl);
-    encode(top_k, bl);
-    encode(return_distance, bl);
+    encode(local_top_k, bl);
     encode(query_vector, bl);
-    encode(algorithm_id, bl);
-    encode(algorithm_version, bl);
-    encode(placement_algorithm, bl);
-    routing_policy.encode(bl);
-    encode(algorithm_params, bl);
     encode(probe_prefixes, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::bufferlist::const_iterator& p) {
-    DECODE_START(1, p);
+    DECODE_START(2, p);
     using ceph::decode;
     decode(bucket_name, p);
     decode(index_name, p);
     decode(data_type, p);
     decode(distance_metric, p);
     decode(dimension, p);
-    decode(top_k, p);
-    decode(return_distance, p);
-    decode(query_vector, p);
-    decode(algorithm_id, p);
-    decode(algorithm_version, p);
-    decode(placement_algorithm, p);
-    routing_policy.decode(p);
-    decode(algorithm_params, p);
-    decode(probe_prefixes, p);
+    if (struct_v >= 2) {
+      decode(local_top_k, p);
+      decode(query_vector, p);
+      decode(probe_prefixes, p);
+    } else {
+      uint32_t top_k = 0;
+      bool ignored_return_distance = false;
+      uint32_t ignored_algorithm_id = 0;
+      uint32_t ignored_algorithm_version = 0;
+      std::string ignored_placement_algorithm;
+      vector_routing_policy_t old_routing_policy;
+      ceph::bufferlist ignored_algorithm_params;
+
+      decode(top_k, p);
+      decode(ignored_return_distance, p);
+      decode(query_vector, p);
+      decode(ignored_algorithm_id, p);
+      decode(ignored_algorithm_version, p);
+      decode(ignored_placement_algorithm, p);
+      old_routing_policy.decode(p);
+      decode(ignored_algorithm_params, p);
+      decode(probe_prefixes, p);
+
+      local_top_k = old_routing_policy.local_topk != 0 ?
+        old_routing_policy.local_topk : top_k;
+    }
     DECODE_FINISH(p);
   }
 };
 
 struct query_vectors_result_entry_t {
+  // User-provided vector key for the matched entry.
   std::string key;
+  // Distance between the query vector and this result entry.
   float distance = 0;
+  // Internal entry identity used to merge duplicate routed results.
+  std::string entry_id;
 
   void encode(ceph::bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
     using ceph::encode;
     encode(key, bl);
     encode(distance, bl);
+    encode(entry_id, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -285,11 +291,13 @@ struct query_vectors_result_entry_t {
     using ceph::decode;
     decode(key, p);
     decode(distance, p);
+    decode(entry_id, p);
     DECODE_FINISH(p);
   }
 };
 
 struct query_vectors_result_t {
+  // Sorted vector query result entries.
   std::vector<query_vectors_result_entry_t> entries;
 
   void encode(ceph::bufferlist& bl) const {

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -27,6 +27,7 @@
 #include "include/ceph_hash.h"
 #include "include/encoding.h"
 #include "include/rados/vector_ops.h"
+#include "common/vector_query_exec.h"
 #include "common/valgrind.h"
 #include "common/EventTrace.h"
 
@@ -688,8 +689,6 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   }
 
   req.placement_algorithm = plan.placement_algorithm;
-  req.routing_policy = plan.routing_policy;
-  req.algorithm_params = plan.algorithm_params;
 
   for (const auto& target : plan.targets) {
     ::ObjectOperation op;
@@ -758,27 +757,22 @@ int librados::IoCtxImpl::query_vectors(
     return -EINVAL;
   }
 
-  ceph::rados::query_vectors_request_t req;
+  librados::vector_query::query_request_t req;
   req.bucket_name = vector_bucket_name;
   req.index_name = index_name;
   req.data_type = encoded_data_type;
   req.distance_metric = encoded_distance_metric;
   req.dimension = dimension;
   req.top_k = top_k;
-  req.return_distance = return_distance;
   req.query_vector = query_vector;
-  req.algorithm_id = ceph::rados::vector_query_algorithm_hash;
-  req.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
-  req.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
 
   ceph::rados::vector_index_config_t config;
   config.data_type = encoded_data_type;
   config.distance_metric = encoded_distance_metric;
   config.dimension = dimension;
-  config.algorithm_id = req.algorithm_id;
-  config.algorithm_version = req.algorithm_version;
-  config.placement_algorithm = req.placement_algorithm;
-  req.routing_policy = config.routing_policy;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
 
   librados::vector_query::query_plan_t plan;
   r = librados::vector_query::build_query_plan(req, config, &plan);
@@ -793,9 +787,56 @@ int librados::IoCtxImpl::query_vectors(
     return r;
   }
 
-  // PR2 stops at client-side planning and routed payload construction. PR3
-  // will add ObjectOperation/query op plumbing and backend execution.
-  return -EOPNOTSUPP;
+  ceph::rados::query_vectors_result_t merged_result;
+  for (const auto& routed_request : routed_requests) {
+    ::ObjectOperation op;
+    bufferlist payload = routed_request.payload;
+    bufferlist reply;
+    int op_rval = 0;
+    op.query_vectors(payload, &reply, &op_rval);
+
+    r = operate_read(routed_request.oid, &op, &reply);
+    if (r == -ENOENT || op_rval == -ENOENT) {
+      continue;
+    }
+    if (r < 0) {
+      return r;
+    }
+    if (op_rval < 0) {
+      return op_rval;
+    }
+    if (reply.length() == 0) {
+      continue;
+    }
+
+    ceph::rados::query_vectors_result_t partial_result;
+    try {
+      auto p = reply.cbegin();
+      decode(partial_result, p);
+      if (!p.end()) {
+        return -EIO;
+      }
+    } catch (const ceph::buffer::error&) {
+      return -EIO;
+    }
+
+    for (const auto& entry : partial_result.entries) {
+      ceph::rados::vector_query_exec::merge_result_entry(
+          &merged_result.entries, entry);
+    }
+  }
+
+  ceph::rados::vector_query_exec::sort_and_trim_results(
+      &merged_result.entries, top_k);
+
+  results->reserve(merged_result.entries.size());
+  for (const auto& entry : merged_result.entries) {
+    librados::query_vectors_result_entry out_entry;
+    out_entry.key = entry.key;
+    out_entry.distance = return_distance ? entry.distance : 0;
+    results->push_back(std::move(out_entry));
+  }
+  return 0;
 }
 
 int librados::IoCtxImpl::append(const object_t& oid, bufferlist& bl, size_t len)

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -821,6 +821,9 @@ int librados::IoCtxImpl::query_vectors(
     }
 
     for (const auto& entry : partial_result.entries) {
+      if (!ceph::rados::vector_query_exec::result_entry_valid(entry)) {
+        return -EIO;
+      }
       ceph::rados::vector_query_exec::merge_result_entry(
           &merged_result.entries, entry);
     }

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -21,6 +21,8 @@
 #include "librados/AioCompletionImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
+#include "librados/vector_placement.h"
+#include "librados/vector_query_planner.h"
 #include "include/ceph_assert.h"
 #include "include/ceph_hash.h"
 #include "include/encoding.h"
@@ -242,8 +244,6 @@ struct C_aio_selfmanaged_snap_create_Complete : public C_aio_selfmanaged_snap_op
 
 namespace {
 
-static constexpr const char *vector_placement_algorithm = "hash-v0";
-
 static_assert(LIBRADOS_VECTOR_MAX_DIMENSION ==
               ceph::rados::vector_max_dimension);
 static_assert(LIBRADOS_VECTOR_DATA_TYPE_FLOAT32 ==
@@ -254,46 +254,6 @@ static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE ==
               ceph::rados::vector_distance_metric_cosine);
 static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_DOT ==
               ceph::rados::vector_distance_metric_dot);
-
-std::string vector_hex_u32(uint32_t value)
-{
-  char buf[9];
-  snprintf(buf, sizeof(buf), "%08x", value);
-  return std::string(buf);
-}
-
-std::string vector_hash_string(const std::string& value)
-{
-  return vector_hex_u32(ceph_str_hash_rjenkins(
-      value.c_str(), static_cast<unsigned>(value.length())));
-}
-
-struct vector_placement_result {
-  object_t oid;
-  std::string placement_key;
-  std::string vector_hash;
-};
-
-vector_placement_result vector_compute_hash_placement(
-    const std::string& vector_bucket_name,
-    const std::string& index_name,
-    const std::string& key,
-    const bufferlist& vector_data)
-{
-  (void)key;
-  // Provisional vector-derived placement. The final LSH/hybrid policy should
-  // replace this helper without changing the public API or storage op shape.
-  const std::string vector_hash =
-    vector_hex_u32(vector_data.crc32c(static_cast<uint32_t>(-1)));
-  const std::string placement_key = vector_hash.substr(0, 4);
-  const std::string oid =
-    ".rados.vector/v1/" + std::string(vector_placement_algorithm) + "/" +
-    vector_hash_string(vector_bucket_name) + "/" +
-    vector_hash_string(index_name) + "/" +
-    placement_key;
-
-  return {object_t(oid), placement_key, vector_hash};
-}
 
 } // anonymous namespace
 
@@ -703,12 +663,6 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
     return -EINVAL;
   }
 
-  const auto placement = vector_compute_hash_placement(
-      vector_bucket_name, index_name, key, vector_data);
-
-  ::ObjectOperation op;
-  prepare_assert_ops(&op);
-
   ceph::rados::put_vector_request_t req;
   req.bucket_name = vector_bucket_name;
   req.index_name = index_name;
@@ -718,15 +672,43 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   req.dimension = dimension;
   req.vector_data = vector_data;
   req.metadata = metadata;
-  req.placement_algorithm = vector_placement_algorithm;
-  req.placement_key = placement.placement_key;
-  req.vector_hash = placement.vector_hash;
 
-  bufferlist payload;
-  encode(req, payload);
-  op.put_vector(payload);
+  ceph::rados::vector_index_config_t config;
+  config.data_type = encoded_data_type;
+  config.distance_metric = encoded_distance_metric;
+  config.dimension = dimension;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
 
-  return operate(placement.oid, &op, NULL);
+  librados::vector_query::put_plan_t plan;
+  r = librados::vector_query::build_put_plan(req, config, &plan);
+  if (r < 0) {
+    return r;
+  }
+
+  req.placement_algorithm = plan.placement_algorithm;
+  req.routing_policy = plan.routing_policy;
+  req.algorithm_params = plan.algorithm_params;
+
+  for (const auto& target : plan.targets) {
+    ::ObjectOperation op;
+    prepare_assert_ops(&op);
+
+    req.placement_key = target.placement_key;
+    req.vector_hash = target.vector_hash;
+
+    bufferlist payload;
+    encode(req, payload);
+    op.put_vector(payload);
+
+    r = operate(target.oid, &op, NULL);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  return 0;
 }
 
 int librados::IoCtxImpl::query_vectors(
@@ -785,13 +767,34 @@ int librados::IoCtxImpl::query_vectors(
   req.top_k = top_k;
   req.return_distance = return_distance;
   req.query_vector = query_vector;
-  req.algorithm_id = ceph::rados::vector_query_algorithm_flat;
+  req.algorithm_id = ceph::rados::vector_query_algorithm_hash;
   req.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  req.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
 
-  bufferlist payload;
-  encode(req, payload);
-  // Query planning and backend execution are intentionally added in follow-up
-  // PRs. PR1 only validates the public API and prepares the request format.
+  ceph::rados::vector_index_config_t config;
+  config.data_type = encoded_data_type;
+  config.distance_metric = encoded_distance_metric;
+  config.dimension = dimension;
+  config.algorithm_id = req.algorithm_id;
+  config.algorithm_version = req.algorithm_version;
+  config.placement_algorithm = req.placement_algorithm;
+  req.routing_policy = config.routing_policy;
+
+  librados::vector_query::query_plan_t plan;
+  r = librados::vector_query::build_query_plan(req, config, &plan);
+  if (r < 0) {
+    return r;
+  }
+
+  std::vector<librados::vector_query::routed_request_t> routed_requests;
+  r = librados::vector_query::build_routed_requests(
+      req, plan, &routed_requests);
+  if (r < 0) {
+    return r;
+  }
+
+  // PR2 stops at client-side planning and routed payload construction. PR3
+  // will add ObjectOperation/query op plumbing and backend execution.
   return -EOPNOTSUPP;
 }
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -649,14 +649,14 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   const uint32_t encoded_data_type = static_cast<uint32_t>(data_type);
   int r = ceph::rados::vector_data_type_size(encoded_data_type, &element_size);
   if (r < 0) {
-    return r;
+    return -EINVAL;
   }
 
   const uint32_t encoded_distance_metric =
     static_cast<uint32_t>(distance_metric);
   if (!ceph::rados::vector_distance_metric_supported(
         encoded_distance_metric)) {
-    return -EOPNOTSUPP;
+    return -EINVAL;
   }
 
   const size_t expected_len = static_cast<size_t>(dimension) * element_size;

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -21,6 +21,7 @@
 #include "librados/librados_util.h"
 
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <map>
 #include <set>
@@ -1377,10 +1378,40 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_query_vectors)(
   bufferlist query_bl;
   query_bl.append(static_cast<const char *>(query_vector), query_vector_len);
   std::vector<librados::query_vectors_result_entry> entries;
-  return ctx->query_vectors(vector_bucket_name, index_name,
-			    data_type, distance_metric, dimension,
-			    query_bl, top_k, return_distance != 0,
-			    &entries);
+  int ret = ctx->query_vectors(vector_bucket_name, index_name,
+			       data_type, distance_metric, dimension,
+			       query_bl, top_k, return_distance != 0,
+			       &entries);
+  if (ret < 0) {
+    return ret;
+  }
+  if (entries.empty()) {
+    return 0;
+  }
+
+  result->entries = static_cast<rados_query_vectors_result_entry_t *>(
+      calloc(entries.size(), sizeof(*result->entries)));
+  if (result->entries == nullptr) {
+    return -ENOMEM;
+  }
+  result->entries_len = entries.size();
+
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const size_t key_len = entries[i].key.length();
+    result->entries[i].key = static_cast<char *>(malloc(key_len + 1));
+    if (result->entries[i].key == nullptr) {
+      for (size_t j = 0; j < i; ++j) {
+	free(result->entries[j].key);
+      }
+      free(result->entries);
+      result->entries = nullptr;
+      result->entries_len = 0;
+      return -ENOMEM;
+    }
+    memcpy(result->entries[i].key, entries[i].key.c_str(), key_len + 1);
+    result->entries[i].distance = entries[i].distance;
+  }
+  return 0;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_query_vectors);
 

--- a/src/librados/vector_placement.h
+++ b/src/librados/vector_placement.h
@@ -11,11 +11,13 @@
 #include "include/buffer.h"
 #include "include/ceph_hash.h"
 #include "include/object.h"
+#include "include/rados/vector_ops.h"
 
 namespace librados {
 namespace vector_placement {
 
-inline constexpr const char *hash_v0_algorithm = "hash-v0";
+inline constexpr const char *hash_v0_algorithm =
+  ceph::rados::vector_placement_algorithm_hash_v0;
 
 struct hash_v0_placement_t {
   object_t oid;

--- a/src/librados/vector_placement.h
+++ b/src/librados/vector_placement.h
@@ -1,0 +1,104 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_LIBRADOS_VECTOR_PLACEMENT_H
+#define CEPH_LIBRADOS_VECTOR_PLACEMENT_H
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include "include/buffer.h"
+#include "include/ceph_hash.h"
+#include "include/object.h"
+
+namespace librados {
+namespace vector_placement {
+
+inline constexpr const char *hash_v0_algorithm = "hash-v0";
+
+struct hash_v0_placement_t {
+  object_t oid;
+  std::string placement_key;
+  std::string vector_hash;
+};
+
+inline std::string hex_u32(uint32_t value)
+{
+  char buf[9];
+  std::snprintf(buf, sizeof(buf), "%08x", value);
+  return std::string(buf);
+}
+
+inline std::string hash_string(const std::string& value)
+{
+  return hex_u32(ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+inline uint32_t hash_to_u32(const std::string& value)
+{
+  return ceph_str_hash_rjenkins(
+      value.c_str(), static_cast<unsigned>(value.length()));
+}
+
+inline std::string hash_v0_vector_hash(const ceph::bufferlist& vector_data)
+{
+  return hex_u32(vector_data.crc32c(static_cast<uint32_t>(-1)));
+}
+
+inline std::string hash_v0_placement_key(const std::string& vector_hash)
+{
+  return vector_hash.substr(0, 4);
+}
+
+inline object_t make_algorithm_oid(const std::string& placement_algorithm,
+                                   const std::string& bucket_name,
+                                   const std::string& index_name,
+                                   const std::string& placement_key)
+{
+  return object_t(
+      ".rados.vector/v1/" + placement_algorithm + "/" +
+      hash_string(bucket_name) + "/" + hash_string(index_name) + "/" +
+      placement_key);
+}
+
+inline object_t make_hash_v0_oid(const std::string& bucket_name,
+                                 const std::string& index_name,
+                                 const std::string& placement_key)
+{
+  return make_algorithm_oid(
+      hash_v0_algorithm, bucket_name, index_name, placement_key);
+}
+
+inline hash_v0_placement_t compute_hash_v0_placement(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    const ceph::bufferlist& vector_data)
+{
+  const std::string vector_hash = hash_v0_vector_hash(vector_data);
+  const std::string placement_key = hash_v0_placement_key(vector_hash);
+  return {
+    make_hash_v0_oid(bucket_name, index_name, placement_key),
+    placement_key,
+    vector_hash,
+  };
+}
+
+inline std::string ranked_hash_v0_placement_key(
+    const std::string& vector_hash,
+    uint32_t rank)
+{
+  if (rank == 0) {
+    return hash_v0_placement_key(vector_hash);
+  }
+  std::string value = vector_hash;
+  value.push_back('\0');
+  value.append(std::to_string(rank));
+  return hash_v0_placement_key(hex_u32(hash_to_u32(value)));
+}
+
+} // namespace vector_placement
+} // namespace librados
+
+#endif

--- a/src/librados/vector_query_planner.h
+++ b/src/librados/vector_query_planner.h
@@ -30,6 +30,18 @@ struct probe_t {
   std::string placement_key;
 };
 
+struct query_request_t {
+  // librados-side query input. Planner-only fields live in
+  // vector_index_config_t/query_plan_t and are not encoded into OSD requests.
+  std::string bucket_name;
+  std::string index_name;
+  uint32_t data_type = 0;
+  uint32_t distance_metric = 0;
+  uint32_t dimension = 0;
+  uint32_t top_k = 0;
+  ceph::bufferlist query_vector;
+};
+
 struct put_plan_t {
   uint32_t algorithm_id = 0;
   uint32_t algorithm_version = 0;
@@ -186,12 +198,12 @@ inline int build_put_plan(
 }
 
 inline int build_query_plan(
-    const ceph::rados::query_vectors_request_t& req,
+    const query_request_t& req,
     const ceph::rados::vector_index_config_t& config,
     query_plan_t *plan)
 {
   if (plan == nullptr || req.bucket_name.empty() || req.index_name.empty() ||
-      req.query_vector.length() == 0) {
+      req.top_k == 0 || req.query_vector.length() == 0) {
     return -EINVAL;
   }
 
@@ -209,7 +221,7 @@ inline int build_query_plan(
   }
 
   const std::string placement_algorithm =
-    effective_placement_algorithm(config, req.placement_algorithm);
+    effective_placement_algorithm(config);
   if (placement_algorithm.empty()) {
     return -EOPNOTSUPP;
   }
@@ -243,29 +255,27 @@ inline int build_query_plan(
 }
 
 inline int build_query_plan(
-    const ceph::rados::query_vectors_request_t& req,
+    const query_request_t& req,
     query_plan_t *plan)
 {
   ceph::rados::vector_index_config_t config;
   config.data_type = req.data_type;
   config.distance_metric = req.distance_metric;
   config.dimension = req.dimension;
-  config.algorithm_id = req.algorithm_id;
-  config.algorithm_version = req.algorithm_version;
-  config.placement_algorithm = req.placement_algorithm;
-  config.routing_policy = req.routing_policy;
-  config.algorithm_params = req.algorithm_params;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  config.placement_algorithm = vector_placement::hash_v0_algorithm;
   return build_query_plan(req, config, plan);
 }
 
-inline int build_plan(const ceph::rados::query_vectors_request_t& req,
+inline int build_plan(const query_request_t& req,
                       plan_t *plan)
 {
   return build_query_plan(req, plan);
 }
 
 inline int build_routed_requests(
-    const ceph::rados::query_vectors_request_t& req,
+    const query_request_t& req,
     const query_plan_t& plan,
     std::vector<routed_request_t> *requests)
 {
@@ -278,13 +288,15 @@ inline int build_routed_requests(
   }
 
   for (const auto& probe : plan.probes) {
-    ceph::rados::query_vectors_request_t probe_req = req;
-    probe_req.algorithm_id = plan.algorithm_id;
-    probe_req.algorithm_version = plan.algorithm_version;
-    probe_req.placement_algorithm = plan.placement_algorithm;
-    probe_req.routing_policy = plan.routing_policy;
-    probe_req.algorithm_params = plan.algorithm_params;
-    probe_req.probe_prefixes.clear();
+    ceph::rados::query_vectors_request_t probe_req;
+    probe_req.bucket_name = req.bucket_name;
+    probe_req.index_name = req.index_name;
+    probe_req.data_type = req.data_type;
+    probe_req.distance_metric = req.distance_metric;
+    probe_req.dimension = req.dimension;
+    probe_req.local_top_k = plan.routing_policy.local_topk != 0 ?
+      plan.routing_policy.local_topk : req.top_k;
+    probe_req.query_vector = req.query_vector;
     probe_req.probe_prefixes.push_back(probe.placement_key);
 
     ceph::bufferlist payload;

--- a/src/librados/vector_query_planner.h
+++ b/src/librados/vector_query_planner.h
@@ -139,6 +139,9 @@ inline int append_hash_v0_targets(
   if (targets == nullptr || count == 0) {
     return -EINVAL;
   }
+  // hash-v0 is the baseline placement contract: it hashes vector bytes, uses
+  // a hash-derived prefix as the placement key, and builds an object id from
+  // bucket/index/placement_key. It is not an ANN planner.
   const std::string vector_hash =
     vector_placement::hash_v0_vector_hash(vector_data);
   for (uint32_t rank = 0; rank < count; ++rank) {

--- a/src/librados/vector_query_planner.h
+++ b/src/librados/vector_query_planner.h
@@ -1,0 +1,304 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_LIBRADOS_VECTOR_QUERY_PLANNER_H
+#define CEPH_LIBRADOS_VECTOR_QUERY_PLANNER_H
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <errno.h>
+
+#include "include/buffer.h"
+#include "include/object.h"
+#include "include/rados/vector_ops.h"
+#include "librados/vector_placement.h"
+
+namespace librados {
+namespace vector_query {
+
+struct put_target_t {
+  object_t oid;
+  std::string placement_key;
+  std::string vector_hash;
+};
+
+struct probe_t {
+  object_t oid;
+  std::string placement_key;
+};
+
+struct put_plan_t {
+  uint32_t algorithm_id = 0;
+  uint32_t algorithm_version = 0;
+  std::string placement_algorithm;
+  ceph::rados::vector_routing_policy_t routing_policy;
+  ceph::bufferlist algorithm_params;
+  std::vector<put_target_t> targets;
+};
+
+struct query_plan_t {
+  uint32_t algorithm_id = 0;
+  uint32_t algorithm_version = 0;
+  std::string placement_algorithm;
+  ceph::rados::vector_routing_policy_t routing_policy;
+  ceph::bufferlist algorithm_params;
+  std::vector<probe_t> probes;
+};
+
+using plan_t = query_plan_t;
+
+struct routed_request_t {
+  object_t oid;
+  std::string placement_key;
+  ceph::bufferlist payload;
+};
+
+inline ceph::rados::vector_routing_policy_t normalize_routing_policy(
+    ceph::rados::vector_routing_policy_t policy)
+{
+  if (policy.write_pgs == 0) {
+    policy.write_pgs = 1;
+  }
+  if (policy.probe_pgs == 0) {
+    policy.probe_pgs = 1;
+  }
+  return policy;
+}
+
+inline std::string default_placement_algorithm(uint32_t algorithm_id)
+{
+  switch (algorithm_id) {
+  case ceph::rados::vector_query_algorithm_hash:
+    return vector_placement::hash_v0_algorithm;
+  default:
+    return std::string();
+  }
+}
+
+inline std::string effective_placement_algorithm(
+    const ceph::rados::vector_index_config_t& config,
+    const std::string& request_algorithm = std::string())
+{
+  if (!config.placement_algorithm.empty()) {
+    return config.placement_algorithm;
+  }
+  if (!request_algorithm.empty()) {
+    return request_algorithm;
+  }
+  return default_placement_algorithm(config.algorithm_id);
+}
+
+inline int validate_index_config(
+    uint32_t req_data_type,
+    uint32_t req_distance_metric,
+    uint32_t req_dimension,
+    const ceph::rados::vector_index_config_t& config)
+{
+  if (config.algorithm_version !=
+      ceph::rados::vector_query_algorithm_version_0) {
+    return -EOPNOTSUPP;
+  }
+  if (config.algorithm_id != ceph::rados::vector_query_algorithm_hash) {
+    return -EOPNOTSUPP;
+  }
+  if (config.data_type != 0 && config.data_type != req_data_type) {
+    return -EINVAL;
+  }
+  if (config.distance_metric != 0 &&
+      config.distance_metric != req_distance_metric) {
+    return -EINVAL;
+  }
+  if (config.dimension != 0 && config.dimension != req_dimension) {
+    return -EINVAL;
+  }
+  return 0;
+}
+
+inline int append_hash_v0_targets(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    const ceph::bufferlist& vector_data,
+    uint32_t count,
+    std::vector<put_target_t> *targets)
+{
+  if (targets == nullptr || count == 0) {
+    return -EINVAL;
+  }
+  const std::string vector_hash =
+    vector_placement::hash_v0_vector_hash(vector_data);
+  for (uint32_t rank = 0; rank < count; ++rank) {
+    const std::string placement_key =
+      vector_placement::ranked_hash_v0_placement_key(vector_hash, rank);
+    targets->push_back({
+      vector_placement::make_hash_v0_oid(
+          bucket_name, index_name, placement_key),
+      placement_key,
+      vector_hash,
+    });
+  }
+  return 0;
+}
+
+inline int build_put_plan(
+    const ceph::rados::put_vector_request_t& req,
+    const ceph::rados::vector_index_config_t& config,
+    put_plan_t *plan)
+{
+  if (plan == nullptr || req.bucket_name.empty() || req.index_name.empty() ||
+      req.key.empty() || req.vector_data.length() == 0) {
+    return -EINVAL;
+  }
+
+  plan->algorithm_id = 0;
+  plan->algorithm_version = 0;
+  plan->placement_algorithm.clear();
+  plan->routing_policy = ceph::rados::vector_routing_policy_t();
+  plan->algorithm_params.clear();
+  plan->targets.clear();
+
+  int r = validate_index_config(
+      req.data_type, req.distance_metric, req.dimension, config);
+  if (r < 0) {
+    return r;
+  }
+
+  const std::string placement_algorithm =
+    effective_placement_algorithm(config, req.placement_algorithm);
+  if (placement_algorithm.empty()) {
+    return -EOPNOTSUPP;
+  }
+
+  plan->algorithm_id = config.algorithm_id;
+  plan->algorithm_version = config.algorithm_version;
+  plan->placement_algorithm = placement_algorithm;
+  plan->routing_policy = normalize_routing_policy(config.routing_policy);
+  plan->algorithm_params = config.algorithm_params;
+
+  if (placement_algorithm == vector_placement::hash_v0_algorithm) {
+    return append_hash_v0_targets(
+        req.bucket_name, req.index_name, req.vector_data,
+        plan->routing_policy.write_pgs, &plan->targets);
+  }
+  return -EOPNOTSUPP;
+}
+
+inline int build_query_plan(
+    const ceph::rados::query_vectors_request_t& req,
+    const ceph::rados::vector_index_config_t& config,
+    query_plan_t *plan)
+{
+  if (plan == nullptr || req.bucket_name.empty() || req.index_name.empty() ||
+      req.query_vector.length() == 0) {
+    return -EINVAL;
+  }
+
+  plan->algorithm_id = 0;
+  plan->algorithm_version = 0;
+  plan->placement_algorithm.clear();
+  plan->routing_policy = ceph::rados::vector_routing_policy_t();
+  plan->algorithm_params.clear();
+  plan->probes.clear();
+
+  int r = validate_index_config(
+      req.data_type, req.distance_metric, req.dimension, config);
+  if (r < 0) {
+    return r;
+  }
+
+  const std::string placement_algorithm =
+    effective_placement_algorithm(config, req.placement_algorithm);
+  if (placement_algorithm.empty()) {
+    return -EOPNOTSUPP;
+  }
+
+  plan->algorithm_id = config.algorithm_id;
+  plan->algorithm_version = config.algorithm_version;
+  plan->placement_algorithm = placement_algorithm;
+  plan->routing_policy = normalize_routing_policy(config.routing_policy);
+  plan->algorithm_params = config.algorithm_params;
+
+  std::vector<put_target_t> targets;
+  if (placement_algorithm == vector_placement::hash_v0_algorithm) {
+    r = append_hash_v0_targets(
+        req.bucket_name, req.index_name, req.query_vector,
+        plan->routing_policy.probe_pgs, &targets);
+  } else {
+    return -EOPNOTSUPP;
+  }
+  if (r < 0) {
+    return r;
+  }
+
+  plan->probes.reserve(targets.size());
+  for (const auto& target : targets) {
+    plan->probes.push_back({
+      target.oid,
+      target.placement_key,
+    });
+  }
+  return 0;
+}
+
+inline int build_query_plan(
+    const ceph::rados::query_vectors_request_t& req,
+    query_plan_t *plan)
+{
+  ceph::rados::vector_index_config_t config;
+  config.data_type = req.data_type;
+  config.distance_metric = req.distance_metric;
+  config.dimension = req.dimension;
+  config.algorithm_id = req.algorithm_id;
+  config.algorithm_version = req.algorithm_version;
+  config.placement_algorithm = req.placement_algorithm;
+  config.routing_policy = req.routing_policy;
+  config.algorithm_params = req.algorithm_params;
+  return build_query_plan(req, config, plan);
+}
+
+inline int build_plan(const ceph::rados::query_vectors_request_t& req,
+                      plan_t *plan)
+{
+  return build_query_plan(req, plan);
+}
+
+inline int build_routed_requests(
+    const ceph::rados::query_vectors_request_t& req,
+    const query_plan_t& plan,
+    std::vector<routed_request_t> *requests)
+{
+  if (requests == nullptr) {
+    return -EINVAL;
+  }
+  requests->clear();
+  if (plan.probes.empty()) {
+    return -EINVAL;
+  }
+
+  for (const auto& probe : plan.probes) {
+    ceph::rados::query_vectors_request_t probe_req = req;
+    probe_req.algorithm_id = plan.algorithm_id;
+    probe_req.algorithm_version = plan.algorithm_version;
+    probe_req.placement_algorithm = plan.placement_algorithm;
+    probe_req.routing_policy = plan.routing_policy;
+    probe_req.algorithm_params = plan.algorithm_params;
+    probe_req.probe_prefixes.clear();
+    probe_req.probe_prefixes.push_back(probe.placement_key);
+
+    ceph::bufferlist payload;
+    encode(probe_req, payload);
+    requests->push_back({
+      probe.oid,
+      probe.placement_key,
+      std::move(payload),
+    });
+  }
+  return 0;
+}
+
+} // namespace vector_query
+} // namespace librados
+
+#endif

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7104,7 +7104,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    ObjectStore::omap_iter_seek_t::min_lower_bound(),
 	    [&scan](std::string_view key, std::string_view value) mutable {
 	      ceph::rados::vector_query_exec::consume_omap_key_value(
-		  key, value, &scan);
+		  key, value, scan);
 	      return ObjectStore::omap_iter_ret_t::NEXT;
 	    });
 	  if (scan_result < 0) {
@@ -7154,38 +7154,9 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  break;
 	}
 
-	if (req.bucket_name.empty() || req.index_name.empty() ||
-	    req.key.empty()) {
-	  result = -EINVAL;
-	  break;
-	}
-	if (req.placement_algorithm.empty() || req.placement_key.empty() ||
-	    req.vector_hash.empty()) {
-	  result = -EINVAL;
-	  break;
-	}
-	if (req.dimension == 0 ||
-	    req.dimension > ceph::rados::vector_max_dimension) {
-	  result = -EINVAL;
-	  break;
-	}
-
-	size_t element_size = 0;
-	result = ceph::rados::vector_data_type_size(
-	  req.data_type, &element_size);
+	result = ceph::rados::vector_query_exec::validate_put_request(
+	  req, true);
 	if (result < 0) {
-	  break;
-	}
-	if (!ceph::rados::vector_distance_metric_supported(
-	      req.distance_metric)) {
-	  result = -EOPNOTSUPP;
-	  break;
-	}
-
-	const size_t expected_len =
-	  static_cast<size_t>(req.dimension) * element_size;
-	if (req.vector_data.length() != expected_len) {
-	  result = -EINVAL;
 	  break;
 	}
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -39,6 +39,7 @@
 #include "common/scrub_types.h"
 #include "include/compat.h"
 #include "include/rados/vector_ops.h"
+#include "common/vector_query_exec.h"
 #include "json_spirit/json_spirit_reader.h"
 #include "json_spirit/json_spirit_value.h"
 #include "messages/MCommandReply.h"
@@ -7061,6 +7062,68 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
           std::max((uint64_t)op.extent.length, oi.size));
 	write_update_size_and_usage(ctx->delta_stats, oi, ctx->modified_ranges,
 	    0, op.extent.length, true);
+      }
+      break;
+
+    case CEPH_OSD_OP_QUERY_VECTORS:
+      ++ctx->num_read;
+      result = 0;
+      {
+	if (!pool.info.supports_omap()) {
+	  result = -EOPNOTSUPP;
+	  break;
+	}
+	if (op.extent.length == 0 ||
+	    op.extent.length != osd_op.indata.length()) {
+	  result = -EINVAL;
+	  break;
+	}
+
+	ceph::rados::query_vectors_request_t req;
+	try {
+	  auto reqp = osd_op.indata.cbegin();
+	  decode(req, reqp);
+	  if (!reqp.end()) {
+	    result = -EINVAL;
+	    break;
+	  }
+	} catch (const ceph::buffer::error&) {
+	  result = -EINVAL;
+	  break;
+	}
+
+	result = ceph::rados::vector_query_exec::validate_query_request(req);
+	if (result < 0) {
+	  break;
+	}
+
+	ceph::rados::vector_query_exec::omap_scan_state_t scan;
+	if (oi.is_omap()) {
+	  const auto scan_result = osd->store->omap_iterate(
+	    ch, ghobject_t(soid),
+	    ObjectStore::omap_iter_seek_t::min_lower_bound(),
+	    [&scan](std::string_view key, std::string_view value) mutable {
+	      ceph::rados::vector_query_exec::consume_omap_key_value(
+		  key, value, &scan);
+	      return ObjectStore::omap_iter_ret_t::NEXT;
+	    });
+	  if (scan_result < 0) {
+	    result = scan_result;
+	    break;
+	  }
+	}
+
+	ceph::rados::query_vectors_result_t query_result;
+	result = ceph::rados::vector_query_exec::build_local_results(
+	    req, scan, &query_result);
+	if (result < 0) {
+	  break;
+	}
+
+	encode(query_result, osd_op.outdata);
+	ctx->delta_stats.num_rd_kb +=
+	  shift_round_up(osd_op.outdata.length(), 10);
+	ctx->delta_stats.num_rd++;
       }
       break;
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -7450,6 +7450,7 @@ ostream& operator<<(ostream& out, const OSDOp& op)
     case CEPH_OSD_OP_WRITE:
     case CEPH_OSD_OP_WRITEFULL:
     case CEPH_OSD_OP_PUT_VECTOR:
+    case CEPH_OSD_OP_QUERY_VECTORS:
     case CEPH_OSD_OP_ZERO:
     case CEPH_OSD_OP_APPEND:
     case CEPH_OSD_OP_MAPEXT:

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2464,6 +2464,7 @@ void Objecter::_send_op_account(Op *op)
     case CEPH_OSD_OP_OMAPGETKEYS:
     case CEPH_OSD_OP_OMAPGETHEADER:
     case CEPH_OSD_OP_OMAPGETVALSBYKEYS:
+    case CEPH_OSD_OP_QUERY_VECTORS:
     case CEPH_OSD_OP_OMAP_CMP: code = l_osdc_osdop_omap_rd; break;
 
     // OMAP write operations

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -599,6 +599,16 @@ struct ObjectOperation {
   void put_vector(ceph::buffer::list&& bl) {
     add_data(CEPH_OSD_OP_PUT_VECTOR, 0, bl.length(), bl);
   }
+  void query_vectors(ceph::buffer::list& bl, ceph::buffer::list *outbl,
+		     int *prval) {
+    add_data(CEPH_OSD_OP_QUERY_VECTORS, 0, bl.length(), bl);
+    out_bl.back() = outbl;
+    out_rval.back() = prval;
+  }
+  void query_vectors(ceph::buffer::list&& bl, ceph::buffer::list *outbl,
+		     int *prval) {
+    query_vectors(bl, outbl, prval);
+  }
   void writesame(uint64_t off, uint64_t write_len, ceph::buffer::list& bl) {
     add_writesame(CEPH_OSD_OP_WRITESAME, off, write_len, bl);
   }

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -110,6 +110,12 @@ TEST_F(LibRadosIo, PutVector) {
       4, nullptr, sizeof(vector), metadata, sizeof(metadata)));
 
   ASSERT_EQ(-EINVAL, rados_put_vector(
+      ioctx, "bucket", "index", "empty-vector",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, 0, metadata, sizeof(metadata)));
+
+  ASSERT_EQ(-EINVAL, rados_put_vector(
       ioctx, "bucket", "", "empty-index",
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
@@ -121,13 +127,13 @@ TEST_F(LibRadosIo, PutVector) {
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), metadata, sizeof(metadata)));
 
-  ASSERT_EQ(-EOPNOTSUPP, rados_put_vector(
+  ASSERT_EQ(-EINVAL, rados_put_vector(
       ioctx, "bucket", "index", "bad-type",
       static_cast<rados_vector_data_type_t>(999),
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), metadata, sizeof(metadata)));
 
-  ASSERT_EQ(-EOPNOTSUPP, rados_put_vector(
+  ASSERT_EQ(-EINVAL, rados_put_vector(
       ioctx, "bucket", "index", "bad-metric",
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       static_cast<rados_vector_distance_metric_t>(999),

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -138,8 +138,8 @@ TEST_F(LibRadosIo, QueryVectorsValidation) {
   float vector[] = {1.0, 2.0, 3.0, 4.0};
   rados_query_vectors_result_t result = {};
 
-  ASSERT_EQ(-EOPNOTSUPP, rados_query_vectors(
-      ioctx, "bucket", "index",
+  ASSERT_EQ(0, rados_query_vectors(
+      ioctx, "empty-query-bucket", "empty-query-index",
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), 10, 1, &result));
@@ -188,6 +188,31 @@ TEST_F(LibRadosIo, QueryVectorsValidation) {
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector) - 1, 10, 1, &result));
+}
+
+TEST_F(LibRadosIo, QueryVectors) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  const char metadata[] = "query-metadata";
+
+  ASSERT_EQ(0, rados_put_vector(
+      ioctx, "query-bucket", "query-index", "vec-c",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata, sizeof(metadata)));
+
+  rados_query_vectors_result_t result = {};
+  ASSERT_EQ(0, rados_query_vectors(
+      ioctx, "query-bucket", "query-index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, 1, &result));
+  ASSERT_NE(nullptr, result.entries);
+  ASSERT_EQ(1u, result.entries_len);
+  ASSERT_STREQ("vec-c", result.entries[0].key);
+  EXPECT_NEAR(0.0f, result.entries[0].distance, 1e-6f);
+  rados_query_vectors_result_release(&result);
+  ASSERT_EQ(nullptr, result.entries);
+  ASSERT_EQ(0u, result.entries_len);
 }
 
 TEST_F(LibRadosIo, TooBig) {

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -66,6 +66,20 @@ TEST_F(LibRadosIo, PutVector) {
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), metadata, sizeof(metadata)));
 
+  rados_query_vectors_result_t query_result = {};
+  ASSERT_EQ(0, rados_query_vectors(
+      ioctx, "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 1, 1, &query_result));
+  ASSERT_NE(nullptr, query_result.entries);
+  ASSERT_EQ(1u, query_result.entries_len);
+  ASSERT_STREQ("vec-1", query_result.entries[0].key);
+  EXPECT_NEAR(0.0f, query_result.entries[0].distance, 1e-6f);
+  rados_query_vectors_result_release(&query_result);
+  ASSERT_EQ(nullptr, query_result.entries);
+  ASSERT_EQ(0u, query_result.entries_len);
+
   const string oid = vector_test_oid("bucket", "index", "vec-1",
                                      vector, sizeof(vector));
   bufferlist vector_bl;

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <algorithm>
 #include <climits>
 #include <cstdio>
 #include <errno.h>
@@ -12,6 +13,7 @@
 #include "include/encoding.h"
 #include "include/err.h"
 #include "include/scope_guard.h"
+#include "common/vector_query_exec.h"
 #include "librados/vector_placement.h"
 #include "librados/vector_query_planner.h"
 #include "test/librados/test_cxx.h"
@@ -64,22 +66,19 @@ static string vector_entry_id(const string& bucket, const string& index,
       value.c_str(), static_cast<unsigned>(value.length())));
 }
 
-static ceph::rados::query_vectors_request_t make_query_planner_request(
+static librados::vector_query::query_request_t make_query_planner_request(
     const string& bucket,
     const string& index,
     const bufferlist& query_vector)
 {
-  ceph::rados::query_vectors_request_t req;
+  librados::vector_query::query_request_t req;
   req.bucket_name = bucket;
   req.index_name = index;
   req.data_type = LIBRADOS_VECTOR_DATA_TYPE_FLOAT32;
   req.distance_metric = LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE;
   req.dimension = 4;
   req.top_k = 10;
-  req.return_distance = true;
   req.query_vector = query_vector;
-  req.algorithm_id = ceph::rados::vector_query_algorithm_hash;
-  req.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
   return req;
 }
 
@@ -98,6 +97,8 @@ TEST(VectorQueryPlanner, HashV0DeterministicRouting) {
   EXPECT_EQ(ceph::rados::vector_query_algorithm_hash, plan1.algorithm_id);
   EXPECT_EQ(ceph::rados::vector_query_algorithm_version_0,
             plan1.algorithm_version);
+  EXPECT_EQ(librados::vector_placement::hash_v0_algorithm,
+            plan1.placement_algorithm);
   EXPECT_EQ(plan1.probes[0].oid.name, plan2.probes[0].oid.name);
   EXPECT_EQ(plan1.probes[0].placement_key,
             plan2.probes[0].placement_key);
@@ -126,6 +127,12 @@ TEST(VectorQueryPlanner, HashV0DeterministicRouting) {
   ceph::rados::query_vectors_request_t routed_req;
   auto payload_iter = requests[0].payload.cbegin();
   decode(routed_req, payload_iter);
+  ASSERT_TRUE(payload_iter.end());
+  EXPECT_EQ("bucket", routed_req.bucket_name);
+  EXPECT_EQ("index", routed_req.index_name);
+  EXPECT_EQ(4u, routed_req.dimension);
+  EXPECT_EQ(10u, routed_req.local_top_k);
+  EXPECT_EQ(query_bl.length(), routed_req.query_vector.length());
   ASSERT_EQ(1u, routed_req.probe_prefixes.size());
   EXPECT_EQ(requests[0].placement_key, routed_req.probe_prefixes[0]);
   EXPECT_EQ(0, ceph::rados::vector_query_exec::validate_query_request(
@@ -517,6 +524,12 @@ TEST_F(LibRadosIoPP, PutVectorPP) {
       4, nullptr, sizeof(vector), metadata));
 
   ASSERT_EQ(-EINVAL, ioctx.put_vector(
+      "bucket", "index", "empty-vector",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, 0, metadata));
+
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
       "bucket", "", "empty-index",
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
@@ -528,13 +541,13 @@ TEST_F(LibRadosIoPP, PutVectorPP) {
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), metadata));
 
-  ASSERT_EQ(-EOPNOTSUPP, ioctx.put_vector(
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
       "bucket", "index", "bad-type",
       static_cast<rados_vector_data_type_t>(999),
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), metadata));
 
-  ASSERT_EQ(-EOPNOTSUPP, ioctx.put_vector(
+  ASSERT_EQ(-EINVAL, ioctx.put_vector(
       "bucket", "index", "bad-metric",
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       static_cast<rados_vector_distance_metric_t>(999),

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -451,6 +451,18 @@ TEST_F(LibRadosIoPP, PutVectorPP) {
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), metadata));
 
+  std::vector<query_vectors_result_entry> query_results;
+  ASSERT_EQ(0, ioctx.query_vectors(
+      "bucket", "index",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 2, true, &query_results));
+  ASSERT_EQ(2u, query_results.size());
+  EXPECT_EQ("vec-pp", query_results[0].key);
+  EXPECT_EQ("vec-pp-2", query_results[1].key);
+  EXPECT_NEAR(0.0f, query_results[0].distance, 1e-6f);
+  EXPECT_NEAR(0.0f, query_results[1].distance, 1e-6f);
+
   const string oid = vector_test_oid("bucket", "index", "vec-pp", vector_bl);
   const string entry_id = vector_entry_id("bucket", "index", "vec-pp");
   const string entry_id2 = vector_entry_id("bucket", "index", "vec-pp-2");

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -12,6 +12,8 @@
 #include "include/encoding.h"
 #include "include/err.h"
 #include "include/scope_guard.h"
+#include "librados/vector_placement.h"
+#include "librados/vector_query_planner.h"
 #include "test/librados/test_cxx.h"
 #include "test/librados/testcase_cxx.h"
 
@@ -60,6 +62,136 @@ static string vector_entry_id(const string& bucket, const string& index,
   value.append(key);
   return vector_hex_u32(ceph_str_hash_rjenkins(
       value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+static ceph::rados::query_vectors_request_t make_query_planner_request(
+    const string& bucket,
+    const string& index,
+    const bufferlist& query_vector)
+{
+  ceph::rados::query_vectors_request_t req;
+  req.bucket_name = bucket;
+  req.index_name = index;
+  req.data_type = LIBRADOS_VECTOR_DATA_TYPE_FLOAT32;
+  req.distance_metric = LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE;
+  req.dimension = 4;
+  req.top_k = 10;
+  req.return_distance = true;
+  req.query_vector = query_vector;
+  req.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  req.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  return req;
+}
+
+TEST(VectorQueryPlanner, HashV0DeterministicRouting) {
+  float query[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist query_bl;
+  query_bl.append(reinterpret_cast<const char *>(query), sizeof(query));
+
+  auto req = make_query_planner_request("bucket", "index", query_bl);
+  librados::vector_query::plan_t plan1;
+  librados::vector_query::plan_t plan2;
+  ASSERT_EQ(0, librados::vector_query::build_plan(req, &plan1));
+  ASSERT_EQ(0, librados::vector_query::build_plan(req, &plan2));
+  ASSERT_EQ(1u, plan1.probes.size());
+  ASSERT_EQ(1u, plan2.probes.size());
+  EXPECT_EQ(ceph::rados::vector_query_algorithm_hash, plan1.algorithm_id);
+  EXPECT_EQ(ceph::rados::vector_query_algorithm_version_0,
+            plan1.algorithm_version);
+  EXPECT_EQ(plan1.probes[0].oid.name, plan2.probes[0].oid.name);
+  EXPECT_EQ(plan1.probes[0].placement_key,
+            plan2.probes[0].placement_key);
+  const auto put_placement =
+    librados::vector_placement::compute_hash_v0_placement(
+        "bucket", "index", query_bl);
+  const auto vector_hash =
+    librados::vector_placement::hash_v0_vector_hash(query_bl);
+  EXPECT_EQ(librados::vector_placement::hash_v0_placement_key(vector_hash),
+            plan1.probes[0].placement_key);
+  EXPECT_EQ(put_placement.vector_hash, vector_hash);
+  EXPECT_EQ(put_placement.placement_key, plan1.probes[0].placement_key);
+  EXPECT_EQ(put_placement.oid.name, plan1.probes[0].oid.name);
+  EXPECT_EQ(librados::vector_placement::make_hash_v0_oid(
+      "bucket", "index", plan1.probes[0].placement_key).name,
+      plan1.probes[0].oid.name);
+
+  std::vector<librados::vector_query::routed_request_t> requests;
+  ASSERT_EQ(0, librados::vector_query::build_routed_requests(
+      req, plan1, &requests));
+  ASSERT_EQ(1u, requests.size());
+  EXPECT_EQ(plan1.probes[0].oid.name, requests[0].oid.name);
+  EXPECT_EQ(plan1.probes[0].placement_key, requests[0].placement_key);
+  EXPECT_GT(requests[0].payload.length(), 0u);
+
+  ceph::rados::query_vectors_request_t routed_req;
+  auto payload_iter = requests[0].payload.cbegin();
+  decode(routed_req, payload_iter);
+  ASSERT_EQ(1u, routed_req.probe_prefixes.size());
+  EXPECT_EQ(requests[0].placement_key, routed_req.probe_prefixes[0]);
+}
+
+TEST(VectorQueryPlanner, HashV0SeparatesBucketAndIndex) {
+  float query[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist query_bl;
+  query_bl.append(reinterpret_cast<const char *>(query), sizeof(query));
+
+  librados::vector_query::plan_t base;
+  librados::vector_query::plan_t other_bucket;
+  librados::vector_query::plan_t other_index;
+  ASSERT_EQ(0, librados::vector_query::build_plan(
+      make_query_planner_request("bucket", "index", query_bl), &base));
+  ASSERT_EQ(0, librados::vector_query::build_plan(
+      make_query_planner_request("bucket-2", "index", query_bl),
+      &other_bucket));
+  ASSERT_EQ(0, librados::vector_query::build_plan(
+      make_query_planner_request("bucket", "index-2", query_bl),
+      &other_index));
+
+  ASSERT_EQ(1u, base.probes.size());
+  ASSERT_EQ(1u, other_bucket.probes.size());
+  ASSERT_EQ(1u, other_index.probes.size());
+  EXPECT_NE(base.probes[0].oid.name, other_bucket.probes[0].oid.name);
+  EXPECT_NE(base.probes[0].oid.name, other_index.probes[0].oid.name);
+}
+
+TEST(VectorQueryPlanner, PutPlanRespectsWritePolicy) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+
+  ceph::rados::put_vector_request_t req;
+  req.bucket_name = "bucket";
+  req.index_name = "index";
+  req.key = "vec";
+  req.data_type = LIBRADOS_VECTOR_DATA_TYPE_FLOAT32;
+  req.distance_metric = LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE;
+  req.dimension = 4;
+  req.vector_data = vector_bl;
+
+  ceph::rados::vector_index_config_t config;
+  config.data_type = req.data_type;
+  config.distance_metric = req.distance_metric;
+  config.dimension = req.dimension;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  config.routing_policy.write_pgs = 3;
+
+  librados::vector_query::put_plan_t plan;
+  ASSERT_EQ(0, librados::vector_query::build_put_plan(req, config, &plan));
+  ASSERT_EQ(3u, plan.targets.size());
+  EXPECT_EQ(3u, plan.routing_policy.write_pgs);
+  EXPECT_EQ(librados::vector_placement::hash_v0_algorithm,
+            plan.placement_algorithm);
+
+  const auto placement =
+    librados::vector_placement::compute_hash_v0_placement(
+        "bucket", "index", vector_bl);
+  EXPECT_EQ(placement.oid.name, plan.targets[0].oid.name);
+  EXPECT_EQ(placement.placement_key, plan.targets[0].placement_key);
+  EXPECT_EQ(placement.vector_hash, plan.targets[0].vector_hash);
+  EXPECT_NE(plan.targets[0].placement_key, plan.targets[1].placement_key);
+  EXPECT_NE(plan.targets[1].placement_key, plan.targets[2].placement_key);
 }
 
 TEST_F(LibRadosIoPP, TooBigPP) {

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -128,6 +128,212 @@ TEST(VectorQueryPlanner, HashV0DeterministicRouting) {
   decode(routed_req, payload_iter);
   ASSERT_EQ(1u, routed_req.probe_prefixes.size());
   EXPECT_EQ(requests[0].placement_key, routed_req.probe_prefixes[0]);
+  EXPECT_EQ(0, ceph::rados::vector_query_exec::validate_query_request(
+      routed_req));
+}
+
+TEST(VectorQueryValidation, RejectsMalformedHashV0WireFields) {
+  float query[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist query_bl;
+  query_bl.append(reinterpret_cast<const char *>(query), sizeof(query));
+
+  auto req = make_query_planner_request("bucket", "index", query_bl);
+  ceph::rados::query_vectors_request_t wire_req;
+  wire_req.bucket_name = req.bucket_name;
+  wire_req.index_name = req.index_name;
+  wire_req.data_type = req.data_type;
+  wire_req.distance_metric = req.distance_metric;
+  wire_req.dimension = req.dimension;
+  wire_req.local_top_k = req.top_k;
+  wire_req.query_vector = req.query_vector;
+  wire_req.probe_prefixes.push_back("abcd");
+  ASSERT_EQ(0, ceph::rados::vector_query_exec::validate_query_request(
+      wire_req));
+
+  auto bad_prefix = wire_req;
+  bad_prefix.probe_prefixes = {"abc"};
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_query_request(
+      bad_prefix));
+
+  auto bad_prefix_case = wire_req;
+  bad_prefix_case.probe_prefixes = {"ABCd"};
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_query_request(
+      bad_prefix_case));
+
+  auto empty_prefix = wire_req;
+  empty_prefix.probe_prefixes = {""};
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_query_request(
+      empty_prefix));
+
+  auto empty_local_topk = wire_req;
+  empty_local_topk.local_top_k = 0;
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_query_request(
+      empty_local_topk));
+}
+
+TEST(VectorQueryValidation, PlannerFieldsStayOutOfWireRequest) {
+  float query[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist query_bl;
+  query_bl.append(reinterpret_cast<const char *>(query), sizeof(query));
+
+  auto req = make_query_planner_request("bucket", "index", query_bl);
+  ceph::rados::vector_index_config_t config;
+  config.data_type = req.data_type;
+  config.distance_metric = req.distance_metric;
+  config.dimension = req.dimension;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
+  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  config.routing_policy.probe_pgs = 1;
+  config.routing_policy.write_pgs = 3;
+  config.routing_policy.local_topk = 2;
+
+  librados::vector_query::query_plan_t plan;
+  ASSERT_EQ(0, librados::vector_query::build_query_plan(req, config, &plan));
+
+  std::vector<librados::vector_query::routed_request_t> requests;
+  ASSERT_EQ(0, librados::vector_query::build_routed_requests(
+      req, plan, &requests));
+  ASSERT_EQ(1u, requests.size());
+
+  ceph::rados::query_vectors_request_t routed_req;
+  auto payload_iter = requests[0].payload.cbegin();
+  decode(routed_req, payload_iter);
+  ASSERT_TRUE(payload_iter.end());
+  EXPECT_EQ(2u, routed_req.local_top_k);
+  ASSERT_EQ(1u, routed_req.probe_prefixes.size());
+  EXPECT_EQ(requests[0].placement_key, routed_req.probe_prefixes[0]);
+  EXPECT_EQ(0, ceph::rados::vector_query_exec::validate_query_request(
+      routed_req));
+}
+
+TEST(VectorPutValidation, RequiresHashV0RoutedFields) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+
+  ceph::rados::put_vector_request_t req;
+  req.bucket_name = "bucket";
+  req.index_name = "index";
+  req.key = "vec";
+  req.data_type = LIBRADOS_VECTOR_DATA_TYPE_FLOAT32;
+  req.distance_metric = LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE;
+  req.dimension = 4;
+  req.vector_data = vector_bl;
+  req.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  req.placement_key = "abcd";
+  req.vector_hash = "1234abcd";
+  ASSERT_EQ(0, ceph::rados::vector_query_exec::validate_put_request(
+      req, true));
+
+  auto bad_algorithm = req;
+  bad_algorithm.placement_algorithm.clear();
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_put_request(
+      bad_algorithm, true));
+
+  auto bad_placement_key = req;
+  bad_placement_key.placement_key = "abc";
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_put_request(
+      bad_placement_key, true));
+
+  auto bad_hash = req;
+  bad_hash.vector_hash = "1234abcg";
+  EXPECT_EQ(-EINVAL, ceph::rados::vector_query_exec::validate_put_request(
+      bad_hash, true));
+}
+
+TEST(VectorQueryResults, DedupsByEntryIdKeepingBestDistance) {
+  std::vector<ceph::rados::query_vectors_result_entry_t> entries;
+
+  ceph::rados::query_vectors_result_entry_t first;
+  first.key = "vec-a";
+  first.entry_id = "entry-a";
+  first.distance = 10.0;
+  ceph::rados::vector_query_exec::merge_result_entry(&entries, first);
+
+  ceph::rados::query_vectors_result_entry_t duplicate;
+  duplicate.key = "vec-a";
+  duplicate.entry_id = "entry-a";
+  duplicate.distance = 2.0;
+  ceph::rados::vector_query_exec::merge_result_entry(&entries, duplicate);
+
+  ceph::rados::query_vectors_result_entry_t same_key_other_entry;
+  same_key_other_entry.key = "vec-a";
+  same_key_other_entry.entry_id = "entry-b";
+  same_key_other_entry.distance = 1.0;
+  ceph::rados::vector_query_exec::merge_result_entry(
+      &entries, same_key_other_entry);
+
+  ASSERT_EQ(2u, entries.size());
+  auto entry_a = std::find_if(
+      entries.begin(), entries.end(), [](const auto& entry) {
+        return entry.entry_id == "entry-a";
+      });
+  ASSERT_NE(entries.end(), entry_a);
+  EXPECT_EQ("vec-a", entry_a->key);
+  EXPECT_EQ(2.0, entry_a->distance);
+
+  auto entry_b = std::find_if(
+      entries.begin(), entries.end(), [](const auto& entry) {
+        return entry.entry_id == "entry-b";
+      });
+  ASSERT_NE(entries.end(), entry_b);
+  EXPECT_EQ("vec-a", entry_b->key);
+  EXPECT_EQ(1.0, entry_b->distance);
+}
+
+TEST(VectorQueryExecutor, LocalTopKLimitsPartialResults) {
+  float query[] = {0.0, 0.0};
+  float near[] = {1.0, 0.0};
+  float far[] = {3.0, 4.0};
+  bufferlist query_bl;
+  bufferlist near_bl;
+  bufferlist far_bl;
+  query_bl.append(reinterpret_cast<const char *>(query), sizeof(query));
+  near_bl.append(reinterpret_cast<const char *>(near), sizeof(near));
+  far_bl.append(reinterpret_cast<const char *>(far), sizeof(far));
+
+  ceph::rados::query_vectors_request_t req;
+  req.bucket_name = "bucket";
+  req.index_name = "index";
+  req.data_type = LIBRADOS_VECTOR_DATA_TYPE_FLOAT32;
+  req.distance_metric = LIBRADOS_VECTOR_DISTANCE_METRIC_EUCLIDEAN;
+  req.dimension = 2;
+  req.local_top_k = 1;
+  req.query_vector = query_bl;
+  req.probe_prefixes.push_back("abcd");
+
+  ceph::rados::vector_query_exec::omap_scan_state_t scan;
+  ceph::rados::vector_query_exec::omap_entry_t near_entry;
+  near_entry.entry_id = "entry-near";
+  near_entry.bucket_name = req.bucket_name;
+  near_entry.index_name = req.index_name;
+  near_entry.user_key = "vec-near";
+  near_entry.content_key = "_CONTENT_near";
+  near_entry.placement_key = "abcd";
+  near_entry.data_type = req.data_type;
+  near_entry.distance_metric = req.distance_metric;
+  near_entry.dimension = req.dimension;
+  near_entry.has_data_type = true;
+  near_entry.has_distance_metric = true;
+  near_entry.has_dimension = true;
+  scan.entries[near_entry.entry_id] = near_entry;
+  scan.contents[near_entry.content_key] = near_bl;
+
+  auto far_entry = near_entry;
+  far_entry.entry_id = "entry-far";
+  far_entry.user_key = "vec-far";
+  far_entry.content_key = "_CONTENT_far";
+  scan.entries[far_entry.entry_id] = far_entry;
+  scan.contents[far_entry.content_key] = far_bl;
+
+  ceph::rados::query_vectors_result_t result;
+  ASSERT_EQ(0, ceph::rados::vector_query_exec::build_local_results(
+      req, scan, &result));
+  ASSERT_EQ(1u, result.entries.size());
+  EXPECT_EQ("entry-near", result.entries[0].entry_id);
+  EXPECT_EQ("vec-near", result.entries[0].key);
+  EXPECT_NEAR(1.0f, result.entries[0].distance, 1e-6f);
 }
 
 TEST(VectorQueryPlanner, HashV0SeparatesBucketAndIndex) {
@@ -339,8 +545,8 @@ TEST_F(LibRadosIoPP, QueryVectorsValidationPP) {
   float vector[] = {1.0, 2.0, 3.0, 4.0};
   std::vector<query_vectors_result_entry> results;
 
-  ASSERT_EQ(-EOPNOTSUPP, ioctx.query_vectors(
-      "bucket", "index",
+  ASSERT_EQ(0, ioctx.query_vectors(
+      "empty-query-bucket-pp", "empty-query-index-pp",
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector), 10, true, &results));
@@ -387,6 +593,51 @@ TEST_F(LibRadosIoPP, QueryVectorsValidationPP) {
       LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
       LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
       4, vector, sizeof(vector) - 1, 10, true, &results));
+}
+
+TEST_F(LibRadosIoPP, QueryVectorsPP) {
+  float vector[] = {1.0, 2.0, 3.0, 4.0};
+  bufferlist metadata;
+
+  ASSERT_EQ(0, ioctx.put_vector(
+      "query-bucket-pp", "query-index-pp", "vec-a",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+  ASSERT_EQ(0, ioctx.put_vector(
+      "query-bucket-pp", "query-index-pp", "vec-b",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), metadata));
+
+  std::vector<query_vectors_result_entry> results;
+  ASSERT_EQ(0, ioctx.query_vectors(
+      "query-bucket-pp", "query-index-pp",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 1, true, &results));
+  ASSERT_EQ(1u, results.size());
+  EXPECT_EQ("vec-a", results[0].key);
+  EXPECT_NEAR(0.0f, results[0].distance, 1e-6f);
+
+  ASSERT_EQ(0, ioctx.query_vectors(
+      "query-bucket-pp", "query-index-pp",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 10, true, &results));
+  ASSERT_EQ(2u, results.size());
+  EXPECT_EQ("vec-a", results[0].key);
+  EXPECT_EQ("vec-b", results[1].key);
+  EXPECT_NEAR(0.0f, results[0].distance, 1e-6f);
+  EXPECT_NEAR(0.0f, results[1].distance, 1e-6f);
+
+  ASSERT_EQ(0, ioctx.query_vectors(
+      "query-bucket-pp", "query-index-pp",
+      LIBRADOS_VECTOR_DATA_TYPE_FLOAT32,
+      LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE,
+      4, vector, sizeof(vector), 1, false, &results));
+  ASSERT_EQ(1u, results.size());
+  EXPECT_EQ(0.0f, results[0].distance);
 }
 
 TEST_F(LibRadosIoPP, ReadOpPP) {


### PR DESCRIPTION
PR1에서 추가한 query_vectors API ~~위에 실제 backend query execution으로 넘기기 전 단계인 client-side planner / request routing~~ 구조를 잡은 PR입니다

**변경 사항**
1. query_vectors planner skeleton 추가
- vector_query::plan_t
- vector_query::probe_t
- vector_query::routed_request_t
- build_plan()
- build_routed_requests()

2. hash-v0 placement 로직 분리
기존 put_vector 쪽에 있던 provisional hash placement 로직을 vector_placement.h로 분리하였습니다
put/query 양쪽에서 동일한 방식으로 oid / placement_key를 계산할 수 있도록 정리하였습니다

3. query routing payload 생성 구조 추가
query_vectors_request_t를 기반으로 probe 대상 oid를 계산, 각 probe별 routed request payload를 생성하는 구조를 추가하였습니다

4. algorithm id 정리
현재 기본 query planner는 hash-v0 기반으로 동작, bit-lsh는 planner 확장을 위해 id만 열어두고 아직 -EOPNOTSUPP로 처리

5. IoCtxImpl::query_vectors()에 planner 연결
기존 validation 이후 바로 request encode까지 --> build_plan() -> build_routed_requests() 단계까지 연결

- HashV0 deterministic routing 테스트
- bucket / index 별 routing 분리 테스트
- bit-lsh planner future work 처리 테스트

**후속 PR 계획**
PR3: OSD / Crimson / SeaStore query execution path 연결
--> routed request를 실제 OSD op로 보내고 backend에서 query request를 처리하는 경로를 붙일 예정

++
알고리즘 고도화 관련
PR3 이후에 진행하는게 괜찮을까요? 
FAISS 같은 검증된 ANN 구현 연동이나 bit-LSH / hybrid planner 구체화는 backend execution path가 붙은 뒤에 recall / 성능 기준을 잡고 별도 PR로 진행할까 합니다.