### PR TITLE
librados: add lsh-v0 vector placement and query routing

### DIFF
--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -79,6 +79,30 @@ inline bool is_hash_v0_vector_hash(std::string_view vector_hash)
   return is_lower_hex_string(vector_hash, vector_hash_v0_vector_hash_len);
 }
 
+inline bool is_lsh_v0_placement_key(std::string_view placement_key)
+{
+  return is_lower_hex_string(
+      placement_key, vector_lsh_v0_placement_key_len);
+}
+
+inline bool is_supported_placement_key(std::string_view placement_algorithm,
+                                       std::string_view placement_key)
+{
+  if (placement_algorithm == vector_placement_algorithm_hash_v0) {
+    return is_hash_v0_placement_key(placement_key);
+  }
+  if (placement_algorithm == vector_placement_algorithm_lsh_v0) {
+    return is_lsh_v0_placement_key(placement_key);
+  }
+  return false;
+}
+
+inline bool is_supported_probe_key(std::string_view placement_key)
+{
+  return is_hash_v0_placement_key(placement_key) ||
+    is_lsh_v0_placement_key(placement_key);
+}
+
 inline int validate_vector_payload(uint32_t data_type,
                                    uint32_t distance_metric,
                                    uint32_t dimension,
@@ -128,8 +152,8 @@ inline int validate_put_request(const put_vector_request_t& req,
     return 0;
   }
 
-  if (req.placement_algorithm != vector_placement_algorithm_hash_v0 ||
-      !is_hash_v0_placement_key(req.placement_key) ||
+  if (!is_supported_placement_key(req.placement_algorithm,
+                                  req.placement_key) ||
       !is_hash_v0_vector_hash(req.vector_hash)) {
     return -EINVAL;
   }
@@ -245,7 +269,7 @@ inline int validate_query_request(const query_vectors_request_t& req,
   }
 
   for (const auto& prefix : req.probe_prefixes) {
-    if (!is_hash_v0_placement_key(prefix)) {
+    if (!is_supported_probe_key(prefix)) {
       return -EINVAL;
     }
   }

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -27,10 +27,16 @@ inline constexpr uint32_t vector_distance_metric_cosine = 2;
 inline constexpr uint32_t vector_distance_metric_dot = 3;
 
 inline constexpr uint32_t vector_query_algorithm_hash = 1;
+inline constexpr uint32_t vector_query_algorithm_lsh = 2;
 inline constexpr uint32_t vector_query_algorithm_version_0 = 0;
 inline constexpr const char *vector_placement_algorithm_hash_v0 = "hash-v0";
+inline constexpr const char *vector_placement_algorithm_lsh_v0 = "lsh-v0";
 inline constexpr uint32_t vector_hash_v0_placement_key_len = 4;
 inline constexpr uint32_t vector_hash_v0_vector_hash_len = 8;
+inline constexpr uint32_t vector_lsh_v0_bits = 10;
+inline constexpr uint32_t vector_lsh_v0_max_bits = 16;
+inline constexpr uint32_t vector_lsh_v0_default_table_count = 16;
+inline constexpr uint32_t vector_lsh_v0_placement_key_len = 8;
 
 struct vector_routing_policy_t {
   // Number of placement targets to write for each vector entry.
@@ -70,7 +76,8 @@ struct vector_index_config_t {
   uint32_t distance_metric = 0;
   // Number of vector dimensions in this index; 0 accepts the request dimension.
   uint32_t dimension = 0;
-  // Planner algorithm family. The current baseline is hash-v0.
+  // Planner algorithm family. hash-v0 is a routing baseline; lsh-v0 adds
+  // semantic candidate routing while preserving the same OSD local search path.
   uint32_t algorithm_id = vector_query_algorithm_hash;
   // Planner/layout variant within algorithm_id. Version 0 is the hash-v0
   // baseline and is intentionally replaceable by future planners.

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -13,7 +13,9 @@
  *
  */
 
+#include <cstdlib>
 #include <limits.h>
+#include <memory>
 
 #include "IoCtxImpl.h"
 
@@ -46,6 +48,54 @@ namespace cb = ceph::buffer;
 
 namespace librados {
 namespace {
+
+uint32_t vector_lsh_env_u32(const char *name,
+                            uint32_t default_value,
+                            uint32_t min_value,
+                            uint32_t max_value)
+{
+  const char *value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return default_value;
+  }
+
+  char *end = nullptr;
+  const unsigned long parsed = std::strtoul(value, &end, 10);
+  if (end == value || *end != '\0') {
+    return default_value;
+  }
+  if (parsed < min_value) {
+    return min_value;
+  }
+  if (parsed > max_value) {
+    return max_value;
+  }
+  return static_cast<uint32_t>(parsed);
+}
+
+uint32_t vector_lsh_table_count()
+{
+  return vector_lsh_env_u32(
+      "CEPH_VECTOR_LSH_TABLES",
+      ceph::rados::vector_lsh_v0_default_table_count,
+      1, 0xffffU);
+}
+
+uint32_t vector_lsh_signature_bits()
+{
+  return vector_lsh_env_u32(
+      "CEPH_VECTOR_LSH_BITS",
+      ceph::rados::vector_lsh_v0_bits,
+      1, ceph::rados::vector_lsh_v0_max_bits);
+}
+
+uint32_t vector_lsh_probe_count(uint32_t table_count, uint32_t signature_bits)
+{
+  const uint32_t hamming = vector_lsh_env_u32(
+      "CEPH_VECTOR_LSH_PROBE_HAMMING", 1, 0, 1);
+  return table_count *
+    (1 + hamming * signature_bits);
+}
 
 struct CB_notify_Finish {
   CephContext *cct;
@@ -678,9 +728,15 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   config.data_type = encoded_data_type;
   config.distance_metric = encoded_distance_metric;
   config.dimension = dimension;
-  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_lsh;
   config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
-  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  config.placement_algorithm = librados::vector_placement::lsh_v0_algorithm;
+  const uint32_t lsh_signature_bits = vector_lsh_signature_bits();
+  encode(lsh_signature_bits, config.algorithm_params);
+  config.routing_policy.write_pgs = vector_lsh_table_count();
+  config.routing_policy.probe_pgs =
+    vector_lsh_probe_count(config.routing_policy.write_pgs,
+                           lsh_signature_bits);
 
   librados::vector_query::put_plan_t plan;
   r = librados::vector_query::build_put_plan(req, config, &plan);
@@ -693,6 +749,19 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   for (const auto& target : plan.targets) {
     ::ObjectOperation op;
     prepare_assert_ops(&op);
+
+    ldout(client->cct, 20) << "vector-debug put computed oid="
+				  << target.oid
+				  << " algorithm=" << req.placement_algorithm
+				  << " bucket=" << req.bucket_name
+			  << " index=" << req.index_name
+			  << " key=" << req.key
+			  << " data_type=" << req.data_type
+			  << " distance_metric=" << req.distance_metric
+			  << " dimension=" << req.dimension
+			  << " placement_key=" << target.placement_key
+			  << " vector_hash=" << target.vector_hash
+			  << dendl;
 
     req.placement_key = target.placement_key;
     req.vector_hash = target.vector_hash;
@@ -770,9 +839,15 @@ int librados::IoCtxImpl::query_vectors(
   config.data_type = encoded_data_type;
   config.distance_metric = encoded_distance_metric;
   config.dimension = dimension;
-  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_lsh;
   config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
-  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  config.placement_algorithm = librados::vector_placement::lsh_v0_algorithm;
+  const uint32_t lsh_signature_bits = vector_lsh_signature_bits();
+  encode(lsh_signature_bits, config.algorithm_params);
+  config.routing_policy.write_pgs = vector_lsh_table_count();
+  config.routing_policy.probe_pgs =
+    vector_lsh_probe_count(config.routing_policy.write_pgs,
+                           lsh_signature_bits);
 
   librados::vector_query::query_plan_t plan;
   r = librados::vector_query::build_query_plan(req, config, &plan);
@@ -787,31 +862,72 @@ int librados::IoCtxImpl::query_vectors(
     return r;
   }
 
-  ceph::rados::query_vectors_result_t merged_result;
-  for (const auto& routed_request : routed_requests) {
+  struct PendingVectorQuery {
     ::ObjectOperation op;
-    bufferlist payload = routed_request.payload;
+    bufferlist payload;
     bufferlist reply;
     int op_rval = 0;
-    op.query_vectors(payload, &reply, &op_rval);
+    int submit_ret = 0;
+    AioCompletionImpl *completion = nullptr;
+    librados::vector_query::routed_request_t routed_request;
+  };
 
-    r = operate_read(routed_request.oid, &op, &reply);
-    if (r == -ENOENT || op_rval == -ENOENT) {
+  std::vector<std::unique_ptr<PendingVectorQuery>> pending_requests;
+  pending_requests.reserve(routed_requests.size());
+  for (const auto& routed_request : routed_requests) {
+    ldout(client->cct, 20) << "vector-debug query computed oid="
+				  << routed_request.oid
+				  << " algorithm=" << plan.placement_algorithm
+				  << " bucket=" << req.bucket_name
+			  << " index=" << req.index_name
+			  << " data_type=" << req.data_type
+			  << " distance_metric=" << req.distance_metric
+			  << " dimension=" << req.dimension
+			  << " top_k=" << req.top_k
+			  << " return_distance=" << return_distance
+			  << " placement_key=" << routed_request.placement_key
+			  << dendl;
+
+    auto pending = std::make_unique<PendingVectorQuery>();
+    pending->payload = routed_request.payload;
+    pending->routed_request = routed_request;
+    pending->completion = new AioCompletionImpl;
+    pending->op.query_vectors(
+        pending->payload, &pending->reply, &pending->op_rval);
+    pending->submit_ret = aio_operate_read(
+        routed_request.oid, &pending->op, pending->completion, 0,
+        &pending->reply);
+    pending_requests.push_back(std::move(pending));
+  }
+
+  ceph::rados::query_vectors_result_t merged_result;
+  for (auto& pending : pending_requests) {
+    r = pending->submit_ret;
+    if (pending->completion != nullptr && r == 0) {
+      pending->completion->wait_for_complete();
+      r = pending->completion->get_return_value();
+    }
+    if (pending->completion != nullptr) {
+      pending->completion->release();
+      pending->completion = nullptr;
+    }
+
+    if (r == -ENOENT || pending->op_rval == -ENOENT) {
       continue;
     }
     if (r < 0) {
       return r;
     }
-    if (op_rval < 0) {
-      return op_rval;
+    if (pending->op_rval < 0) {
+      return pending->op_rval;
     }
-    if (reply.length() == 0) {
+    if (pending->reply.length() == 0) {
       continue;
     }
 
     ceph::rados::query_vectors_result_t partial_result;
     try {
-      auto p = reply.cbegin();
+      auto p = pending->reply.cbegin();
       decode(partial_result, p);
       if (!p.end()) {
         return -EIO;

--- a/src/librados/vector_placement.h
+++ b/src/librados/vector_placement.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <string>
+#include <vector>
 
 #include "include/buffer.h"
 #include "include/ceph_hash.h"
@@ -18,6 +19,8 @@ namespace vector_placement {
 
 inline constexpr const char *hash_v0_algorithm =
   ceph::rados::vector_placement_algorithm_hash_v0;
+inline constexpr const char *lsh_v0_algorithm =
+  ceph::rados::vector_placement_algorithm_lsh_v0;
 
 struct hash_v0_placement_t {
   object_t oid;
@@ -30,6 +33,16 @@ inline std::string hex_u32(uint32_t value)
   char buf[9];
   std::snprintf(buf, sizeof(buf), "%08x", value);
   return std::string(buf);
+}
+
+inline uint32_t mix_u32(uint32_t value)
+{
+  value ^= value >> 16;
+  value *= 0x7feb352dU;
+  value ^= value >> 15;
+  value *= 0x846ca68bU;
+  value ^= value >> 16;
+  return value;
 }
 
 inline std::string hash_string(const std::string& value)
@@ -73,6 +86,14 @@ inline object_t make_hash_v0_oid(const std::string& bucket_name,
       hash_v0_algorithm, bucket_name, index_name, placement_key);
 }
 
+inline object_t make_lsh_v0_oid(const std::string& bucket_name,
+                                const std::string& index_name,
+                                const std::string& placement_key)
+{
+  return make_algorithm_oid(
+      lsh_v0_algorithm, bucket_name, index_name, placement_key);
+}
+
 inline hash_v0_placement_t compute_hash_v0_placement(
     const std::string& bucket_name,
     const std::string& index_name,
@@ -98,6 +119,64 @@ inline std::string ranked_hash_v0_placement_key(
   value.push_back('\0');
   value.append(std::to_string(rank));
   return hash_v0_placement_key(hex_u32(hash_to_u32(value)));
+}
+
+
+inline int copy_float32_vector(const ceph::bufferlist& vector_data,
+                               uint32_t dimension,
+                               std::vector<float> *values)
+{
+  if (values == nullptr || dimension == 0) {
+    return -EINVAL;
+  }
+  const size_t expected_len = static_cast<size_t>(dimension) * sizeof(float);
+  if (vector_data.length() != expected_len) {
+    return -EINVAL;
+  }
+  values->resize(dimension);
+  auto p = vector_data.cbegin();
+  p.copy(expected_len, reinterpret_cast<char*>(values->data()));
+  return 0;
+}
+
+inline int lsh_v0_hyperplane_sign(uint32_t table,
+                                  uint32_t bit,
+                                  uint32_t dimension)
+{
+  const uint32_t seed =
+    table * 0x9e3779b9U ^ bit * 0x85ebca6bU ^ dimension * 0xc2b2ae35U;
+  return (mix_u32(seed) & 1U) == 0U ? -1 : 1;
+}
+
+inline uint32_t lsh_v0_signature(
+    const std::vector<float>& values,
+    uint32_t table,
+    uint32_t signature_bits = ceph::rados::vector_lsh_v0_bits)
+{
+  if (signature_bits == 0) {
+    signature_bits = ceph::rados::vector_lsh_v0_bits;
+  }
+  if (signature_bits > ceph::rados::vector_lsh_v0_max_bits) {
+    signature_bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+
+  uint32_t signature = 0;
+  for (uint32_t bit = 0; bit < signature_bits; ++bit) {
+    double projection = 0;
+    for (uint32_t dim = 0; dim < values.size(); ++dim) {
+      projection += static_cast<double>(values[dim]) *
+        lsh_v0_hyperplane_sign(table, bit, dim);
+    }
+    if (projection >= 0) {
+      signature |= 1U << bit;
+    }
+  }
+  return signature;
+}
+
+inline std::string lsh_v0_placement_key(uint32_t table, uint32_t signature)
+{
+  return hex_u32(((table & 0xffffU) << 16) | (signature & 0xffffU));
 }
 
 } // namespace vector_placement

--- a/src/librados/vector_query_planner.h
+++ b/src/librados/vector_query_planner.h
@@ -85,6 +85,8 @@ inline std::string default_placement_algorithm(uint32_t algorithm_id)
   switch (algorithm_id) {
   case ceph::rados::vector_query_algorithm_hash:
     return vector_placement::hash_v0_algorithm;
+  case ceph::rados::vector_query_algorithm_lsh:
+    return vector_placement::lsh_v0_algorithm;
   default:
     return std::string();
   }
@@ -113,7 +115,8 @@ inline int validate_index_config(
       ceph::rados::vector_query_algorithm_version_0) {
     return -EOPNOTSUPP;
   }
-  if (config.algorithm_id != ceph::rados::vector_query_algorithm_hash) {
+  if (config.algorithm_id != ceph::rados::vector_query_algorithm_hash &&
+      config.algorithm_id != ceph::rados::vector_query_algorithm_lsh) {
     return -EOPNOTSUPP;
   }
   if (config.data_type != 0 && config.data_type != req_data_type) {
@@ -127,6 +130,30 @@ inline int validate_index_config(
     return -EINVAL;
   }
   return 0;
+}
+
+inline uint32_t lsh_v0_signature_bits(
+    const ceph::bufferlist& algorithm_params)
+{
+  uint32_t bits = ceph::rados::vector_lsh_v0_bits;
+  if (algorithm_params.length() > 0) {
+    try {
+      auto p = algorithm_params.cbegin();
+      decode(bits, p);
+      if (!p.end()) {
+        bits = ceph::rados::vector_lsh_v0_bits;
+      }
+    } catch (const ceph::buffer::error&) {
+      bits = ceph::rados::vector_lsh_v0_bits;
+    }
+  }
+  if (bits == 0) {
+    bits = ceph::rados::vector_lsh_v0_bits;
+  }
+  if (bits > ceph::rados::vector_lsh_v0_max_bits) {
+    bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+  return bits;
 }
 
 inline int append_hash_v0_targets(
@@ -153,6 +180,108 @@ inline int append_hash_v0_targets(
       placement_key,
       vector_hash,
     });
+  }
+  return 0;
+}
+
+inline int append_lsh_v0_write_targets(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    const ceph::bufferlist& vector_data,
+    uint32_t dimension,
+    uint32_t table_count,
+    uint32_t signature_bits,
+    std::vector<put_target_t> *targets)
+{
+  if (targets == nullptr || table_count == 0 || table_count > 0xffffU) {
+    return -EINVAL;
+  }
+
+  std::vector<float> values;
+  int r = vector_placement::copy_float32_vector(vector_data, dimension, &values);
+  if (r < 0) {
+    return r;
+  }
+
+  const std::string vector_hash =
+    vector_placement::hash_v0_vector_hash(vector_data);
+  for (uint32_t table = 0; table < table_count; ++table) {
+    const uint32_t signature =
+      vector_placement::lsh_v0_signature(values, table, signature_bits);
+    const std::string placement_key =
+      vector_placement::lsh_v0_placement_key(table, signature);
+    targets->push_back({
+      vector_placement::make_lsh_v0_oid(
+          bucket_name, index_name, placement_key),
+      placement_key,
+      vector_hash,
+    });
+  }
+  return 0;
+}
+
+inline void append_lsh_v0_query_target(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    uint32_t table,
+    uint32_t signature,
+    const std::string& vector_hash,
+    std::vector<put_target_t> *targets)
+{
+  const std::string placement_key =
+    vector_placement::lsh_v0_placement_key(table, signature);
+  targets->push_back({
+    vector_placement::make_lsh_v0_oid(bucket_name, index_name, placement_key),
+    placement_key,
+    vector_hash,
+  });
+}
+
+inline int append_lsh_v0_query_targets(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    const ceph::bufferlist& query_vector,
+    uint32_t dimension,
+    uint32_t table_count,
+    uint32_t signature_bits,
+    uint32_t probe_limit,
+    std::vector<put_target_t> *targets)
+{
+  if (targets == nullptr || table_count == 0 || table_count > 0xffffU ||
+      probe_limit == 0) {
+    return -EINVAL;
+  }
+
+  std::vector<float> values;
+  int r = vector_placement::copy_float32_vector(query_vector, dimension, &values);
+  if (r < 0) {
+    return r;
+  }
+
+  const std::string vector_hash =
+    vector_placement::hash_v0_vector_hash(query_vector);
+  std::vector<uint32_t> signatures;
+  signatures.reserve(table_count);
+  for (uint32_t table = 0; table < table_count; ++table) {
+    signatures.push_back(vector_placement::lsh_v0_signature(
+        values, table, signature_bits));
+    append_lsh_v0_query_target(
+        bucket_name, index_name, table, signatures.back(), vector_hash,
+        targets);
+    if (targets->size() >= probe_limit) {
+      return 0;
+    }
+  }
+
+  for (uint32_t bit = 0; bit < signature_bits; ++bit) {
+    for (uint32_t table = 0; table < table_count; ++table) {
+      append_lsh_v0_query_target(
+          bucket_name, index_name, table, signatures[table] ^ (1U << bit),
+          vector_hash, targets);
+      if (targets->size() >= probe_limit) {
+        return 0;
+      }
+    }
   }
   return 0;
 }
@@ -196,6 +325,12 @@ inline int build_put_plan(
     return append_hash_v0_targets(
         req.bucket_name, req.index_name, req.vector_data,
         plan->routing_policy.write_pgs, &plan->targets);
+  } else if (placement_algorithm == vector_placement::lsh_v0_algorithm) {
+    const uint32_t signature_bits =
+      lsh_v0_signature_bits(config.algorithm_params);
+    return append_lsh_v0_write_targets(
+        req.bucket_name, req.index_name, req.vector_data, req.dimension,
+        plan->routing_policy.write_pgs, signature_bits, &plan->targets);
   }
   return -EOPNOTSUPP;
 }
@@ -239,6 +374,13 @@ inline int build_query_plan(
   if (placement_algorithm == vector_placement::hash_v0_algorithm) {
     r = append_hash_v0_targets(
         req.bucket_name, req.index_name, req.query_vector,
+        plan->routing_policy.probe_pgs, &targets);
+  } else if (placement_algorithm == vector_placement::lsh_v0_algorithm) {
+    const uint32_t signature_bits =
+      lsh_v0_signature_bits(config.algorithm_params);
+    r = append_lsh_v0_query_targets(
+        req.bucket_name, req.index_name, req.query_vector, req.dimension,
+        plan->routing_policy.write_pgs, signature_bits,
         plan->routing_policy.probe_pgs, &targets);
   } else {
     return -EOPNOTSUPP;

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -3,11 +3,13 @@
 
 #include <climits>
 #include <cstdio>
+#include <vector>
 
 #include "include/rados/librados.h"
 #include "include/ceph_hash.h"
 #include "include/encoding.h"
 #include "include/err.h"
+#include "librados/vector_placement.h"
 #include "include/scope_guard.h"
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
@@ -28,12 +30,6 @@ static string vector_hex_u32(uint32_t value)
   return string(buf);
 }
 
-static string vector_hash_string(const string& value)
-{
-  return vector_hex_u32(ceph_str_hash_rjenkins(
-      value.c_str(), static_cast<unsigned>(value.length())));
-}
-
 static string vector_test_oid(const string& bucket, const string& index,
                               const string& key, const void *vector_data,
                               size_t vector_data_len)
@@ -41,11 +37,16 @@ static string vector_test_oid(const string& bucket, const string& index,
   (void)key;
   bufferlist bl;
   bl.append(static_cast<const char *>(vector_data), vector_data_len);
-  const string vector_hash =
-    vector_hex_u32(bl.crc32c(static_cast<uint32_t>(-1)));
-  const string placement_key = vector_hash.substr(0, 4);
-  return ".rados.vector/v1/hash-v0/" + vector_hash_string(bucket) + "/" +
-    vector_hash_string(index) + "/" + placement_key;
+  std::vector<float> values;
+  if (librados::vector_placement::copy_float32_vector(bl, 4, &values) < 0) {
+    return string();
+  }
+  const uint32_t signature =
+    librados::vector_placement::lsh_v0_signature(values, 0);
+  const string placement_key =
+    librados::vector_placement::lsh_v0_placement_key(0, signature);
+  return librados::vector_placement::make_lsh_v0_oid(
+      bucket, index, placement_key).name;
 }
 
 TEST_F(LibRadosIo, SimpleWrite) {

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -5,6 +5,7 @@
 #include <climits>
 #include <cstdio>
 #include <errno.h>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -34,22 +35,22 @@ static string vector_hex_u32(uint32_t value)
   return string(buf);
 }
 
-static string vector_hash_string(const string& value)
-{
-  return vector_hex_u32(ceph_str_hash_rjenkins(
-      value.c_str(), static_cast<unsigned>(value.length())));
-}
-
 static string vector_test_oid(const string& bucket, const string& index,
                               const string& key,
                               const bufferlist& vector_data)
 {
   (void)key;
-  const string vector_hash =
-    vector_hex_u32(vector_data.crc32c(static_cast<uint32_t>(-1)));
-  const string placement_key = vector_hash.substr(0, 4);
-  return ".rados.vector/v1/hash-v0/" + vector_hash_string(bucket) + "/" +
-    vector_hash_string(index) + "/" + placement_key;
+  std::vector<float> values;
+  if (librados::vector_placement::copy_float32_vector(
+        vector_data, 4, &values) < 0) {
+    return string();
+  }
+  const uint32_t signature =
+    librados::vector_placement::lsh_v0_signature(values, 0);
+  const string placement_key =
+    librados::vector_placement::lsh_v0_placement_key(0, signature);
+  return librados::vector_placement::make_lsh_v0_oid(
+      bucket, index, placement_key).name;
 }
 
 static string vector_entry_id(const string& bucket, const string& index,


### PR DESCRIPTION
query_vectors end-to-end path 위에 기본 vector routing을 hash-v0 placeholder에서 lsh-v0 기반 placement로 바꿉니다.
--> 현재 native put/query path에서 실제로 쓰는 lsh-v0 경로만 정리

---

**변경 사항**

**lsh-v0 placement primitive 추가**
- vector_query_algorithm_lsh / vector_placement_algorithm_lsh_v0 추가
- LSH signature bits / table 관련 기본 constant 추가
- vector_placement.h에 lsh-v0 공통 함수 추가
- put/query validation에서 lsh-v0 placement key / probe key를 허용되게 함

**lsh-v0 planner 추가**
- put_vector 시 vector를 table별 LSH signature로 변환하고, 각 table/signature에 대응하는 object target을 생성
- query_vectors 시 query vector에서 probe 대상 object 목록을 계산
- exact bucket probe와 hamming probe를 librados planner 쪽에서 생성
- OSD에는 planner-only 파라미터가 아니라 routed query request만 전달

**public put/query path에 lsh-v0 연결**
- IoCtxImpl::put_vector() / query_vectors() 기본 planner를 hash-v0에서 lsh-v0로 변경
- 환경변수로 lsh-v0 fanout 설정
- 최종 결과는 기존 query_vectors merge semantics에 맞춰 정렬 / top-k trim

**테스트 반영**
- 기존 put/query 테스트에서 expected OID 계산을 lsh-v0 placement 방식으로 변경
- PG-LSH 관련 테스트나 helper는 아직 없습니다

--- 

**후속 PR 계획**

lsh-v0 기본 path가 안정화된 뒤, PG 기반 routing이나 다른 ANN planner는 recall / 성능 기준을 잡고 별도 PR로 분리해서 진행할 예정입니다. 
++ 현재 pg기반 routing 하였으나 리콜이 만족스럽지 않아 보완하고 있습니다