### PR TITLE
librados, osd: add PG-LSH vector placement and routing

### DIFF
--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -31,6 +31,7 @@ struct omap_entry_t {
   std::string user_key;
   std::string content_key;
   std::string placement_key;
+  std::string vector_hash;
   uint32_t data_type = 0;
   uint32_t distance_metric = 0;
   uint32_t dimension = 0;
@@ -42,6 +43,23 @@ struct omap_entry_t {
 struct omap_scan_state_t {
   std::map<std::string, omap_entry_t> entries;
   std::map<std::string, ceph::bufferlist> contents;
+};
+
+struct query_filter_stats_t {
+  uint64_t total_entries = 0;
+  uint64_t incomplete_entries = 0;
+  uint64_t bucket_mismatch = 0;
+  uint64_t index_mismatch = 0;
+  uint64_t data_type_mismatch = 0;
+  uint64_t distance_metric_mismatch = 0;
+  uint64_t dimension_mismatch = 0;
+  uint64_t probe_mismatch = 0;
+  uint64_t missing_content = 0;
+  uint64_t distance_error = 0;
+  uint64_t matched_entries = 0;
+  uint64_t distance_computations = 0;
+  uint64_t merged_entries = 0;
+  uint64_t final_entries = 0;
 };
 
 inline bool starts_with(std::string_view value, std::string_view prefix)
@@ -85,6 +103,11 @@ inline bool is_lsh_v0_placement_key(std::string_view placement_key)
       placement_key, vector_lsh_v0_placement_key_len);
 }
 
+inline bool is_pg_lsh_v0_placement_key(std::string_view placement_key)
+{
+  return is_hash_v0_vector_hash(placement_key);
+}
+
 inline bool is_supported_placement_key(std::string_view placement_algorithm,
                                        std::string_view placement_key)
 {
@@ -93,6 +116,9 @@ inline bool is_supported_placement_key(std::string_view placement_algorithm,
   }
   if (placement_algorithm == vector_placement_algorithm_lsh_v0) {
     return is_lsh_v0_placement_key(placement_key);
+  }
+  if (placement_algorithm == vector_placement_algorithm_pg_lsh_v0) {
+    return is_pg_lsh_v0_placement_key(placement_key);
   }
   return false;
 }
@@ -243,6 +269,8 @@ inline void consume_omap_key_value(std::string_view key,
     decode_omap_string_value(bl, &entry.content_key);
   } else if (field == "placement_key") {
     decode_omap_string_value(bl, &entry.placement_key);
+  } else if (field == "vector_hash") {
+    decode_omap_string_value(bl, &entry.vector_hash);
   } else if (field == "data_type") {
     entry.has_data_type = decode_omap_value(bl, &entry.data_type);
   } else if (field == "distance_metric") {
@@ -431,12 +459,16 @@ inline void sort_and_trim_results(std::vector<query_vectors_result_entry_t> *ent
 
 inline int build_local_results(const query_vectors_request_t& req,
                                const omap_scan_state_t& scan,
-                               query_vectors_result_t *result)
+                               query_vectors_result_t *result,
+                               query_filter_stats_t *stats = nullptr)
 {
   if (result == nullptr) {
     return -EINVAL;
   }
   result->entries.clear();
+  if (stats != nullptr) {
+    *stats = query_filter_stats_t();
+  }
 
   int r = validate_query_request(req);
   if (r < 0) {
@@ -445,18 +477,78 @@ inline int build_local_results(const query_vectors_request_t& req,
 
   for (const auto& [entry_id, entry] : scan.entries) {
     (void)entry_id;
-    if (!entry_matches_query(req, entry)) {
+    if (stats != nullptr) {
+      stats->total_entries++;
+    }
+    if (entry.bucket_name.empty() ||
+        entry.index_name.empty() ||
+        entry.user_key.empty() ||
+        entry.content_key.empty() ||
+        !entry.has_data_type ||
+        !entry.has_distance_metric ||
+        !entry.has_dimension) {
+      if (stats != nullptr) {
+        stats->incomplete_entries++;
+      }
+      continue;
+    }
+    if (entry.bucket_name != req.bucket_name) {
+      if (stats != nullptr) {
+        stats->bucket_mismatch++;
+      }
+      continue;
+    }
+    if (entry.index_name != req.index_name) {
+      if (stats != nullptr) {
+        stats->index_mismatch++;
+      }
+      continue;
+    }
+    if (entry.data_type != req.data_type) {
+      if (stats != nullptr) {
+        stats->data_type_mismatch++;
+      }
+      continue;
+    }
+    if (entry.distance_metric != req.distance_metric) {
+      if (stats != nullptr) {
+        stats->distance_metric_mismatch++;
+      }
+      continue;
+    }
+    if (entry.dimension != req.dimension) {
+      if (stats != nullptr) {
+        stats->dimension_mismatch++;
+      }
+      continue;
+    }
+    if (!probe_matches(req, entry)) {
+      if (stats != nullptr) {
+        stats->probe_mismatch++;
+      }
       continue;
     }
     const auto content = scan.contents.find(entry.content_key);
     if (content == scan.contents.end()) {
+      if (stats != nullptr) {
+        stats->missing_content++;
+      }
       continue;
     }
 
     float distance = 0;
+    if (stats != nullptr) {
+      stats->distance_computations++;
+    }
     r = compute_float32_distance(req, content->second, &distance);
     if (r < 0) {
+      if (stats != nullptr) {
+        stats->distance_error++;
+      }
       continue;
+    }
+    if (stats != nullptr) {
+      stats->matched_entries++;
     }
 
     query_vectors_result_entry_t result_entry;
@@ -466,7 +558,13 @@ inline int build_local_results(const query_vectors_request_t& req,
     merge_result_entry(&result->entries, result_entry);
   }
 
+  if (stats != nullptr) {
+    stats->merged_entries = result->entries.size();
+  }
   sort_and_trim_results(&result->entries, req.local_top_k);
+  if (stats != nullptr) {
+    stats->final_entries = result->entries.size();
+  }
   return 0;
 }
 

--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -79,6 +79,30 @@ inline bool is_hash_v0_vector_hash(std::string_view vector_hash)
   return is_lower_hex_string(vector_hash, vector_hash_v0_vector_hash_len);
 }
 
+inline bool is_lsh_v0_placement_key(std::string_view placement_key)
+{
+  return is_lower_hex_string(
+      placement_key, vector_lsh_v0_placement_key_len);
+}
+
+inline bool is_supported_placement_key(std::string_view placement_algorithm,
+                                       std::string_view placement_key)
+{
+  if (placement_algorithm == vector_placement_algorithm_hash_v0) {
+    return is_hash_v0_placement_key(placement_key);
+  }
+  if (placement_algorithm == vector_placement_algorithm_lsh_v0) {
+    return is_lsh_v0_placement_key(placement_key);
+  }
+  return false;
+}
+
+inline bool is_supported_probe_key(std::string_view placement_key)
+{
+  return is_hash_v0_placement_key(placement_key) ||
+    is_lsh_v0_placement_key(placement_key);
+}
+
 inline int validate_vector_payload(uint32_t data_type,
                                    uint32_t distance_metric,
                                    uint32_t dimension,
@@ -128,8 +152,8 @@ inline int validate_put_request(const put_vector_request_t& req,
     return 0;
   }
 
-  if (req.placement_algorithm != vector_placement_algorithm_hash_v0 ||
-      !is_hash_v0_placement_key(req.placement_key) ||
+  if (!is_supported_placement_key(req.placement_algorithm,
+                                  req.placement_key) ||
       !is_hash_v0_vector_hash(req.vector_hash)) {
     return -EINVAL;
   }
@@ -245,7 +269,7 @@ inline int validate_query_request(const query_vectors_request_t& req,
   }
 
   for (const auto& prefix : req.probe_prefixes) {
-    if (!is_hash_v0_placement_key(prefix)) {
+    if (!is_supported_probe_key(prefix)) {
       return -EINVAL;
     }
   }

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -27,13 +27,23 @@ namespace librados {
 
 using ceph::bufferlist;
 
+struct IoCtxImpl;
+inline namespace v14_2_0 {
+class IoCtx;
+}
+
+namespace vector_internal {
+struct IoCtxAccess {
+  static IoCtxImpl *get(v14_2_0::IoCtx& ioctx);
+};
+}
+
 struct query_vectors_result_entry {
   std::string key;
   float distance = 0;
 };
 
 struct AioCompletionImpl;
-struct IoCtxImpl;
 struct ListObjectImpl;
 class NObjectIteratorImpl;
 struct ObjListCtx;
@@ -1546,6 +1556,7 @@ inline namespace v14_2_0 {
     friend class libradosstriper::RadosStriper; // Striper needs to see our IoCtxImpl
     friend class ObjectWriteOperation;  // copy_from needs to see our IoCtxImpl
     friend class ObjectReadOperation;  // set_chunk needs to see our IoCtxImpl
+    friend struct librados::vector_internal::IoCtxAccess;
 
     IoCtxImpl *io_ctx_impl;
   };

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -27,10 +27,16 @@ inline constexpr uint32_t vector_distance_metric_cosine = 2;
 inline constexpr uint32_t vector_distance_metric_dot = 3;
 
 inline constexpr uint32_t vector_query_algorithm_hash = 1;
+inline constexpr uint32_t vector_query_algorithm_lsh = 2;
 inline constexpr uint32_t vector_query_algorithm_version_0 = 0;
 inline constexpr const char *vector_placement_algorithm_hash_v0 = "hash-v0";
+inline constexpr const char *vector_placement_algorithm_lsh_v0 = "lsh-v0";
 inline constexpr uint32_t vector_hash_v0_placement_key_len = 4;
 inline constexpr uint32_t vector_hash_v0_vector_hash_len = 8;
+inline constexpr uint32_t vector_lsh_v0_bits = 10;
+inline constexpr uint32_t vector_lsh_v0_max_bits = 16;
+inline constexpr uint32_t vector_lsh_v0_default_table_count = 16;
+inline constexpr uint32_t vector_lsh_v0_placement_key_len = 8;
 
 struct vector_routing_policy_t {
   // Number of placement targets to write for each vector entry.
@@ -70,7 +76,8 @@ struct vector_index_config_t {
   uint32_t distance_metric = 0;
   // Number of vector dimensions in this index; 0 accepts the request dimension.
   uint32_t dimension = 0;
-  // Planner algorithm family. The current baseline is hash-v0.
+  // Planner algorithm family. hash-v0 is a routing baseline; lsh-v0 adds
+  // semantic candidate routing while preserving the same OSD local search path.
   uint32_t algorithm_id = vector_query_algorithm_hash;
   // Planner/layout variant within algorithm_id. Version 0 is the hash-v0
   // baseline and is intentionally replaceable by future planners.

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -31,6 +31,7 @@ inline constexpr uint32_t vector_query_algorithm_lsh = 2;
 inline constexpr uint32_t vector_query_algorithm_version_0 = 0;
 inline constexpr const char *vector_placement_algorithm_hash_v0 = "hash-v0";
 inline constexpr const char *vector_placement_algorithm_lsh_v0 = "lsh-v0";
+inline constexpr const char *vector_placement_algorithm_pg_lsh_v0 = "pg-lsh-v0";
 inline constexpr uint32_t vector_hash_v0_placement_key_len = 4;
 inline constexpr uint32_t vector_hash_v0_vector_hash_len = 8;
 inline constexpr uint32_t vector_lsh_v0_bits = 10;

--- a/src/include/rados/vector_ops.h
+++ b/src/include/rados/vector_ops.h
@@ -283,6 +283,10 @@ struct query_vectors_result_entry_t {
 struct query_vectors_result_t {
   // Sorted vector query result entries.
   std::vector<query_vectors_result_entry_t> entries;
+  // OSD-local physical scan stats. These are deliberately minimal; benchmark
+  // clients derive logical candidate and duplicate counts after global merge.
+  uint64_t local_matching_entries = 0;
+  uint64_t local_distance_computations = 0;
 
   void encode(ceph::bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
@@ -291,6 +295,8 @@ struct query_vectors_result_t {
     for (const auto& entry : entries) {
       entry.encode(bl);
     }
+    encode(local_matching_entries, bl);
+    encode(local_distance_computations, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -306,6 +312,8 @@ struct query_vectors_result_t {
       entry.decode(p);
       entries.push_back(std::move(entry));
     }
+    decode(local_matching_entries, p);
+    decode(local_distance_computations, p);
     DECODE_FINISH(p);
   }
 };

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -13,7 +13,9 @@
  *
  */
 
+#include <cstdlib>
 #include <limits.h>
+#include <memory>
 
 #include "IoCtxImpl.h"
 
@@ -46,6 +48,54 @@ namespace cb = ceph::buffer;
 
 namespace librados {
 namespace {
+
+uint32_t vector_lsh_env_u32(const char *name,
+                            uint32_t default_value,
+                            uint32_t min_value,
+                            uint32_t max_value)
+{
+  const char *value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return default_value;
+  }
+
+  char *end = nullptr;
+  const unsigned long parsed = std::strtoul(value, &end, 10);
+  if (end == value || *end != '\0') {
+    return default_value;
+  }
+  if (parsed < min_value) {
+    return min_value;
+  }
+  if (parsed > max_value) {
+    return max_value;
+  }
+  return static_cast<uint32_t>(parsed);
+}
+
+uint32_t vector_lsh_table_count()
+{
+  return vector_lsh_env_u32(
+      "CEPH_VECTOR_LSH_TABLES",
+      ceph::rados::vector_lsh_v0_default_table_count,
+      1, 0xffffU);
+}
+
+uint32_t vector_lsh_signature_bits()
+{
+  return vector_lsh_env_u32(
+      "CEPH_VECTOR_LSH_BITS",
+      ceph::rados::vector_lsh_v0_bits,
+      1, ceph::rados::vector_lsh_v0_max_bits);
+}
+
+uint32_t vector_lsh_probe_count(uint32_t table_count, uint32_t signature_bits)
+{
+  const uint32_t hamming = vector_lsh_env_u32(
+      "CEPH_VECTOR_LSH_PROBE_HAMMING", 1, 0, 1);
+  return table_count *
+    (1 + hamming * signature_bits);
+}
 
 struct CB_notify_Finish {
   CephContext *cct;
@@ -678,9 +728,15 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   config.data_type = encoded_data_type;
   config.distance_metric = encoded_distance_metric;
   config.dimension = dimension;
-  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_lsh;
   config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
-  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  config.placement_algorithm = librados::vector_placement::lsh_v0_algorithm;
+  const uint32_t lsh_signature_bits = vector_lsh_signature_bits();
+  encode(lsh_signature_bits, config.algorithm_params);
+  config.routing_policy.write_pgs = vector_lsh_table_count();
+  config.routing_policy.probe_pgs =
+    vector_lsh_probe_count(config.routing_policy.write_pgs,
+                           lsh_signature_bits);
 
   librados::vector_query::put_plan_t plan;
   r = librados::vector_query::build_put_plan(req, config, &plan);
@@ -693,6 +749,19 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
   for (const auto& target : plan.targets) {
     ::ObjectOperation op;
     prepare_assert_ops(&op);
+
+    ldout(client->cct, 20) << "vector-debug put computed oid="
+				  << target.oid
+				  << " algorithm=" << req.placement_algorithm
+				  << " bucket=" << req.bucket_name
+			  << " index=" << req.index_name
+			  << " key=" << req.key
+			  << " data_type=" << req.data_type
+			  << " distance_metric=" << req.distance_metric
+			  << " dimension=" << req.dimension
+			  << " placement_key=" << target.placement_key
+			  << " vector_hash=" << target.vector_hash
+			  << dendl;
 
     req.placement_key = target.placement_key;
     req.vector_hash = target.vector_hash;
@@ -770,9 +839,15 @@ int librados::IoCtxImpl::query_vectors(
   config.data_type = encoded_data_type;
   config.distance_metric = encoded_distance_metric;
   config.dimension = dimension;
-  config.algorithm_id = ceph::rados::vector_query_algorithm_hash;
+  config.algorithm_id = ceph::rados::vector_query_algorithm_lsh;
   config.algorithm_version = ceph::rados::vector_query_algorithm_version_0;
-  config.placement_algorithm = librados::vector_placement::hash_v0_algorithm;
+  config.placement_algorithm = librados::vector_placement::lsh_v0_algorithm;
+  const uint32_t lsh_signature_bits = vector_lsh_signature_bits();
+  encode(lsh_signature_bits, config.algorithm_params);
+  config.routing_policy.write_pgs = vector_lsh_table_count();
+  config.routing_policy.probe_pgs =
+    vector_lsh_probe_count(config.routing_policy.write_pgs,
+                           lsh_signature_bits);
 
   librados::vector_query::query_plan_t plan;
   r = librados::vector_query::build_query_plan(req, config, &plan);
@@ -787,31 +862,72 @@ int librados::IoCtxImpl::query_vectors(
     return r;
   }
 
-  ceph::rados::query_vectors_result_t merged_result;
-  for (const auto& routed_request : routed_requests) {
+  struct PendingVectorQuery {
     ::ObjectOperation op;
-    bufferlist payload = routed_request.payload;
+    bufferlist payload;
     bufferlist reply;
     int op_rval = 0;
-    op.query_vectors(payload, &reply, &op_rval);
+    int submit_ret = 0;
+    AioCompletionImpl *completion = nullptr;
+    librados::vector_query::routed_request_t routed_request;
+  };
 
-    r = operate_read(routed_request.oid, &op, &reply);
-    if (r == -ENOENT || op_rval == -ENOENT) {
+  std::vector<std::unique_ptr<PendingVectorQuery>> pending_requests;
+  pending_requests.reserve(routed_requests.size());
+  for (const auto& routed_request : routed_requests) {
+    ldout(client->cct, 20) << "vector-debug query computed oid="
+				  << routed_request.oid
+				  << " algorithm=" << plan.placement_algorithm
+				  << " bucket=" << req.bucket_name
+			  << " index=" << req.index_name
+			  << " data_type=" << req.data_type
+			  << " distance_metric=" << req.distance_metric
+			  << " dimension=" << req.dimension
+			  << " top_k=" << req.top_k
+			  << " return_distance=" << return_distance
+			  << " placement_key=" << routed_request.placement_key
+			  << dendl;
+
+    auto pending = std::make_unique<PendingVectorQuery>();
+    pending->payload = routed_request.payload;
+    pending->routed_request = routed_request;
+    pending->completion = new AioCompletionImpl;
+    pending->op.query_vectors(
+        pending->payload, &pending->reply, &pending->op_rval);
+    pending->submit_ret = aio_operate_read(
+        routed_request.oid, &pending->op, pending->completion, 0,
+        &pending->reply);
+    pending_requests.push_back(std::move(pending));
+  }
+
+  ceph::rados::query_vectors_result_t merged_result;
+  for (auto& pending : pending_requests) {
+    r = pending->submit_ret;
+    if (pending->completion != nullptr && r == 0) {
+      pending->completion->wait_for_complete();
+      r = pending->completion->get_return_value();
+    }
+    if (pending->completion != nullptr) {
+      pending->completion->release();
+      pending->completion = nullptr;
+    }
+
+    if (r == -ENOENT || pending->op_rval == -ENOENT) {
       continue;
     }
     if (r < 0) {
       return r;
     }
-    if (op_rval < 0) {
-      return op_rval;
+    if (pending->op_rval < 0) {
+      return pending->op_rval;
     }
-    if (reply.length() == 0) {
+    if (pending->reply.length() == 0) {
       continue;
     }
 
     ceph::rados::query_vectors_result_t partial_result;
     try {
-      auto p = reply.cbegin();
+      auto p = pending->reply.cbegin();
       decode(partial_result, p);
       if (!p.end()) {
         return -EIO;

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -13,6 +13,7 @@
  *
  */
 
+#include <limits>
 #include <limits.h>
 
 #include "common/config.h"
@@ -36,6 +37,7 @@
 #include "librados/RadosXattrIter.h"
 #include "librados/ListObjectImpl.h"
 #include "librados/librados_util.h"
+#include "librados/vector_pg_lsh.h"
 #include "cls/lock/cls_lock_client.h"
 
 #include <string>
@@ -480,6 +482,105 @@ void librados::ObjectWriteOperation::write_full(const bufferlist& bl)
   ::ObjectOperation *o = &impl->o;
   bufferlist c = bl;
   o->write_full(c);
+}
+
+int librados::v14_2_0::vector_pg_lsh::put_vector(
+    librados::v14_2_0::IoCtx& ioctx,
+    const librados::v14_2_0::vector_pg_lsh::put_target_t& target,
+    ceph::rados::put_vector_request_t req)
+{
+  int ret = verify_probe_locator(ioctx, target.pg, target.locator_key);
+  if (ret < 0) {
+    return ret;
+  }
+
+  req.placement_algorithm =
+    ceph::rados::vector_placement_algorithm_pg_lsh_v0;
+  req.placement_key = target.placement_key;
+  req.vector_hash = target.vector_hash;
+
+  bufferlist payload;
+  encode(req, payload);
+
+  ::ObjectOperation op;
+  op.put_vector(payload);
+
+  librados::v14_2_0::IoCtx routed_ioctx;
+  routed_ioctx.dup(ioctx);
+  routed_ioctx.locator_set_key(target.locator_key);
+
+  IoCtxImpl *impl = vector_internal::IoCtxAccess::get(routed_ioctx);
+  return impl->operate(target.oid, &op, nullptr);
+}
+
+int librados::v14_2_0::vector_pg_lsh::submit_query(
+    librados::v14_2_0::IoCtx& ioctx,
+    const librados::v14_2_0::vector_pg_lsh::query_probe_t& probe,
+    ceph::rados::query_vectors_request_t req,
+    librados::v14_2_0::vector_pg_lsh::query_op_state_t *op_state,
+    librados::v14_2_0::AioCompletion *completion,
+    bufferlist *reply,
+    int *op_rval)
+{
+  if (op_state == nullptr || completion == nullptr ||
+      reply == nullptr || op_rval == nullptr) {
+    return -EINVAL;
+  }
+
+  int ret = verify_probe_locator(ioctx, probe.pg, probe.locator_key);
+  if (ret < 0) {
+    return ret;
+  }
+
+  req.probe_prefixes.clear();
+  req.local_top_k = std::numeric_limits<uint32_t>::max();
+
+  op_state->payload.clear();
+  encode(req, op_state->payload);
+  *op_rval = 0;
+  op_state->op.query_vectors(op_state->payload, reply, op_rval);
+
+  op_state->routed_ioctx.dup(ioctx);
+  op_state->routed_ioctx.locator_set_key(probe.locator_key);
+
+  IoCtxImpl *impl =
+    vector_internal::IoCtxAccess::get(op_state->routed_ioctx);
+  return impl->aio_operate_read(
+      probe.oid, &op_state->op, completion->pc, 0, reply);
+}
+
+int librados::v14_2_0::vector_pg_lsh::query_sync(
+    librados::v14_2_0::IoCtx& ioctx,
+    const librados::v14_2_0::vector_pg_lsh::query_probe_t& probe,
+    ceph::rados::query_vectors_request_t req,
+    bufferlist *reply,
+    int *op_rval)
+{
+  if (reply == nullptr || op_rval == nullptr) {
+    return -EINVAL;
+  }
+
+  int ret = verify_probe_locator(ioctx, probe.pg, probe.locator_key);
+  if (ret < 0) {
+    return ret;
+  }
+
+  req.probe_prefixes.clear();
+  req.local_top_k = std::numeric_limits<uint32_t>::max();
+
+  bufferlist payload;
+  encode(req, payload);
+
+  ::ObjectOperation op;
+  *op_rval = 0;
+  op.query_vectors(payload, reply, op_rval);
+
+  librados::v14_2_0::IoCtx routed_ioctx;
+  routed_ioctx.dup(ioctx);
+  routed_ioctx.locator_set_key(probe.locator_key);
+
+  IoCtxImpl *impl = vector_internal::IoCtxAccess::get(routed_ioctx);
+  return impl->operate_read(probe.oid, &op, reply);
 }
 
 void librados::ObjectWriteOperation::writesame(uint64_t off, uint64_t write_len,
@@ -1849,7 +1950,7 @@ int librados::IoCtx::lock_exclusive(const std::string &oid, const std::string &n
   if (duration)
     dur.set_from_timeval(duration);
 
-  return rados::cls::lock::lock(this, oid, name, ClsLockType::EXCLUSIVE, cookie, "",
+  return ::rados::cls::lock::lock(this, oid, name, ClsLockType::EXCLUSIVE, cookie, "",
 		  		description, dur, flags);
 }
 
@@ -1862,14 +1963,14 @@ int librados::IoCtx::lock_shared(const std::string &oid, const std::string &name
   if (duration)
     dur.set_from_timeval(duration);
 
-  return rados::cls::lock::lock(this, oid, name, ClsLockType::SHARED, cookie, tag,
+  return ::rados::cls::lock::lock(this, oid, name, ClsLockType::SHARED, cookie, tag,
 		  		description, dur, flags);
 }
 
 int librados::IoCtx::unlock(const std::string &oid, const std::string &name,
 			    const std::string &cookie)
 {
-  return rados::cls::lock::unlock(this, oid, name, cookie);
+  return ::rados::cls::lock::unlock(this, oid, name, cookie);
 }
 
 struct AioUnlockCompletion : public librados::ObjectOperationCompletion {
@@ -1891,7 +1992,7 @@ struct AioUnlockCompletion : public librados::ObjectOperationCompletion {
 int librados::IoCtx::aio_unlock(const std::string &oid, const std::string &name,
 			        const std::string &cookie, AioCompletion *c)
 {
-  return rados::cls::lock::aio_unlock(this, oid, name, cookie, c);
+  return ::rados::cls::lock::aio_unlock(this, oid, name, cookie, c);
 }
 
 int librados::IoCtx::break_lock(const std::string &oid, const std::string &name,
@@ -1900,7 +2001,7 @@ int librados::IoCtx::break_lock(const std::string &oid, const std::string &name,
   entity_name_t locker;
   if (!locker.parse(client))
     return -EINVAL;
-  return rados::cls::lock::break_lock(this, oid, name, cookie, locker);
+  return ::rados::cls::lock::break_lock(this, oid, name, cookie, locker);
 }
 
 int librados::IoCtx::list_lockers(const std::string &oid, const std::string &name,
@@ -1909,14 +2010,14 @@ int librados::IoCtx::list_lockers(const std::string &oid, const std::string &nam
 				  std::list<librados::locker_t> *lockers)
 {
   std::list<librados::locker_t> tmp_lockers;
-  map<rados::cls::lock::locker_id_t, rados::cls::lock::locker_info_t> rados_lockers;
+  map<::rados::cls::lock::locker_id_t, ::rados::cls::lock::locker_info_t> rados_lockers;
   std::string tmp_tag;
   ClsLockType tmp_type;
-  int r = rados::cls::lock::get_lock_info(this, oid, name, &rados_lockers, &tmp_type, &tmp_tag);
+  int r = ::rados::cls::lock::get_lock_info(this, oid, name, &rados_lockers, &tmp_type, &tmp_tag);
   if (r < 0)
 	  return r;
 
-  map<rados::cls::lock::locker_id_t, rados::cls::lock::locker_info_t>::iterator map_it;
+  map<::rados::cls::lock::locker_id_t, ::rados::cls::lock::locker_info_t>::iterator map_it;
   for (map_it = rados_lockers.begin(); map_it != rados_lockers.end(); ++map_it) {
     librados::locker_t locker;
     locker.client = stringify(map_it->first.locker);

--- a/src/librados/vector_pg_lsh.h
+++ b/src/librados/vector_pg_lsh.h
@@ -1,0 +1,413 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_LIBRADOS_VECTOR_PG_LSH_H
+#define CEPH_LIBRADOS_VECTOR_PG_LSH_H
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <errno.h>
+
+#include "include/buffer.h"
+#include "include/object.h"
+#include "include/rados/librados.hpp"
+#include "include/rados/vector_ops.h"
+#include "librados/IoCtxImpl.h"
+#include "librados/vector_placement.h"
+
+namespace librados {
+namespace vector_internal {
+
+inline IoCtxImpl *IoCtxAccess::get(v14_2_0::IoCtx& ioctx)
+{
+  return ioctx.io_ctx_impl;
+}
+
+} // namespace vector_internal
+
+inline namespace v14_2_0 {
+namespace vector_pg_lsh {
+
+struct pool_pg_info_t {
+  uint32_t pg_num = 0;
+  uint32_t pgp_num = 0;
+  uint64_t osdmap_epoch = 0;
+};
+
+struct params_t {
+  uint32_t k = 0;
+  uint32_t l = 0;
+  uint32_t seed = 0;
+  uint32_t hamming_radius = 0;
+  uint32_t d = 0;
+  uint32_t m = 0;
+};
+
+struct locator_state_t {
+  std::mutex lock;
+  std::unordered_map<uint32_t, std::string> cache;
+  uint32_t next_salt = 0;
+};
+
+struct put_target_t {
+  uint32_t pg = 0;
+  object_t oid;
+  std::string locator_key;
+  std::string placement_key;
+  std::string vector_hash;
+};
+
+struct query_probe_t {
+  uint32_t pg = 0;
+  uint32_t min_hamming_distance = 0;
+  uint32_t table_vote_count = 0;
+  object_t oid;
+  std::string locator_key;
+  std::string placement_key;
+};
+
+struct query_op_state_t {
+  v14_2_0::IoCtx routed_ioctx;
+  ::ObjectOperation op;
+  ceph::bufferlist payload;
+};
+
+inline int validate_params(const params_t& params,
+                           const pool_pg_info_t& pool_info)
+{
+  if (params.k == 0 ||
+      params.k > ceph::rados::vector_lsh_v0_max_bits ||
+      params.l == 0 ||
+      params.l > 0xffffU ||
+      params.hamming_radius > params.k ||
+      params.d == 0 ||
+      params.m == 0 ||
+      pool_info.pg_num == 0 ||
+      pool_info.pgp_num == 0) {
+    return -EINVAL;
+  }
+  if (params.d > pool_info.pg_num || params.m > pool_info.pg_num) {
+    return -EINVAL;
+  }
+  if (params.d > params.l) {
+    return -EINVAL;
+  }
+  return 0;
+}
+
+class locator_cache_t {
+ public:
+  locator_cache_t(v14_2_0::IoCtx *ioctx,
+                  pool_pg_info_t info,
+                  std::string pool_name,
+                  std::string bucket_name,
+                  std::string index_name,
+                  std::shared_ptr<locator_state_t> state = nullptr)
+    : ioctx(ioctx),
+      info(info),
+      pool_name(std::move(pool_name)),
+      bucket_hash(vector_placement::hash_string(bucket_name)),
+      index_hash(vector_placement::hash_string(index_name)),
+      state(state ? std::move(state) : std::make_shared<locator_state_t>()) {}
+
+  int precompute_all()
+  {
+    if (ioctx == nullptr || info.pg_num == 0) {
+      return -EINVAL;
+    }
+
+    std::lock_guard locker(state->lock);
+    const uint32_t search_limit =
+      std::max<uint32_t>(10000000U, info.pg_num * 1024U);
+    while (state->cache.size() < info.pg_num &&
+           state->next_salt < search_limit) {
+      std::string candidate = make_locator_key(state->next_salt++);
+      uint32_t actual = 0;
+      const int ret =
+        ioctx->get_object_pg_hash_position2(candidate, &actual);
+      if (ret < 0) {
+        return ret;
+      }
+      if (actual < info.pg_num &&
+          state->cache.find(actual) == state->cache.end()) {
+        state->cache.emplace(actual, std::move(candidate));
+      }
+    }
+
+    if (state->cache.size() != info.pg_num) {
+      return -ENOENT;
+    }
+
+    for (uint32_t pg = 0; pg < info.pg_num; ++pg) {
+      const auto found = state->cache.find(pg);
+      if (found == state->cache.end()) {
+        return -ENOENT;
+      }
+      uint32_t actual = 0;
+      const int ret =
+        ioctx->get_object_pg_hash_position2(found->second, &actual);
+      if (ret < 0) {
+        return ret;
+      }
+      if (actual != pg) {
+        return -ESTALE;
+      }
+    }
+    return 0;
+  }
+
+  int locator_for_pg(uint32_t pg, std::string *locator_key)
+  {
+    if (locator_key == nullptr || ioctx == nullptr || pg >= info.pg_num) {
+      return -EINVAL;
+    }
+
+    std::string found_locator;
+    {
+      std::lock_guard locker(state->lock);
+      const auto found = state->cache.find(pg);
+      if (found == state->cache.end()) {
+        return -ENOENT;
+      }
+      found_locator = found->second;
+    }
+
+    const int ret = verify_locator(pg, found_locator);
+    if (ret < 0) {
+      return ret;
+    }
+    *locator_key = std::move(found_locator);
+    return 0;
+  }
+
+  int verify_locator(uint32_t pg, const std::string& locator_key) const
+  {
+    if (ioctx == nullptr || pg >= info.pg_num || locator_key.empty()) {
+      return -EINVAL;
+    }
+    uint32_t actual = 0;
+    const int ret = ioctx->get_object_pg_hash_position2(locator_key, &actual);
+    if (ret < 0) {
+      return ret;
+    }
+    return actual == pg ? 0 : -ESTALE;
+  }
+
+ private:
+  std::string make_locator_key(uint32_t salt) const
+  {
+    return "pg-lsh-v0:" + pool_name + ":" + bucket_hash + ":" + index_hash +
+      ":salt:" + std::to_string(salt);
+  }
+
+  v14_2_0::IoCtx *ioctx = nullptr;
+  pool_pg_info_t info;
+  std::string pool_name;
+  std::string bucket_hash;
+  std::string index_hash;
+  std::shared_ptr<locator_state_t> state;
+};
+
+inline int select_write_pgs(const ceph::bufferlist& vector_data,
+                            uint32_t dimension,
+                            const params_t& params,
+                            const pool_pg_info_t& pool_info,
+                            std::vector<uint32_t> *write_pgs)
+{
+  if (write_pgs == nullptr) {
+    return -EINVAL;
+  }
+  write_pgs->clear();
+
+  int ret = validate_params(params, pool_info);
+  if (ret < 0) {
+    return ret;
+  }
+
+  std::vector<vector_placement::pg_lsh_v0_group_t> exact_groups;
+  ret = vector_placement::pg_lsh_v0_exact_groups(
+      vector_data, dimension, params.k, params.l, params.seed,
+      &exact_groups);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *write_pgs = vector_placement::pg_lsh_v0_select_write_pgs(
+      exact_groups, pool_info.pg_num, params.seed, params.d);
+  return 0;
+}
+
+inline int select_query_pgs(
+    const ceph::bufferlist& query_vector,
+    uint32_t dimension,
+    const params_t& params,
+    const pool_pg_info_t& pool_info,
+    std::vector<vector_placement::pg_lsh_v0_ranked_pg_t> *query_pgs,
+    uint64_t *generated_group_count)
+{
+  if (query_pgs == nullptr) {
+    return -EINVAL;
+  }
+  query_pgs->clear();
+  if (generated_group_count != nullptr) {
+    *generated_group_count = 0;
+  }
+
+  int ret = validate_params(params, pool_info);
+  if (ret < 0) {
+    return ret;
+  }
+
+  std::vector<vector_placement::pg_lsh_v0_group_t> groups;
+  ret = vector_placement::pg_lsh_v0_query_groups(
+      query_vector, dimension, params.k, params.l, params.hamming_radius,
+      params.seed, &groups);
+  if (ret < 0) {
+    return ret;
+  }
+  if (generated_group_count != nullptr) {
+    *generated_group_count = groups.size();
+  }
+
+  *query_pgs = vector_placement::pg_lsh_v0_select_unique_pgs(
+      groups, pool_info.pg_num, params.seed, params.m);
+  return 0;
+}
+
+inline int build_put_targets(const std::string& bucket_name,
+                             const std::string& index_name,
+                             const ceph::bufferlist& vector_data,
+                             uint32_t dimension,
+                             const params_t& params,
+                             const pool_pg_info_t& pool_info,
+                             locator_cache_t *locator_cache,
+                             std::vector<put_target_t> *targets)
+{
+  if (targets == nullptr || locator_cache == nullptr ||
+      bucket_name.empty() || index_name.empty()) {
+    return -EINVAL;
+  }
+  targets->clear();
+
+  std::vector<uint32_t> write_pgs;
+  int ret = select_write_pgs(
+      vector_data, dimension, params, pool_info, &write_pgs);
+  if (ret < 0) {
+    return ret;
+  }
+
+  const std::string vector_hash =
+    vector_placement::hash_v0_vector_hash(vector_data);
+  targets->reserve(write_pgs.size());
+  for (const uint32_t pg : write_pgs) {
+    std::string locator_key;
+    ret = locator_cache->locator_for_pg(pg, &locator_key);
+    if (ret < 0) {
+      return ret;
+    }
+    targets->push_back({
+      pg,
+      vector_placement::make_pg_lsh_v0_oid(bucket_name, index_name, pg),
+      std::move(locator_key),
+      vector_placement::pg_lsh_v0_placement_key(pg),
+      vector_hash,
+    });
+  }
+  return 0;
+}
+
+inline int build_query_probes(const std::string& bucket_name,
+                              const std::string& index_name,
+                              const ceph::bufferlist& query_vector,
+                              uint32_t dimension,
+                              const params_t& params,
+                              const pool_pg_info_t& pool_info,
+                              locator_cache_t *locator_cache,
+                              std::vector<query_probe_t> *probes,
+                              uint64_t *generated_group_count)
+{
+  if (probes == nullptr || locator_cache == nullptr ||
+      bucket_name.empty() || index_name.empty()) {
+    return -EINVAL;
+  }
+  probes->clear();
+  if (generated_group_count != nullptr) {
+    *generated_group_count = 0;
+  }
+
+  int ret = validate_params(params, pool_info);
+  if (ret < 0) {
+    return ret;
+  }
+
+  std::vector<vector_placement::pg_lsh_v0_ranked_pg_t> ranked;
+  ret = select_query_pgs(
+      query_vector, dimension, params, pool_info, &ranked,
+      generated_group_count);
+  if (ret < 0) {
+    return ret;
+  }
+
+  probes->reserve(ranked.size());
+  for (const auto& candidate : ranked) {
+    std::string locator_key;
+    ret = locator_cache->locator_for_pg(candidate.pg, &locator_key);
+    if (ret < 0) {
+      return ret;
+    }
+    probes->push_back({
+      candidate.pg,
+      candidate.min_hamming_distance,
+      candidate.table_votes,
+      vector_placement::make_pg_lsh_v0_oid(
+          bucket_name, index_name, candidate.pg),
+      std::move(locator_key),
+      vector_placement::pg_lsh_v0_placement_key(candidate.pg),
+    });
+  }
+  return 0;
+}
+
+inline int verify_probe_locator(v14_2_0::IoCtx& ioctx,
+                                uint32_t pg,
+                                const std::string& locator_key)
+{
+  uint32_t actual = 0;
+  const int ret = ioctx.get_object_pg_hash_position2(locator_key, &actual);
+  if (ret < 0) {
+    return ret;
+  }
+  return actual == pg ? 0 : -ESTALE;
+}
+
+CEPH_RADOS_API int put_vector(v14_2_0::IoCtx& ioctx,
+                              const put_target_t& target,
+                              ceph::rados::put_vector_request_t req);
+
+CEPH_RADOS_API int submit_query(v14_2_0::IoCtx& ioctx,
+                                const query_probe_t& probe,
+                                ceph::rados::query_vectors_request_t req,
+                                query_op_state_t *op_state,
+                                v14_2_0::AioCompletion *completion,
+                                ceph::bufferlist *reply,
+                                int *op_rval);
+
+CEPH_RADOS_API int query_sync(v14_2_0::IoCtx& ioctx,
+                              const query_probe_t& probe,
+                              ceph::rados::query_vectors_request_t req,
+                              ceph::bufferlist *reply,
+                              int *op_rval);
+
+} // namespace vector_pg_lsh
+} // inline namespace v14_2_0
+} // namespace librados
+
+#endif

--- a/src/librados/vector_placement.h
+++ b/src/librados/vector_placement.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <string>
+#include <vector>
 
 #include "include/buffer.h"
 #include "include/ceph_hash.h"
@@ -18,6 +19,8 @@ namespace vector_placement {
 
 inline constexpr const char *hash_v0_algorithm =
   ceph::rados::vector_placement_algorithm_hash_v0;
+inline constexpr const char *lsh_v0_algorithm =
+  ceph::rados::vector_placement_algorithm_lsh_v0;
 
 struct hash_v0_placement_t {
   object_t oid;
@@ -30,6 +33,16 @@ inline std::string hex_u32(uint32_t value)
   char buf[9];
   std::snprintf(buf, sizeof(buf), "%08x", value);
   return std::string(buf);
+}
+
+inline uint32_t mix_u32(uint32_t value)
+{
+  value ^= value >> 16;
+  value *= 0x7feb352dU;
+  value ^= value >> 15;
+  value *= 0x846ca68bU;
+  value ^= value >> 16;
+  return value;
 }
 
 inline std::string hash_string(const std::string& value)
@@ -73,6 +86,14 @@ inline object_t make_hash_v0_oid(const std::string& bucket_name,
       hash_v0_algorithm, bucket_name, index_name, placement_key);
 }
 
+inline object_t make_lsh_v0_oid(const std::string& bucket_name,
+                                const std::string& index_name,
+                                const std::string& placement_key)
+{
+  return make_algorithm_oid(
+      lsh_v0_algorithm, bucket_name, index_name, placement_key);
+}
+
 inline hash_v0_placement_t compute_hash_v0_placement(
     const std::string& bucket_name,
     const std::string& index_name,
@@ -98,6 +119,64 @@ inline std::string ranked_hash_v0_placement_key(
   value.push_back('\0');
   value.append(std::to_string(rank));
   return hash_v0_placement_key(hex_u32(hash_to_u32(value)));
+}
+
+
+inline int copy_float32_vector(const ceph::bufferlist& vector_data,
+                               uint32_t dimension,
+                               std::vector<float> *values)
+{
+  if (values == nullptr || dimension == 0) {
+    return -EINVAL;
+  }
+  const size_t expected_len = static_cast<size_t>(dimension) * sizeof(float);
+  if (vector_data.length() != expected_len) {
+    return -EINVAL;
+  }
+  values->resize(dimension);
+  auto p = vector_data.cbegin();
+  p.copy(expected_len, reinterpret_cast<char*>(values->data()));
+  return 0;
+}
+
+inline int lsh_v0_hyperplane_sign(uint32_t table,
+                                  uint32_t bit,
+                                  uint32_t dimension)
+{
+  const uint32_t seed =
+    table * 0x9e3779b9U ^ bit * 0x85ebca6bU ^ dimension * 0xc2b2ae35U;
+  return (mix_u32(seed) & 1U) == 0U ? -1 : 1;
+}
+
+inline uint32_t lsh_v0_signature(
+    const std::vector<float>& values,
+    uint32_t table,
+    uint32_t signature_bits = ceph::rados::vector_lsh_v0_bits)
+{
+  if (signature_bits == 0) {
+    signature_bits = ceph::rados::vector_lsh_v0_bits;
+  }
+  if (signature_bits > ceph::rados::vector_lsh_v0_max_bits) {
+    signature_bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+
+  uint32_t signature = 0;
+  for (uint32_t bit = 0; bit < signature_bits; ++bit) {
+    double projection = 0;
+    for (uint32_t dim = 0; dim < values.size(); ++dim) {
+      projection += static_cast<double>(values[dim]) *
+        lsh_v0_hyperplane_sign(table, bit, dim);
+    }
+    if (projection >= 0) {
+      signature |= 1U << bit;
+    }
+  }
+  return signature;
+}
+
+inline std::string lsh_v0_placement_key(uint32_t table, uint32_t signature)
+{
+  return hex_u32(((table & 0xffffU) << 16) | (signature & 0xffffU));
 }
 
 } // namespace vector_placement

--- a/src/librados/vector_placement.h
+++ b/src/librados/vector_placement.h
@@ -6,7 +6,10 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <algorithm>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "include/buffer.h"
@@ -21,6 +24,8 @@ inline constexpr const char *hash_v0_algorithm =
   ceph::rados::vector_placement_algorithm_hash_v0;
 inline constexpr const char *lsh_v0_algorithm =
   ceph::rados::vector_placement_algorithm_lsh_v0;
+inline constexpr const char *pg_lsh_v0_algorithm =
+  ceph::rados::vector_placement_algorithm_pg_lsh_v0;
 
 struct hash_v0_placement_t {
   object_t oid;
@@ -94,6 +99,16 @@ inline object_t make_lsh_v0_oid(const std::string& bucket_name,
       lsh_v0_algorithm, bucket_name, index_name, placement_key);
 }
 
+inline object_t make_pg_lsh_v0_oid(const std::string& bucket_name,
+                                   const std::string& index_name,
+                                   uint32_t pg)
+{
+  return object_t(
+      ".rados.vector/v1/" + std::string(pg_lsh_v0_algorithm) + "/" +
+      hash_string(bucket_name) + "/" + hash_string(index_name) + "/pg_" +
+      std::to_string(pg));
+}
+
 inline hash_v0_placement_t compute_hash_v0_placement(
     const std::string& bucket_name,
     const std::string& index_name,
@@ -121,7 +136,6 @@ inline std::string ranked_hash_v0_placement_key(
   return hash_v0_placement_key(hex_u32(hash_to_u32(value)));
 }
 
-
 inline int copy_float32_vector(const ceph::bufferlist& vector_data,
                                uint32_t dimension,
                                std::vector<float> *values)
@@ -146,6 +160,17 @@ inline int lsh_v0_hyperplane_sign(uint32_t table,
   const uint32_t seed =
     table * 0x9e3779b9U ^ bit * 0x85ebca6bU ^ dimension * 0xc2b2ae35U;
   return (mix_u32(seed) & 1U) == 0U ? -1 : 1;
+}
+
+inline int pg_lsh_v0_hyperplane_sign(uint32_t seed,
+                                     uint32_t table,
+                                     uint32_t bit,
+                                     uint32_t dimension)
+{
+  const uint32_t mixed_seed =
+    seed ^ table * 0x9e3779b9U ^ bit * 0x85ebca6bU ^
+    dimension * 0xc2b2ae35U;
+  return (mix_u32(mixed_seed) & 1U) == 0U ? -1 : 1;
 }
 
 inline uint32_t lsh_v0_signature(
@@ -174,9 +199,239 @@ inline uint32_t lsh_v0_signature(
   return signature;
 }
 
+inline uint32_t pg_lsh_v0_lsh_bucket_id(
+    const std::vector<float>& values,
+    uint32_t table,
+    uint32_t lsh_bucket_id_bits,
+    uint32_t seed)
+{
+  if (lsh_bucket_id_bits == 0) {
+    lsh_bucket_id_bits = ceph::rados::vector_lsh_v0_bits;
+  }
+  if (lsh_bucket_id_bits > ceph::rados::vector_lsh_v0_max_bits) {
+    lsh_bucket_id_bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+
+  uint32_t lsh_bucket_id = 0;
+  for (uint32_t bit = 0; bit < lsh_bucket_id_bits; ++bit) {
+    double projection = 0;
+    for (uint32_t dim = 0; dim < values.size(); ++dim) {
+      projection += static_cast<double>(values[dim]) *
+        pg_lsh_v0_hyperplane_sign(seed, table, bit, dim);
+    }
+    if (projection >= 0) {
+      lsh_bucket_id |= 1U << bit;
+    }
+  }
+  return lsh_bucket_id;
+}
+
 inline std::string lsh_v0_placement_key(uint32_t table, uint32_t signature)
 {
   return hex_u32(((table & 0xffffU) << 16) | (signature & 0xffffU));
+}
+
+inline std::string pg_lsh_v0_placement_key(uint32_t pg)
+{
+  return hex_u32(pg);
+}
+
+inline uint32_t pg_lsh_v0_group_to_pg(uint32_t table,
+                                      uint32_t lsh_bucket_id,
+                                      uint32_t pg_num,
+                                      uint32_t seed)
+{
+  if (pg_num == 0) {
+    return 0;
+  }
+  const uint32_t h = mix_u32(seed ^ table * 0x9e3779b9U ^
+                            lsh_bucket_id * 0x85ebca6bU);
+  return h % pg_num;
+}
+
+struct pg_lsh_v0_group_t {
+  uint32_t table = 0;
+  uint32_t lsh_bucket_id = 0;
+  uint32_t hamming_distance = 0;
+};
+
+inline void pg_lsh_v0_append_hamming_masks(uint32_t lsh_bucket_id_bits,
+                                           uint32_t start_bit,
+                                           uint32_t remaining,
+                                           uint32_t mask,
+                                           std::vector<uint32_t> *masks)
+{
+  if (remaining == 0) {
+    masks->push_back(mask);
+    return;
+  }
+  for (uint32_t bit = start_bit; bit < lsh_bucket_id_bits; ++bit) {
+    pg_lsh_v0_append_hamming_masks(
+        lsh_bucket_id_bits, bit + 1, remaining - 1,
+        mask | (1U << bit), masks);
+  }
+}
+
+inline std::vector<uint32_t> pg_lsh_v0_hamming_masks(
+    uint32_t lsh_bucket_id_bits,
+    uint32_t radius)
+{
+  std::vector<uint32_t> masks;
+  if (lsh_bucket_id_bits > ceph::rados::vector_lsh_v0_max_bits) {
+    lsh_bucket_id_bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+  if (radius > lsh_bucket_id_bits) {
+    radius = lsh_bucket_id_bits;
+  }
+  masks.push_back(0);
+  for (uint32_t distance = 1; distance <= radius; ++distance) {
+    pg_lsh_v0_append_hamming_masks(
+        lsh_bucket_id_bits, 0, distance, 0, &masks);
+  }
+  return masks;
+}
+
+inline std::vector<uint32_t> pg_lsh_v0_hamming_masks_at_distance(
+    uint32_t lsh_bucket_id_bits,
+    uint32_t distance)
+{
+  std::vector<uint32_t> masks;
+  if (lsh_bucket_id_bits > ceph::rados::vector_lsh_v0_max_bits) {
+    lsh_bucket_id_bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+  if (distance > lsh_bucket_id_bits) {
+    return masks;
+  }
+  if (distance == 0) {
+    masks.push_back(0);
+    return masks;
+  }
+  pg_lsh_v0_append_hamming_masks(
+      lsh_bucket_id_bits, 0, distance, 0, &masks);
+  return masks;
+}
+
+inline int pg_lsh_v0_exact_groups(const ceph::bufferlist& vector_data,
+                                  uint32_t dimension,
+                                  uint32_t lsh_bucket_id_bits,
+                                  uint32_t table_count,
+                                  uint32_t seed,
+                                  std::vector<pg_lsh_v0_group_t> *groups)
+{
+  if (groups == nullptr || table_count == 0 || table_count > 0xffffU) {
+    return -EINVAL;
+  }
+  std::vector<float> values;
+  int r = copy_float32_vector(vector_data, dimension, &values);
+  if (r < 0) {
+    return r;
+  }
+  groups->clear();
+  groups->reserve(table_count);
+  for (uint32_t table = 0; table < table_count; ++table) {
+    groups->push_back({
+      table,
+      pg_lsh_v0_lsh_bucket_id(values, table, lsh_bucket_id_bits, seed),
+      0,
+    });
+  }
+  return 0;
+}
+
+inline int pg_lsh_v0_query_groups(const ceph::bufferlist& query_vector,
+                                  uint32_t dimension,
+                                  uint32_t lsh_bucket_id_bits,
+                                  uint32_t table_count,
+                                  uint32_t hamming_radius,
+                                  uint32_t seed,
+                                  std::vector<pg_lsh_v0_group_t> *groups)
+{
+  if (groups == nullptr || table_count == 0 || table_count > 0xffffU) {
+    return -EINVAL;
+  }
+  std::vector<pg_lsh_v0_group_t> exact;
+  int r = pg_lsh_v0_exact_groups(
+      query_vector, dimension, lsh_bucket_id_bits, table_count, seed, &exact);
+  if (r < 0) {
+    return r;
+  }
+  groups->clear();
+  groups->reserve(
+      exact.size() * pg_lsh_v0_hamming_masks(lsh_bucket_id_bits,
+                                            hamming_radius).size());
+  if (lsh_bucket_id_bits > ceph::rados::vector_lsh_v0_max_bits) {
+    lsh_bucket_id_bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+  if (hamming_radius > lsh_bucket_id_bits) {
+    hamming_radius = lsh_bucket_id_bits;
+  }
+  for (uint32_t distance = 0; distance <= hamming_radius; ++distance) {
+    const auto masks =
+      pg_lsh_v0_hamming_masks_at_distance(lsh_bucket_id_bits, distance);
+    for (const auto& group : exact) {
+      for (const uint32_t mask : masks) {
+        groups->push_back({
+          group.table,
+          group.lsh_bucket_id ^ mask,
+          distance,
+        });
+      }
+    }
+  }
+  return 0;
+}
+
+struct pg_lsh_v0_ranked_pg_t {
+  uint32_t pg = 0;
+  uint32_t min_hamming_distance = 0;
+  uint32_t table_votes = 0;
+};
+
+inline std::vector<pg_lsh_v0_ranked_pg_t> pg_lsh_v0_select_unique_pgs(
+    const std::vector<pg_lsh_v0_group_t>& groups,
+    uint32_t pg_num,
+    uint32_t seed,
+    uint32_t budget)
+{
+  std::vector<pg_lsh_v0_ranked_pg_t> out;
+  if (pg_num == 0 || budget == 0) {
+    return out;
+  }
+
+  std::unordered_set<uint32_t> seen;
+  out.reserve(std::min<size_t>(groups.size(), budget));
+  for (const auto& group : groups) {
+    const uint32_t pg = pg_lsh_v0_group_to_pg(
+        group.table, group.lsh_bucket_id, pg_num, seed);
+    if (!seen.insert(pg).second) {
+      continue;
+    }
+    out.push_back({
+      pg,
+      group.hamming_distance,
+      1,
+    });
+    if (out.size() == budget) {
+      break;
+    }
+  }
+  return out;
+}
+
+inline std::vector<uint32_t> pg_lsh_v0_select_write_pgs(
+    const std::vector<pg_lsh_v0_group_t>& exact_groups,
+    uint32_t pg_num,
+    uint32_t seed,
+    uint32_t write_pg_count)
+{
+  std::vector<uint32_t> out;
+  out.reserve(write_pg_count);
+  const auto selected = pg_lsh_v0_select_unique_pgs(
+      exact_groups, pg_num, seed, write_pg_count);
+  for (const auto& candidate : selected) {
+    out.push_back(candidate.pg);
+  }
+  return out;
 }
 
 } // namespace vector_placement

--- a/src/librados/vector_query_planner.h
+++ b/src/librados/vector_query_planner.h
@@ -85,6 +85,8 @@ inline std::string default_placement_algorithm(uint32_t algorithm_id)
   switch (algorithm_id) {
   case ceph::rados::vector_query_algorithm_hash:
     return vector_placement::hash_v0_algorithm;
+  case ceph::rados::vector_query_algorithm_lsh:
+    return vector_placement::lsh_v0_algorithm;
   default:
     return std::string();
   }
@@ -113,7 +115,8 @@ inline int validate_index_config(
       ceph::rados::vector_query_algorithm_version_0) {
     return -EOPNOTSUPP;
   }
-  if (config.algorithm_id != ceph::rados::vector_query_algorithm_hash) {
+  if (config.algorithm_id != ceph::rados::vector_query_algorithm_hash &&
+      config.algorithm_id != ceph::rados::vector_query_algorithm_lsh) {
     return -EOPNOTSUPP;
   }
   if (config.data_type != 0 && config.data_type != req_data_type) {
@@ -127,6 +130,30 @@ inline int validate_index_config(
     return -EINVAL;
   }
   return 0;
+}
+
+inline uint32_t lsh_v0_signature_bits(
+    const ceph::bufferlist& algorithm_params)
+{
+  uint32_t bits = ceph::rados::vector_lsh_v0_bits;
+  if (algorithm_params.length() > 0) {
+    try {
+      auto p = algorithm_params.cbegin();
+      decode(bits, p);
+      if (!p.end()) {
+        bits = ceph::rados::vector_lsh_v0_bits;
+      }
+    } catch (const ceph::buffer::error&) {
+      bits = ceph::rados::vector_lsh_v0_bits;
+    }
+  }
+  if (bits == 0) {
+    bits = ceph::rados::vector_lsh_v0_bits;
+  }
+  if (bits > ceph::rados::vector_lsh_v0_max_bits) {
+    bits = ceph::rados::vector_lsh_v0_max_bits;
+  }
+  return bits;
 }
 
 inline int append_hash_v0_targets(
@@ -153,6 +180,108 @@ inline int append_hash_v0_targets(
       placement_key,
       vector_hash,
     });
+  }
+  return 0;
+}
+
+inline int append_lsh_v0_write_targets(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    const ceph::bufferlist& vector_data,
+    uint32_t dimension,
+    uint32_t table_count,
+    uint32_t signature_bits,
+    std::vector<put_target_t> *targets)
+{
+  if (targets == nullptr || table_count == 0 || table_count > 0xffffU) {
+    return -EINVAL;
+  }
+
+  std::vector<float> values;
+  int r = vector_placement::copy_float32_vector(vector_data, dimension, &values);
+  if (r < 0) {
+    return r;
+  }
+
+  const std::string vector_hash =
+    vector_placement::hash_v0_vector_hash(vector_data);
+  for (uint32_t table = 0; table < table_count; ++table) {
+    const uint32_t signature =
+      vector_placement::lsh_v0_signature(values, table, signature_bits);
+    const std::string placement_key =
+      vector_placement::lsh_v0_placement_key(table, signature);
+    targets->push_back({
+      vector_placement::make_lsh_v0_oid(
+          bucket_name, index_name, placement_key),
+      placement_key,
+      vector_hash,
+    });
+  }
+  return 0;
+}
+
+inline void append_lsh_v0_query_target(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    uint32_t table,
+    uint32_t signature,
+    const std::string& vector_hash,
+    std::vector<put_target_t> *targets)
+{
+  const std::string placement_key =
+    vector_placement::lsh_v0_placement_key(table, signature);
+  targets->push_back({
+    vector_placement::make_lsh_v0_oid(bucket_name, index_name, placement_key),
+    placement_key,
+    vector_hash,
+  });
+}
+
+inline int append_lsh_v0_query_targets(
+    const std::string& bucket_name,
+    const std::string& index_name,
+    const ceph::bufferlist& query_vector,
+    uint32_t dimension,
+    uint32_t table_count,
+    uint32_t signature_bits,
+    uint32_t probe_limit,
+    std::vector<put_target_t> *targets)
+{
+  if (targets == nullptr || table_count == 0 || table_count > 0xffffU ||
+      probe_limit == 0) {
+    return -EINVAL;
+  }
+
+  std::vector<float> values;
+  int r = vector_placement::copy_float32_vector(query_vector, dimension, &values);
+  if (r < 0) {
+    return r;
+  }
+
+  const std::string vector_hash =
+    vector_placement::hash_v0_vector_hash(query_vector);
+  std::vector<uint32_t> signatures;
+  signatures.reserve(table_count);
+  for (uint32_t table = 0; table < table_count; ++table) {
+    signatures.push_back(vector_placement::lsh_v0_signature(
+        values, table, signature_bits));
+    append_lsh_v0_query_target(
+        bucket_name, index_name, table, signatures.back(), vector_hash,
+        targets);
+    if (targets->size() >= probe_limit) {
+      return 0;
+    }
+  }
+
+  for (uint32_t bit = 0; bit < signature_bits; ++bit) {
+    for (uint32_t table = 0; table < table_count; ++table) {
+      append_lsh_v0_query_target(
+          bucket_name, index_name, table, signatures[table] ^ (1U << bit),
+          vector_hash, targets);
+      if (targets->size() >= probe_limit) {
+        return 0;
+      }
+    }
   }
   return 0;
 }
@@ -196,6 +325,12 @@ inline int build_put_plan(
     return append_hash_v0_targets(
         req.bucket_name, req.index_name, req.vector_data,
         plan->routing_policy.write_pgs, &plan->targets);
+  } else if (placement_algorithm == vector_placement::lsh_v0_algorithm) {
+    const uint32_t signature_bits =
+      lsh_v0_signature_bits(config.algorithm_params);
+    return append_lsh_v0_write_targets(
+        req.bucket_name, req.index_name, req.vector_data, req.dimension,
+        plan->routing_policy.write_pgs, signature_bits, &plan->targets);
   }
   return -EOPNOTSUPP;
 }
@@ -239,6 +374,13 @@ inline int build_query_plan(
   if (placement_algorithm == vector_placement::hash_v0_algorithm) {
     r = append_hash_v0_targets(
         req.bucket_name, req.index_name, req.query_vector,
+        plan->routing_policy.probe_pgs, &targets);
+  } else if (placement_algorithm == vector_placement::lsh_v0_algorithm) {
+    const uint32_t signature_bits =
+      lsh_v0_signature_bits(config.algorithm_params);
+    r = append_lsh_v0_query_targets(
+        req.bucket_name, req.index_name, req.query_vector, req.dimension,
+        plan->routing_policy.write_pgs, signature_bits,
         plan->routing_policy.probe_pgs, &targets);
   } else {
     return -EOPNOTSUPP;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7096,6 +7096,16 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	if (result < 0) {
 	  break;
 	}
+		dout(20) << "vector-debug query request object name="
+		<< soid.oid.name
+		<< " bucket=" << req.bucket_name
+		<< " index=" << req.index_name
+		<< " data_type=" << req.data_type
+		<< " distance_metric=" << req.distance_metric
+		<< " dimension=" << req.dimension
+		<< " local_top_k=" << req.local_top_k
+		<< " probe_prefix_count=" << req.probe_prefixes.size()
+		<< dendl;
 
 	ceph::rados::vector_query_exec::omap_scan_state_t scan;
 	if (oi.is_omap()) {
@@ -7112,13 +7122,49 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    break;
 	  }
 	}
+		dout(20) << "vector-debug query iterated object name="
+		<< soid.oid.name
+		<< " soid=" << soid
+		<< " content_count=" << scan.contents.size()
+		<< " entry_count=" << scan.entries.size()
+		<< dendl;
 
 	ceph::rados::query_vectors_result_t query_result;
+	ceph::rados::vector_query_exec::query_filter_stats_t filter_stats;
 	result = ceph::rados::vector_query_exec::build_local_results(
-	    req, scan, &query_result);
+	    req, scan, &query_result, &filter_stats);
 	if (result < 0) {
 	  break;
 	}
+	query_result.local_matching_entries = filter_stats.matched_entries;
+	query_result.local_distance_computations =
+	  filter_stats.distance_computations;
+		dout(20) << "vector-debug query filter object name="
+		<< soid.oid.name
+		<< " bucket=" << req.bucket_name
+		<< " index=" << req.index_name
+		<< " data_type=" << req.data_type
+		<< " distance_metric=" << req.distance_metric
+		<< " dimension=" << req.dimension
+		<< " entry_count=" << scan.entries.size()
+		<< " content_count=" << scan.contents.size()
+		<< " total_entries=" << filter_stats.total_entries
+		<< " matched_entries=" << filter_stats.matched_entries
+		<< " distance_computations="
+		<< filter_stats.distance_computations
+		<< " merged_entries=" << filter_stats.merged_entries
+		<< " final_entries=" << filter_stats.final_entries
+		<< " incomplete_entries=" << filter_stats.incomplete_entries
+		<< " bucket_mismatch=" << filter_stats.bucket_mismatch
+		<< " index_mismatch=" << filter_stats.index_mismatch
+		<< " data_type_mismatch=" << filter_stats.data_type_mismatch
+		<< " distance_metric_mismatch="
+		<< filter_stats.distance_metric_mismatch
+		<< " dimension_mismatch=" << filter_stats.dimension_mismatch
+		<< " probe_mismatch=" << filter_stats.probe_mismatch
+		<< " missing_content=" << filter_stats.missing_content
+		<< " distance_error=" << filter_stats.distance_error
+		<< dendl;
 
 	encode(query_result, osd_op.outdata);
 	ctx->delta_stats.num_rd_kb +=
@@ -7159,6 +7205,18 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	if (result < 0) {
 	  break;
 	}
+		dout(20) << "vector-debug put request object name="
+			<< soid.oid.name
+			<< " algorithm=" << req.placement_algorithm
+			<< " bucket=" << req.bucket_name
+		<< " index=" << req.index_name
+		<< " key=" << req.key
+		<< " data_type=" << req.data_type
+		<< " distance_metric=" << req.distance_metric
+		<< " dimension=" << req.dimension
+		<< " placement_key=" << req.placement_key
+		<< " vector_hash=" << req.vector_hash
+		<< dendl;
 
 	maybe_create_new_object(ctx);
 

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -3,11 +3,13 @@
 
 #include <climits>
 #include <cstdio>
+#include <vector>
 
 #include "include/rados/librados.h"
 #include "include/ceph_hash.h"
 #include "include/encoding.h"
 #include "include/err.h"
+#include "librados/vector_placement.h"
 #include "include/scope_guard.h"
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
@@ -28,12 +30,6 @@ static string vector_hex_u32(uint32_t value)
   return string(buf);
 }
 
-static string vector_hash_string(const string& value)
-{
-  return vector_hex_u32(ceph_str_hash_rjenkins(
-      value.c_str(), static_cast<unsigned>(value.length())));
-}
-
 static string vector_test_oid(const string& bucket, const string& index,
                               const string& key, const void *vector_data,
                               size_t vector_data_len)
@@ -41,11 +37,16 @@ static string vector_test_oid(const string& bucket, const string& index,
   (void)key;
   bufferlist bl;
   bl.append(static_cast<const char *>(vector_data), vector_data_len);
-  const string vector_hash =
-    vector_hex_u32(bl.crc32c(static_cast<uint32_t>(-1)));
-  const string placement_key = vector_hash.substr(0, 4);
-  return ".rados.vector/v1/hash-v0/" + vector_hash_string(bucket) + "/" +
-    vector_hash_string(index) + "/" + placement_key;
+  std::vector<float> values;
+  if (librados::vector_placement::copy_float32_vector(bl, 4, &values) < 0) {
+    return string();
+  }
+  const uint32_t signature =
+    librados::vector_placement::lsh_v0_signature(values, 0);
+  const string placement_key =
+    librados::vector_placement::lsh_v0_placement_key(0, signature);
+  return librados::vector_placement::make_lsh_v0_oid(
+      bucket, index, placement_key).name;
 }
 
 TEST_F(LibRadosIo, SimpleWrite) {

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -5,6 +5,7 @@
 #include <climits>
 #include <cstdio>
 #include <errno.h>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -34,22 +35,22 @@ static string vector_hex_u32(uint32_t value)
   return string(buf);
 }
 
-static string vector_hash_string(const string& value)
-{
-  return vector_hex_u32(ceph_str_hash_rjenkins(
-      value.c_str(), static_cast<unsigned>(value.length())));
-}
-
 static string vector_test_oid(const string& bucket, const string& index,
                               const string& key,
                               const bufferlist& vector_data)
 {
   (void)key;
-  const string vector_hash =
-    vector_hex_u32(vector_data.crc32c(static_cast<uint32_t>(-1)));
-  const string placement_key = vector_hash.substr(0, 4);
-  return ".rados.vector/v1/hash-v0/" + vector_hash_string(bucket) + "/" +
-    vector_hash_string(index) + "/" + placement_key;
+  std::vector<float> values;
+  if (librados::vector_placement::copy_float32_vector(
+        vector_data, 4, &values) < 0) {
+    return string();
+  }
+  const uint32_t signature =
+    librados::vector_placement::lsh_v0_signature(values, 0);
+  const string placement_key =
+    librados::vector_placement::lsh_v0_placement_key(0, signature);
+  return librados::vector_placement::make_lsh_v0_oid(
+      bucket, index, placement_key).name;
 }
 
 static string vector_entry_id(const string& bucket, const string& index,

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -2,10 +2,19 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <climits>
 #include <cstdio>
 #include <errno.h>
+#include <limits>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <thread>
+#include <unordered_set>
 #include <vector>
+#include <unistd.h>
 
 #include "gtest/gtest.h"
 
@@ -15,6 +24,8 @@
 #include "include/err.h"
 #include "include/scope_guard.h"
 #include "common/vector_query_exec.h"
+#include "json_spirit/json_spirit.h"
+#include "librados/vector_pg_lsh.h"
 #include "librados/vector_placement.h"
 #include "librados/vector_query_planner.h"
 #include "test/librados/test_cxx.h"
@@ -65,6 +76,38 @@ static string vector_entry_id(const string& bucket, const string& index,
   value.append(key);
   return vector_hex_u32(ceph_str_hash_rjenkins(
       value.c_str(), static_cast<unsigned>(value.length())));
+}
+
+static uint32_t pg_lsh_test_lsh_bucket_id_for_pg(uint32_t table,
+                                                 uint32_t pg_num,
+                                                 uint32_t seed,
+                                                 uint32_t target_pg)
+{
+  for (uint32_t lsh_bucket_id = 0;
+       lsh_bucket_id < (1U << ceph::rados::vector_lsh_v0_max_bits);
+       ++lsh_bucket_id) {
+    if (librados::vector_placement::pg_lsh_v0_group_to_pg(
+          table, lsh_bucket_id, pg_num, seed) == target_pg) {
+      return lsh_bucket_id;
+    }
+  }
+  return std::numeric_limits<uint32_t>::max();
+}
+
+static uint32_t pg_lsh_test_lsh_bucket_id_not_pg(uint32_t table,
+                                                 uint32_t pg_num,
+                                                 uint32_t seed,
+                                                 uint32_t excluded_pg)
+{
+  for (uint32_t lsh_bucket_id = 0;
+       lsh_bucket_id < (1U << ceph::rados::vector_lsh_v0_max_bits);
+       ++lsh_bucket_id) {
+    if (librados::vector_placement::pg_lsh_v0_group_to_pg(
+          table, lsh_bucket_id, pg_num, seed) != excluded_pg) {
+      return lsh_bucket_id;
+    }
+  }
+  return std::numeric_limits<uint32_t>::max();
 }
 
 static librados::vector_query::query_request_t make_query_planner_request(
@@ -406,6 +449,672 @@ TEST(VectorQueryPlanner, PutPlanRespectsWritePolicy) {
   EXPECT_EQ(placement.vector_hash, plan.targets[0].vector_hash);
   EXPECT_NE(plan.targets[0].placement_key, plan.targets[1].placement_key);
   EXPECT_NE(plan.targets[1].placement_key, plan.targets[2].placement_key);
+}
+
+TEST(VectorPlacement, PgLshV0SelectionUsesLogicalOrderAndBudget) {
+  float vector[] = {1.0, -2.0, 3.0, -4.0};
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+
+  constexpr uint32_t k = 10;
+  constexpr uint32_t l = 16;
+  constexpr uint32_t seed = 12345;
+  constexpr uint32_t pg_num = 16;
+
+  std::vector<librados::vector_placement::pg_lsh_v0_group_t> exact1;
+  std::vector<librados::vector_placement::pg_lsh_v0_group_t> exact2;
+  ASSERT_EQ(0, librados::vector_placement::pg_lsh_v0_exact_groups(
+      vector_bl, 4, k, l, seed, &exact1));
+  ASSERT_EQ(0, librados::vector_placement::pg_lsh_v0_exact_groups(
+      vector_bl, 4, k, l, seed, &exact2));
+  ASSERT_EQ(l, exact1.size());
+  ASSERT_EQ(exact1.size(), exact2.size());
+  for (size_t i = 0; i < exact1.size(); ++i) {
+    EXPECT_EQ(exact1[i].table, exact2[i].table);
+    EXPECT_EQ(exact1[i].lsh_bucket_id, exact2[i].lsh_bucket_id);
+    EXPECT_EQ(0u, exact1[i].hamming_distance);
+  }
+
+  const auto write_pgs =
+    librados::vector_placement::pg_lsh_v0_select_write_pgs(
+        exact1, pg_num, seed, 4);
+  ASSERT_EQ(4u, write_pgs.size());
+  std::unordered_set<uint32_t> unique_write_pgs(
+      write_pgs.begin(), write_pgs.end());
+  EXPECT_EQ(write_pgs.size(), unique_write_pgs.size());
+
+  std::vector<librados::vector_placement::pg_lsh_v0_group_t> query_groups;
+  ASSERT_EQ(0, librados::vector_placement::pg_lsh_v0_query_groups(
+      vector_bl, 4, k, l, 1, seed, &query_groups));
+  EXPECT_EQ(l * (1 + k), query_groups.size());
+  for (uint32_t table = 0; table < l; ++table) {
+    EXPECT_EQ(table, query_groups[table].table);
+    EXPECT_EQ(0u, query_groups[table].hamming_distance);
+  }
+  for (uint32_t table = 0; table < l; ++table) {
+    const size_t first_radius_one = l + table * k;
+    EXPECT_EQ(table, query_groups[first_radius_one].table);
+    EXPECT_EQ(1u, query_groups[first_radius_one].hamming_distance);
+  }
+
+  librados::vector_pg_lsh::pool_pg_info_t pool_info;
+  pool_info.pg_num = pg_num;
+  pool_info.pgp_num = pg_num;
+  pool_info.osdmap_epoch = 1;
+
+  librados::vector_pg_lsh::params_t params;
+  params.k = k;
+  params.l = l;
+  params.seed = seed;
+  params.hamming_radius = 0;
+  params.d = 2;
+  params.m = 16;
+
+  std::vector<librados::vector_placement::pg_lsh_v0_ranked_pg_t> query_pgs;
+  uint64_t generated_group_count = 0;
+  ASSERT_EQ(0, librados::vector_pg_lsh::select_query_pgs(
+      vector_bl, 4, params, pool_info, &query_pgs,
+      &generated_group_count));
+  EXPECT_EQ(l, generated_group_count);
+  EXPECT_LT(query_pgs.size(), params.m);
+  EXPECT_EQ(10u, query_pgs.size());
+  std::unordered_set<uint32_t> unique_query_pgs;
+  for (const auto& pg : query_pgs) {
+    EXPECT_TRUE(unique_query_pgs.insert(pg.pg).second);
+  }
+
+  std::vector<uint32_t> vector_write_pgs;
+  ASSERT_EQ(0, librados::vector_pg_lsh::select_write_pgs(
+      vector_bl, 4, params, pool_info, &vector_write_pgs));
+  ASSERT_EQ(params.d, vector_write_pgs.size());
+
+  params.m = 8;
+  ASSERT_EQ(0, librados::vector_pg_lsh::select_query_pgs(
+      vector_bl, 4, params, pool_info, &query_pgs,
+      &generated_group_count));
+  EXPECT_EQ(l, generated_group_count);
+  ASSERT_EQ(params.m, query_pgs.size());
+  unique_query_pgs.clear();
+  for (const auto& pg : query_pgs) {
+    unique_query_pgs.insert(pg.pg);
+  }
+  for (const uint32_t pg : vector_write_pgs) {
+    EXPECT_EQ(1u, unique_query_pgs.count(pg));
+  }
+
+  params.m = 16;
+  params.hamming_radius = 1;
+  ASSERT_EQ(0, librados::vector_pg_lsh::select_query_pgs(
+      vector_bl, 4, params, pool_info, &query_pgs,
+      &generated_group_count));
+  EXPECT_EQ(l * (1 + k), generated_group_count);
+  ASSERT_EQ(params.m, query_pgs.size());
+
+  librados::vector_pg_lsh::params_t exhausted_params;
+  exhausted_params.k = 1;
+  exhausted_params.l = 2;
+  exhausted_params.seed = seed;
+  exhausted_params.hamming_radius = 0;
+  exhausted_params.d = 1;
+  exhausted_params.m = 16;
+  ASSERT_EQ(0, librados::vector_pg_lsh::select_query_pgs(
+      vector_bl, 4, exhausted_params, pool_info, &query_pgs,
+      &generated_group_count));
+  EXPECT_EQ(2u, generated_group_count);
+  EXPECT_LE(query_pgs.size(), generated_group_count);
+  EXPECT_LT(query_pgs.size(), exhausted_params.m);
+}
+
+TEST(VectorPlacement, PgLshV0ManualCollisionSelection) {
+  constexpr uint32_t seed = 12345;
+  constexpr uint32_t pg_num = 16;
+  const uint32_t collision_pg =
+    librados::vector_placement::pg_lsh_v0_group_to_pg(
+        0, 0, pg_num, seed);
+  const uint32_t table1_collision_lsh_bucket_id =
+    pg_lsh_test_lsh_bucket_id_for_pg(1, pg_num, seed, collision_pg);
+  const uint32_t table2_other_lsh_bucket_id =
+    pg_lsh_test_lsh_bucket_id_not_pg(2, pg_num, seed, collision_pg);
+  ASSERT_NE(std::numeric_limits<uint32_t>::max(),
+            table1_collision_lsh_bucket_id);
+  ASSERT_NE(std::numeric_limits<uint32_t>::max(),
+            table2_other_lsh_bucket_id);
+
+  std::vector<librados::vector_placement::pg_lsh_v0_group_t> exact = {
+    {0, 0, 0},
+    {1, table1_collision_lsh_bucket_id, 0},
+    {2, table2_other_lsh_bucket_id, 0},
+  };
+  const auto write_pgs =
+    librados::vector_placement::pg_lsh_v0_select_write_pgs(
+        exact, pg_num, seed, 2);
+  ASSERT_EQ(2u, write_pgs.size());
+  EXPECT_EQ(collision_pg, write_pgs[0]);
+  EXPECT_NE(collision_pg, write_pgs[1]);
+
+  bool found_order_case = false;
+  uint32_t high_pg = 0;
+  uint32_t low_pg = 0;
+  uint32_t high_lsh_bucket_id = 0;
+  uint32_t low_lsh_bucket_id = 0;
+  for (uint32_t candidate_high = pg_num - 1;
+       candidate_high > 0 && !found_order_case;
+       --candidate_high) {
+    const uint32_t candidate_high_lsh_bucket_id =
+      pg_lsh_test_lsh_bucket_id_for_pg(0, pg_num, seed, candidate_high);
+    if (candidate_high_lsh_bucket_id ==
+        std::numeric_limits<uint32_t>::max()) {
+      continue;
+    }
+    for (uint32_t candidate_low = 0;
+         candidate_low < candidate_high;
+         ++candidate_low) {
+      const uint32_t candidate_low_lsh_bucket_id =
+        pg_lsh_test_lsh_bucket_id_for_pg(1, pg_num, seed, candidate_low);
+      if (candidate_low_lsh_bucket_id ==
+          std::numeric_limits<uint32_t>::max()) {
+        continue;
+      }
+      high_pg = candidate_high;
+      low_pg = candidate_low;
+      high_lsh_bucket_id = candidate_high_lsh_bucket_id;
+      low_lsh_bucket_id = candidate_low_lsh_bucket_id;
+      found_order_case = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found_order_case);
+
+  const std::vector<librados::vector_placement::pg_lsh_v0_group_t>
+    order_groups = {
+      {0, high_lsh_bucket_id, 0},
+      {1, low_lsh_bucket_id, 0},
+    };
+  const auto selected = librados::vector_placement::pg_lsh_v0_select_unique_pgs(
+      order_groups, pg_num, seed, 2);
+  ASSERT_EQ(2u, selected.size());
+  ASSERT_GT(high_pg, low_pg);
+  EXPECT_EQ(high_pg, selected[0].pg);
+  EXPECT_EQ(low_pg, selected[1].pg);
+}
+
+static bool vector_test_json_uint64(const std::string& body,
+                                    const std::string& field,
+                                    uint64_t *out)
+{
+  if (out == nullptr) {
+    return false;
+  }
+  json_spirit::mValue root;
+  if (!json_spirit::read(body, root) ||
+      root.type() != json_spirit::obj_type) {
+    return false;
+  }
+  const auto& obj = root.get_obj();
+  const auto it = obj.find(field);
+  if (it == obj.end() || it->second.type() != json_spirit::int_type) {
+    return false;
+  }
+  const int64_t value = it->second.get_int64();
+  if (value < 0) {
+    return false;
+  }
+  *out = static_cast<uint64_t>(value);
+  return true;
+}
+
+static int pool_pg_info_for_test(
+    Rados& cluster,
+    const std::string& pool_name,
+    librados::vector_pg_lsh::pool_pg_info_t *info)
+{
+  if (info == nullptr) {
+    return -EINVAL;
+  }
+
+  bufferlist outbl;
+  uint64_t value = 0;
+  std::string cmd = "{\"prefix\":\"osd pool get\",\"pool\":\"" + pool_name +
+    "\",\"var\":\"pg_num\",\"format\":\"json\"}";
+  int r = cluster.mon_command(std::move(cmd), {}, &outbl, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  if (!vector_test_json_uint64(outbl.to_str(), "pg_num", &value) ||
+      value == 0 || value > std::numeric_limits<uint32_t>::max()) {
+    return -EINVAL;
+  }
+  info->pg_num = static_cast<uint32_t>(value);
+
+  outbl.clear();
+  cmd = "{\"prefix\":\"osd pool get\",\"pool\":\"" + pool_name +
+    "\",\"var\":\"pgp_num\",\"format\":\"json\"}";
+  r = cluster.mon_command(std::move(cmd), {}, &outbl, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  if (!vector_test_json_uint64(outbl.to_str(), "pgp_num", &value) ||
+      value == 0 || value > std::numeric_limits<uint32_t>::max()) {
+    return -EINVAL;
+  }
+  info->pgp_num = static_cast<uint32_t>(value);
+
+  outbl.clear();
+  cmd = "{\"prefix\":\"osd dump\",\"format\":\"json\"}";
+  r = cluster.mon_command(std::move(cmd), {}, &outbl, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  if (!vector_test_json_uint64(outbl.to_str(), "epoch", &value)) {
+    return -EINVAL;
+  }
+  info->osdmap_epoch = value;
+  return 0;
+}
+
+static int ensure_pool_pg_count_for_test(Rados& cluster,
+                                         const std::string& pool_name,
+                                         uint32_t required_pg_num,
+                                         librados::vector_pg_lsh::pool_pg_info_t *info)
+{
+  if (info == nullptr || required_pg_num == 0) {
+    return -EINVAL;
+  }
+
+  int r = pool_pg_info_for_test(cluster, pool_name, info);
+  if (r < 0) {
+    return r;
+  }
+  if (info->pg_num >= required_pg_num &&
+      info->pgp_num >= required_pg_num) {
+    return cluster.wait_for_latest_osdmap();
+  }
+
+  bufferlist outbl;
+  std::string cmd = "{\"prefix\":\"osd pool set\",\"pool\":\"" + pool_name +
+    "\",\"var\":\"pg_num\",\"val\":\"" + std::to_string(required_pg_num) +
+    "\",\"format\":\"json\"}";
+  r = cluster.mon_command(std::move(cmd), {}, &outbl, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  outbl.clear();
+  cmd = "{\"prefix\":\"osd pool set\",\"pool\":\"" + pool_name +
+    "\",\"var\":\"pgp_num\",\"val\":\"" + std::to_string(required_pg_num) +
+    "\",\"format\":\"json\"}";
+  r = cluster.mon_command(std::move(cmd), {}, &outbl, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  r = cluster.wait_for_latest_osdmap();
+  if (r < 0) {
+    return r;
+  }
+
+  for (int attempt = 0; attempt < 30; ++attempt) {
+    r = pool_pg_info_for_test(cluster, pool_name, info);
+    if (r < 0) {
+      return r;
+    }
+    if (info->pg_num >= required_pg_num &&
+        info->pgp_num >= required_pg_num) {
+      return 0;
+    }
+    sleep(1);
+  }
+  return -ETIMEDOUT;
+}
+
+static int acting_primary_for_raw_pg(Rados& cluster,
+                                     int64_t pool_id,
+                                     uint32_t raw_pg,
+                                     int *primary);
+
+static int choose_two_raw_pgs_with_different_primaries(
+    Rados& cluster,
+    int64_t pool_id,
+    uint32_t pg_num,
+    uint32_t *pg0,
+    uint32_t *pg1,
+    int *primary0,
+    int *primary1)
+{
+  if (pg0 == nullptr || pg1 == nullptr ||
+      primary0 == nullptr || primary1 == nullptr ||
+      pg_num < 2) {
+    return -EINVAL;
+  }
+
+  bool have_pg0 = false;
+  for (uint32_t pg = 0; pg < pg_num; ++pg) {
+    int primary = -1;
+    int r = acting_primary_for_raw_pg(cluster, pool_id, pg, &primary);
+    if (r < 0) {
+      return r;
+    }
+    if (!have_pg0) {
+      *pg0 = pg;
+      *primary0 = primary;
+      have_pg0 = true;
+      continue;
+    }
+    if (primary != *primary0) {
+      *pg1 = pg;
+      *primary1 = primary;
+      return 0;
+    }
+  }
+  return -ENOENT;
+}
+
+static int acting_primary_for_raw_pg(Rados& cluster,
+                                     int64_t pool_id,
+                                     uint32_t raw_pg,
+                                     int *primary)
+{
+  if (primary == nullptr || pool_id < 0) {
+    return -EINVAL;
+  }
+
+  std::ostringstream pgid;
+  pgid << pool_id << "." << std::hex << raw_pg;
+  bufferlist outbl;
+  std::string cmd = "{\"prefix\":\"pg map\",\"pgid\":\"" + pgid.str() +
+    "\",\"format\":\"json\"}";
+  int r = cluster.mon_command(std::move(cmd), {}, &outbl, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  json_spirit::mValue root;
+  if (!json_spirit::read(outbl.to_str(), root)) {
+    return -EINVAL;
+  }
+  const auto& obj = root.get_obj();
+  const auto acting_it = obj.find("acting");
+  if (acting_it == obj.end()) {
+    return -ENOENT;
+  }
+  const auto& acting = acting_it->second.get_array();
+  if (acting.empty()) {
+    return -ENOENT;
+  }
+  *primary = acting.front().get_int();
+  return 0;
+}
+
+static int put_pg_lsh_test_vector(IoCtx& ioctx,
+                                  uint32_t pg,
+                                  const string& locator,
+                                  const string& key,
+                                  const float *vector,
+                                  size_t vector_len)
+{
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), vector_len);
+
+  ceph::rados::put_vector_request_t req;
+  req.bucket_name = "pg-lsh-bucket";
+  req.index_name = "pg-lsh-index";
+  req.key = key;
+  req.data_type = ceph::rados::vector_data_type_float32;
+  req.distance_metric = ceph::rados::vector_distance_metric_euclidean;
+  req.dimension = 4;
+  req.vector_data = vector_bl;
+
+  librados::vector_pg_lsh::put_target_t target;
+  target.pg = pg;
+  target.oid = librados::vector_placement::make_pg_lsh_v0_oid(
+      req.bucket_name, req.index_name, pg);
+  target.locator_key = locator;
+  target.placement_key =
+    librados::vector_placement::pg_lsh_v0_placement_key(pg);
+  target.vector_hash =
+    librados::vector_placement::hash_v0_vector_hash(vector_bl);
+  return librados::vector_pg_lsh::put_vector(ioctx, target, std::move(req));
+}
+
+TEST_F(LibRadosIoPP, PgLshV0RawOpsRouteAndMergeByEntryId) {
+  librados::vector_pg_lsh::pool_pg_info_t pool_info;
+  ASSERT_EQ(0, ensure_pool_pg_count_for_test(
+      cluster, pool_name, 8, &pool_info));
+  ioctx.close();
+  ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
+  ASSERT_EQ(0, cluster.wait_for_latest_osdmap());
+
+  const int64_t pool_id = ioctx.get_id();
+  ASSERT_GE(pool_id, 0);
+
+  uint32_t pg0 = 0;
+  uint32_t pg1 = 0;
+  int primary0 = -1;
+  int primary1 = -1;
+  const int choose_ret = choose_two_raw_pgs_with_different_primaries(
+      cluster, pool_id, pool_info.pg_num, &pg0, &pg1,
+      &primary0, &primary1);
+  if (choose_ret == -ENOENT) {
+    GTEST_SKIP() << "test pool does not expose two acting primaries";
+  }
+  ASSERT_EQ(0, choose_ret);
+  EXPECT_NE(primary0, primary1);
+
+  auto locator_state =
+    std::make_shared<librados::vector_pg_lsh::locator_state_t>();
+  librados::vector_pg_lsh::locator_cache_t locator_cache(
+      &ioctx, pool_info, pool_name, "pg-lsh-bucket", "pg-lsh-index",
+      locator_state);
+  ASSERT_EQ(0, locator_cache.precompute_all());
+  IoCtx& test_ioctx = ioctx;
+  std::atomic<uint32_t> locator_errors{0};
+  std::vector<std::thread> locator_threads;
+  for (uint32_t thread_id = 0; thread_id < 4; ++thread_id) {
+    locator_threads.emplace_back([&locator_cache, &test_ioctx, &pool_info,
+                                  &locator_errors] {
+      for (uint32_t pg = 0; pg < pool_info.pg_num; ++pg) {
+        string locator;
+        uint32_t actual = 0;
+        if (locator_cache.locator_for_pg(pg, &locator) < 0 ||
+            test_ioctx.get_object_pg_hash_position2(locator, &actual) < 0 ||
+            actual != pg) {
+          locator_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto& thread : locator_threads) {
+    thread.join();
+  }
+  ASSERT_EQ(0u, locator_errors.load());
+
+  librados::vector_pg_lsh::params_t params;
+  params.k = 4;
+  params.l = 2;
+  params.seed = 12345;
+  params.hamming_radius = 0;
+  params.d = 2;
+  params.m = 2;
+  ASSERT_EQ(0, librados::vector_pg_lsh::validate_params(
+      params, pool_info));
+
+  std::array<float, 4> near_vector = {};
+  std::vector<librados::vector_pg_lsh::put_target_t> put_targets;
+  std::vector<librados::vector_pg_lsh::query_probe_t> probes;
+  uint64_t generated_group_count = 0;
+  int query_primary0 = -1;
+  int query_primary1 = -1;
+  bool found_vector = false;
+  for (uint32_t candidate = 0; candidate < 4096; ++candidate) {
+    std::array<float, 4> candidate_vector = {};
+    for (uint32_t dim = 0; dim < candidate_vector.size(); ++dim) {
+      const uint32_t x = candidate * 1103515245u + 12345u +
+        dim * 2654435761u;
+      int raw = static_cast<int>((x >> 24) & 0xffU) - 128;
+      if (raw == 0) {
+        raw = static_cast<int>(dim) + 1;
+      }
+      candidate_vector[dim] = static_cast<float>(raw) / 17.0f;
+    }
+
+    bufferlist candidate_bl;
+    candidate_bl.append(
+        reinterpret_cast<const char *>(candidate_vector.data()),
+        candidate_vector.size() * sizeof(float));
+
+    std::vector<librados::vector_pg_lsh::put_target_t> candidate_targets;
+    if (librados::vector_pg_lsh::build_put_targets(
+          "pg-lsh-bucket", "pg-lsh-index", candidate_bl,
+          candidate_vector.size(), params, pool_info, &locator_cache,
+          &candidate_targets) < 0 ||
+        candidate_targets.size() != params.d ||
+        candidate_targets[0].pg == candidate_targets[1].pg) {
+      continue;
+    }
+
+    std::vector<librados::vector_pg_lsh::query_probe_t> candidate_probes;
+    uint64_t candidate_generated_groups = 0;
+    if (librados::vector_pg_lsh::build_query_probes(
+          "pg-lsh-bucket", "pg-lsh-index", candidate_bl,
+          candidate_vector.size(), params, pool_info, &locator_cache,
+          &candidate_probes, &candidate_generated_groups) < 0 ||
+        candidate_probes.size() != params.m ||
+        candidate_generated_groups != params.l) {
+      continue;
+    }
+
+    const std::unordered_set<uint32_t> write_pgs = {
+      candidate_targets[0].pg,
+      candidate_targets[1].pg,
+    };
+    const std::unordered_set<uint32_t> query_pgs = {
+      candidate_probes[0].pg,
+      candidate_probes[1].pg,
+    };
+    if (write_pgs != query_pgs) {
+      continue;
+    }
+
+    int p0 = -1;
+    int p1 = -1;
+    ASSERT_EQ(0, acting_primary_for_raw_pg(
+        cluster, pool_id, candidate_probes[0].pg, &p0));
+    ASSERT_EQ(0, acting_primary_for_raw_pg(
+        cluster, pool_id, candidate_probes[1].pg, &p1));
+    if (p0 == p1) {
+      continue;
+    }
+
+    near_vector = candidate_vector;
+    put_targets = std::move(candidate_targets);
+    probes = std::move(candidate_probes);
+    generated_group_count = candidate_generated_groups;
+    query_primary0 = p0;
+    query_primary1 = p1;
+    found_vector = true;
+    break;
+  }
+  ASSERT_TRUE(found_vector)
+    << "failed to find deterministic D=2/M=2 pg-lsh route across acting primaries";
+  ASSERT_EQ(params.d, put_targets.size());
+  ASSERT_EQ(params.m, probes.size());
+  ASSERT_EQ(params.l, generated_group_count);
+  EXPECT_NE(query_primary0, query_primary1);
+
+  std::unordered_set<uint32_t> queried_pgs;
+  for (const auto& probe : probes) {
+    EXPECT_TRUE(queried_pgs.insert(probe.pg).second);
+    uint32_t actual = 0;
+    ASSERT_EQ(0, ioctx.get_object_pg_hash_position2(
+        probe.locator_key, &actual));
+    EXPECT_EQ(probe.pg, actual);
+  }
+  ASSERT_EQ(params.m, queried_pgs.size());
+  for (const auto& target : put_targets) {
+    EXPECT_EQ(1u, queried_pgs.count(target.pg));
+    uint32_t actual = 0;
+    ASSERT_EQ(0, ioctx.get_object_pg_hash_position2(
+        target.locator_key, &actual));
+    EXPECT_EQ(target.pg, actual);
+  }
+
+  bufferlist near_bl;
+  near_bl.append(reinterpret_cast<const char *>(near_vector.data()),
+                 near_vector.size() * sizeof(float));
+  ceph::rados::put_vector_request_t put_req;
+  put_req.bucket_name = "pg-lsh-bucket";
+  put_req.index_name = "pg-lsh-index";
+  put_req.key = "vec-dup";
+  put_req.data_type = ceph::rados::vector_data_type_float32;
+  put_req.distance_metric = ceph::rados::vector_distance_metric_euclidean;
+  put_req.dimension = near_vector.size();
+  put_req.vector_data = near_bl;
+  for (const auto& target : put_targets) {
+    ASSERT_EQ(0, librados::vector_pg_lsh::put_vector(
+        ioctx, target, put_req));
+  }
+
+  const float far_vector[] = {10.0, 20.0, 30.0, 40.0};
+  ASSERT_EQ(0, put_pg_lsh_test_vector(
+      ioctx, probes[1].pg, probes[1].locator_key, "vec-far",
+      far_vector, sizeof(far_vector)));
+
+  struct PendingProbe {
+    librados::vector_pg_lsh::query_probe_t probe;
+    librados::vector_pg_lsh::query_op_state_t op_state;
+    std::unique_ptr<AioCompletion> completion;
+    bufferlist reply;
+    int op_rval = 0;
+  };
+  std::vector<std::unique_ptr<PendingProbe>> pending;
+  pending.reserve(probes.size());
+  for (const auto& probe : probes) {
+    auto pending_probe = std::make_unique<PendingProbe>();
+    pending_probe->probe = probe;
+    pending_probe->completion.reset(Rados::aio_create_completion());
+    ASSERT_NE(nullptr, pending_probe->completion);
+
+    ceph::rados::query_vectors_request_t req;
+    req.bucket_name = "pg-lsh-bucket";
+    req.index_name = "pg-lsh-index";
+    req.data_type = ceph::rados::vector_data_type_float32;
+    req.distance_metric = ceph::rados::vector_distance_metric_euclidean;
+    req.dimension = near_vector.size();
+    req.local_top_k = std::numeric_limits<uint32_t>::max();
+    req.query_vector = near_bl;
+
+    ASSERT_EQ(0, librados::vector_pg_lsh::submit_query(
+        ioctx, probe, std::move(req), &pending_probe->op_state,
+        pending_probe->completion.get(), &pending_probe->reply,
+        &pending_probe->op_rval));
+    pending.push_back(std::move(pending_probe));
+  }
+
+  std::vector<ceph::rados::query_vectors_result_entry_t> merged;
+  uint64_t matching_entries = 0;
+  uint64_t distance_computations = 0;
+  for (const auto& pending_probe : pending) {
+    ASSERT_EQ(0, pending_probe->completion->wait_for_complete());
+    ASSERT_EQ(0, pending_probe->completion->get_return_value());
+    ASSERT_EQ(0, pending_probe->op_rval);
+
+    ceph::rados::query_vectors_result_t partial;
+    auto p = pending_probe->reply.cbegin();
+    decode(partial, p);
+    ASSERT_TRUE(p.end());
+    matching_entries += partial.local_matching_entries;
+    distance_computations += partial.local_distance_computations;
+    for (const auto& entry : partial.entries) {
+      ceph::rados::vector_query_exec::merge_result_entry(&merged, entry);
+    }
+  }
+
+  EXPECT_EQ(3u, matching_entries);
+  EXPECT_EQ(3u, distance_computations);
+  ASSERT_EQ(2u, merged.size());
+  ceph::rados::vector_query_exec::sort_and_trim_results(&merged, 2);
+  EXPECT_EQ("vec-dup", merged[0].key);
+  EXPECT_EQ("vec-far", merged[1].key);
+  EXPECT_NEAR(0.0f, merged[0].distance, 1e-6f);
 }
 
 TEST_F(LibRadosIoPP, TooBigPP) {


### PR DESCRIPTION
**PG-LSH placement policy 추가**

vector_placement_algorithm_pg_lsh_v0 추가

vector_placement.h에 PG-LSH 공통 함수 추가

* vector를 table별 LSH signature로 변환
* (table, signature) 조합을 raw PG 번호로 매핑
* put에서는 처음 나오는 unique PG D개 선택
* query에서는 exact group과 hamming group에서 unique PG M개 선택
* 현재는 vote aggregation이 아니라 group 생성 순서대로 PG를 선택

++vote 방식이 효과가 미미하여 뺐습니다

---
**PG 기반 librados routing 추가**

vector_pg_lsh.h에 PG-LSH planner 추가

* K, L, seed, hamming_radius, D, M 검증
* get_object_pg_hash_position2()로 locator key가 실제 어느 PG로 가는지 확인

--> Object name은 PG별 vector container 형태로 생성

.rados.vector/v1/pg-lsh-v0/<bucket_hash>/<index_hash>/**pg정보**
pg_<pg>는 logical object layout에 사용하고 실제 raw PG routing은 IoCtxImpl::oloc.key에 locator key를 설정하여 처리합니다
vector_hash는 object나 PG 선택에서 뺐습니다(hash-v0에서는 사용했었음)

---
**put_vector path 연결**

put_vector()에서 vector의 LSH signature를 계산, write 대상 PG D개 선택

각 PG에 대해

* pg_<pg> object 생성
* 해당 PG로 매핑되는 locator key 조회
* IoCtxImpl::oloc.key에 locator key 설정
* target object에 put_vector op 전송
* op 완료 후 기존 locator key 복구

하나의 vector는 설정된 D에 따라 여러 PG object에 중복 저장

---

+ query_vectors path 연결
+ OSD query scan 통계 추가