### PR TITLE
librados, osd: add vector-aware sub-OID placement

### DIFF
--- a/src/common/vector_query_exec.h
+++ b/src/common/vector_query_exec.h
@@ -350,7 +350,44 @@ inline void copy_bufferlist_bytes(const ceph::bufferlist& bl,
   p.copy(len, out);
 }
 
+inline int prepare_float32_query(const query_vectors_request_t& req,
+                                 std::vector<float> *query_values,
+                                 double *query_norm)
+{
+  if (query_values == nullptr || query_norm == nullptr) {
+    return -EINVAL;
+  }
+  const size_t expected_len =
+    static_cast<size_t>(req.dimension) * sizeof(float);
+  if (req.data_type != vector_data_type_float32 ||
+      req.query_vector.length() != expected_len) {
+    return -EINVAL;
+  }
+
+  query_values->resize(req.dimension);
+  copy_bufferlist_bytes(
+      req.query_vector,
+      reinterpret_cast<char*>(query_values->data()),
+      expected_len);
+
+  *query_norm = 0;
+  for (const float value : *query_values) {
+    *query_norm += static_cast<double>(value) * value;
+  }
+  return 0;
+}
+
+inline const char *contiguous_bufferlist_data(const ceph::bufferlist& bl)
+{
+  if (bl.length() == 0 || !bl.is_contiguous() || bl.get_num_buffers() == 0) {
+    return nullptr;
+  }
+  return bl.buffers().front().c_str();
+}
+
 inline int compute_float32_distance(const query_vectors_request_t& req,
+                                    const std::vector<float>& query_values,
+                                    double query_norm,
                                     const ceph::bufferlist& candidate,
                                     float *distance)
 {
@@ -360,24 +397,26 @@ inline int compute_float32_distance(const query_vectors_request_t& req,
   const size_t expected_len =
     static_cast<size_t>(req.dimension) * sizeof(float);
   if (req.data_type != vector_data_type_float32 ||
-      req.query_vector.length() != expected_len ||
+      query_values.size() != req.dimension ||
       candidate.length() != expected_len) {
     return -EINVAL;
   }
 
-  std::vector<char> query_data(expected_len);
-  std::vector<char> candidate_data(expected_len);
-  copy_bufferlist_bytes(req.query_vector, query_data.data(), expected_len);
-  copy_bufferlist_bytes(candidate, candidate_data.data(), expected_len);
+  std::vector<char> candidate_copy;
+  const char *candidate_data = contiguous_bufferlist_data(candidate);
+  if (candidate_data == nullptr) {
+    candidate_copy.resize(expected_len);
+    copy_bufferlist_bytes(candidate, candidate_copy.data(), expected_len);
+    candidate_data = candidate_copy.data();
+  }
+
   double dot = 0;
-  double query_norm = 0;
   double candidate_norm = 0;
   double sum_sq = 0;
   for (uint32_t i = 0; i < req.dimension; ++i) {
-    const double q = read_float32(query_data.data(), i);
-    const double c = read_float32(candidate_data.data(), i);
+    const double q = query_values[i];
+    const double c = read_float32(candidate_data, i);
     dot += q * c;
-    query_norm += q * q;
     candidate_norm += c * c;
     const double diff = q - c;
     sum_sq += diff * diff;
@@ -457,6 +496,55 @@ inline void sort_and_trim_results(std::vector<query_vectors_result_entry_t> *ent
   }
 }
 
+inline void add_local_topk_result(
+    std::vector<query_vectors_result_entry_t> *entries,
+    const query_vectors_result_entry_t& candidate,
+    uint32_t top_k,
+    bool *heapified)
+{
+  if (entries == nullptr || heapified == nullptr) {
+    return;
+  }
+  if (top_k == 0) {
+    entries->push_back(candidate);
+    return;
+  }
+
+  const size_t limit = top_k;
+  if (entries->size() < limit) {
+    entries->push_back(candidate);
+    if (entries->size() == limit) {
+      std::make_heap(entries->begin(), entries->end(), result_entry_better);
+      *heapified = true;
+    }
+    return;
+  }
+
+  if (result_entry_better(candidate, entries->front())) {
+    std::pop_heap(entries->begin(), entries->end(), result_entry_better);
+    entries->back() = candidate;
+    std::push_heap(entries->begin(), entries->end(), result_entry_better);
+  }
+}
+
+inline void finalize_local_topk_results(
+    std::vector<query_vectors_result_entry_t> *entries,
+    uint32_t top_k,
+    bool heapified)
+{
+  if (entries == nullptr) {
+    return;
+  }
+  if (heapified) {
+    std::sort_heap(entries->begin(), entries->end(), result_entry_better);
+  } else {
+    std::sort(entries->begin(), entries->end(), result_entry_better);
+  }
+  if (top_k != 0 && entries->size() > top_k) {
+    entries->resize(top_k);
+  }
+}
+
 inline int build_local_results(const query_vectors_request_t& req,
                                const omap_scan_state_t& scan,
                                query_vectors_result_t *result,
@@ -475,6 +563,14 @@ inline int build_local_results(const query_vectors_request_t& req,
     return r;
   }
 
+  std::vector<float> query_values;
+  double query_norm = 0;
+  r = prepare_float32_query(req, &query_values, &query_norm);
+  if (r < 0) {
+    return r;
+  }
+
+  bool local_heapified = false;
   for (const auto& [entry_id, entry] : scan.entries) {
     (void)entry_id;
     if (stats != nullptr) {
@@ -540,7 +636,8 @@ inline int build_local_results(const query_vectors_request_t& req,
     if (stats != nullptr) {
       stats->distance_computations++;
     }
-    r = compute_float32_distance(req, content->second, &distance);
+    r = compute_float32_distance(
+        req, query_values, query_norm, content->second, &distance);
     if (r < 0) {
       if (stats != nullptr) {
         stats->distance_error++;
@@ -555,13 +652,15 @@ inline int build_local_results(const query_vectors_request_t& req,
     result_entry.key = entry.user_key;
     result_entry.distance = distance;
     result_entry.entry_id = entry.entry_id;
-    merge_result_entry(&result->entries, result_entry);
+    add_local_topk_result(
+        &result->entries, result_entry, req.local_top_k, &local_heapified);
   }
 
   if (stats != nullptr) {
-    stats->merged_entries = result->entries.size();
+    stats->merged_entries = stats->matched_entries;
   }
-  sort_and_trim_results(&result->entries, req.local_top_k);
+  finalize_local_topk_results(
+      &result->entries, req.local_top_k, local_heapified);
   if (stats != nullptr) {
     stats->final_entries = result->entries.size();
   }

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -2,6 +2,7 @@ set(crimson_seastore_srcs
   cached_extent.cc
   lba_mapping.cc
   seastore_types.cc
+  vector_node.cc
   segment_manager.cc
   segment_manager/ephemeral.cc
   segment_manager/block.cc

--- a/src/crimson/os/seastore/btree/btree_types.h
+++ b/src/crimson/os/seastore/btree/btree_types.h
@@ -138,7 +138,8 @@ struct __attribute__((packed)) lba_map_val_le_t {
   pladdr_le_t pladdr;
   extent_ref_count_le_t refcount{0};
   checksum_le_t checksum{0};
-  extent_types_le_t type{EXTENT_TYPES_MAX};
+  extent_types_le_t type{
+    static_cast<extent_types_le_t>(extent_types_t::NONE)};
 
   lba_map_val_le_t() = default;
   lba_map_val_le_t(const lba_map_val_le_t &) = default;

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -2791,7 +2791,7 @@ cache_stats_t Cache::get_stats(
       auto& trans_io_per_src = get_by_src(trans_io_by_src, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        if (ext == extent_types_t::NONE) {
+        if (!is_valid_extent_type(ext)) {
           continue;
         }
         auto& extent_io = get_by_ext(io_by_ext, ext);
@@ -2808,7 +2808,7 @@ cache_stats_t Cache::get_stats(
     cache_size_stats_t phys_sizes;
     for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
       auto ext = static_cast<extent_types_t>(_ext);
-      if (ext == extent_types_t::NONE) {
+      if (!is_valid_extent_type(ext)) {
         continue;
       }
       const auto& extent_sizes = get_by_ext(stats.dirty_sizes_by_ext, ext);
@@ -2839,7 +2839,7 @@ cache_stats_t Cache::get_stats(
       const auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        if (ext == extent_types_t::NONE) {
+        if (!is_valid_extent_type(ext)) {
           continue;
         }
         const auto& extent_io = get_by_ext(io_by_ext, ext);
@@ -2892,7 +2892,7 @@ cache_stats_t Cache::get_stats(
       const auto& last_access_by_ext = get_by_src(last_access_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        if (ext == extent_types_t::NONE) {
+        if (!is_valid_extent_type(ext)) {
           continue;
         }
         cache_access_stats_t& extent_access = get_by_ext(access_by_ext, ext);
@@ -2915,7 +2915,7 @@ cache_stats_t Cache::get_stats(
       const auto& access_by_ext = get_by_src(_access_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        if (ext == extent_types_t::NONE) {
+        if (!is_valid_extent_type(ext)) {
           continue;
         }
         const auto& extent_access = get_by_ext(access_by_ext, ext);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -21,6 +21,7 @@
 #include "crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h"
 #include "crimson/os/seastore/backref/backref_tree_node.h"
 #include "crimson/os/seastore/omap_manager/log/log_node.h"
+#include "crimson/os/seastore/vector_node.h"
 #include "test/crimson/seastore/test_block.h"
 
 using std::string_view;
@@ -79,6 +80,9 @@ CachedExtentRef Cache::retire_absent_extent_addr_by_type(
       t, laddr, addr, length, std::move(extent_init_func));
   case extent_types_t::LOG_NODE:
     return retire_absent_extent_addr<log_manager::LogNode>(
+      t, laddr, addr, length, std::move(extent_init_func));
+  case extent_types_t::VECTOR_NODE:
+    return retire_absent_extent_addr<VectorNode>(
       t, laddr, addr, length, std::move(extent_init_func));
   case extent_types_t::OBJECT_DATA_BLOCK:
     return retire_absent_extent_addr<ObjectDataBlock>(
@@ -150,9 +154,10 @@ void Cache::register_metrics(store_index_t store_index)
     {extent_types_t::TEST_BLOCK_PHYSICAL, {sm::label_instance("ext", "TEST_BLOCK_PHYSICAL")}},
     {extent_types_t::BACKREF_INTERNAL,    {sm::label_instance("ext", "BACKREF_INTERNAL")}},
     {extent_types_t::BACKREF_LEAF,        {sm::label_instance("ext", "BACKREF_LEAF")}},
-    {extent_types_t::LOG_NODE,            {sm::label_instance("ext", "LOG_NODE")}}
+    {extent_types_t::LOG_NODE,            {sm::label_instance("ext", "LOG_NODE")}},
+    {extent_types_t::VECTOR_NODE,         {sm::label_instance("ext", "VECTOR_NODE")}}
   };
-  assert(labels_by_ext.size() == (std::size_t)extent_types_t::NONE);
+  assert(labels_by_ext.size() == EXTENT_TYPES_MAX - 1);
   for (auto& [src, src_label] : labels_by_src) {
     src_label.push_back(sm::label_instance("shard_store_index", std::to_string(store_index)));
   }
@@ -1182,6 +1187,9 @@ CachedExtentRef Cache::alloc_remapped_extent_by_type(
   case extent_types_t::COLL_BLOCK:
     return alloc_remapped_extent<collection_manager::CollectionNode>(
       t, remap_laddr, remap_paddr, remap_offset, remap_length, original_bptr);
+  case extent_types_t::VECTOR_NODE:
+    return alloc_remapped_extent<VectorNode>(
+      t, remap_laddr, remap_paddr, remap_offset, remap_length, original_bptr);
   case extent_types_t::OBJECT_DATA_BLOCK:
     return alloc_remapped_extent<ObjectDataBlock>(
       t, remap_laddr, remap_paddr, remap_offset, remap_length, original_bptr);
@@ -1235,6 +1243,9 @@ CachedExtentRef Cache::alloc_new_non_data_extent_by_type(
   case extent_types_t::LOG_NODE:
      return alloc_new_non_data_extent<log_manager::LogNode>(
        t, length, hint, gen);
+  case extent_types_t::VECTOR_NODE:
+    return alloc_new_non_data_extent<VectorNode>(
+      t, length, hint, gen);
   case extent_types_t::NONE: {
     ceph_assert(0 == "NONE is an invalid extent type");
     return CachedExtentRef();
@@ -2604,6 +2615,9 @@ Cache::_get_absent_extent_by_type(
     ret = CachedExtent::make_cached_extent_ref<
       log_manager::LogNode>(length);
     break;
+  case extent_types_t::VECTOR_NODE:
+    ret = CachedExtent::make_cached_extent_ref<VectorNode>(length);
+    break;
   case extent_types_t::NONE:
     ceph_assert(0 == "NONE is an invalid extent type");
     break;
@@ -2729,6 +2743,12 @@ Cache::do_get_caching_extent_by_type(
     ).safe_then([](auto extent) {
       return CachedExtentRef(extent.detach(), false /* add_ref */);
     });
+  case extent_types_t::VECTOR_NODE:
+    return do_get_caching_extent<VectorNode>(
+      offset, length, std::move(extent_init_func), std::move(on_cache), p_src
+    ).safe_then([](auto extent) {
+      return CachedExtentRef(extent.detach(), false /* add_ref */);
+    });
   case extent_types_t::NONE: {
     ceph_assert(0 == "NONE is an invalid extent type");
     return get_extent_ertr::make_ready_future<CachedExtentRef>();
@@ -2771,6 +2791,9 @@ cache_stats_t Cache::get_stats(
       auto& trans_io_per_src = get_by_src(trans_io_by_src, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
+        if (ext == extent_types_t::NONE) {
+          continue;
+        }
         auto& extent_io = get_by_ext(io_by_ext, ext);
         const auto& last_extent_io = get_by_ext(last_io_by_ext, ext);
         extent_io.minus(last_extent_io);
@@ -2785,6 +2808,9 @@ cache_stats_t Cache::get_stats(
     cache_size_stats_t phys_sizes;
     for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
       auto ext = static_cast<extent_types_t>(_ext);
+      if (ext == extent_types_t::NONE) {
+        continue;
+      }
       const auto& extent_sizes = get_by_ext(stats.dirty_sizes_by_ext, ext);
 
       if (is_data_type(ext)) {
@@ -2813,6 +2839,9 @@ cache_stats_t Cache::get_stats(
       const auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
+        if (ext == extent_types_t::NONE) {
+          continue;
+        }
         const auto& extent_io = get_by_ext(io_by_ext, ext);
         if (is_data_type(ext)) {
           data_io.add(extent_io);
@@ -2863,6 +2892,9 @@ cache_stats_t Cache::get_stats(
       const auto& last_access_by_ext = get_by_src(last_access_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
+        if (ext == extent_types_t::NONE) {
+          continue;
+        }
         cache_access_stats_t& extent_access = get_by_ext(access_by_ext, ext);
         const auto& last_extent_access = get_by_ext(last_access_by_ext, ext);
         extent_access.minus(last_extent_access);
@@ -2883,6 +2915,9 @@ cache_stats_t Cache::get_stats(
       const auto& access_by_ext = get_by_src(_access_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
+        if (ext == extent_types_t::NONE) {
+          continue;
+        }
         const auto& extent_access = get_by_ext(access_by_ext, ext);
         if (is_data_type(ext)) {
           data_access.add(extent_access);

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -193,6 +193,9 @@ void ExtentQueue::get_stats(
       auto& trans_io_per_src = get_by_src(trans_io_by_src, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
+        if (ext == extent_types_t::NONE) {
+          continue;
+        }
         auto& extent_io = get_by_ext(io_by_ext, ext);
         const auto& last_extent_io = get_by_ext(last_io_by_ext, ext);
         extent_io.minus(last_extent_io);
@@ -210,6 +213,9 @@ void ExtentQueue::get_stats(
     cache_size_stats_t phys_sizes;
     for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
       auto ext = static_cast<extent_types_t>(_ext);
+      if (ext == extent_types_t::NONE) {
+        continue;
+      }
       const auto& extent_sizes = get_by_ext(sizes_by_ext, ext);
       if (is_data_type(ext)) {
         data_sizes.add(extent_sizes);
@@ -239,6 +245,9 @@ void ExtentQueue::get_stats(
       const auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
+        if (ext == extent_types_t::NONE) {
+          continue;
+        }
         const auto extent_io = get_by_ext(io_by_ext, ext);
         if (is_data_type(ext)) {
           data_io.add(extent_io);

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -193,7 +193,7 @@ void ExtentQueue::get_stats(
       auto& trans_io_per_src = get_by_src(trans_io_by_src, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        if (ext == extent_types_t::NONE) {
+        if (!is_valid_extent_type(ext)) {
           continue;
         }
         auto& extent_io = get_by_ext(io_by_ext, ext);
@@ -213,7 +213,7 @@ void ExtentQueue::get_stats(
     cache_size_stats_t phys_sizes;
     for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
       auto ext = static_cast<extent_types_t>(_ext);
-      if (ext == extent_types_t::NONE) {
+      if (!is_valid_extent_type(ext)) {
         continue;
       }
       const auto& extent_sizes = get_by_ext(sizes_by_ext, ext);
@@ -245,7 +245,7 @@ void ExtentQueue::get_stats(
       const auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        if (ext == extent_types_t::NONE) {
+        if (!is_valid_extent_type(ext)) {
           continue;
         }
         const auto extent_io = get_by_ext(io_by_ext, ext);

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -450,7 +450,7 @@ struct LBACursor : BtreeCursor<laddr_t, lba::lba_map_val_t, LBALeafNode> {
   extent_types_t get_extent_type() const {
     assert(is_viewable());
     assert(!is_end());
-    assert(iter.get_val().type != extent_types_t::NONE);
+    assert(is_valid_extent_type(iter.get_val().type));
     return iter.get_val().type;
   }
 

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -47,6 +47,7 @@ struct onode_layout_t {
     * do_clone, do_clonerange
     */
   bool need_cow = false;
+  laddr_le_t vector_node_laddr = laddr_le_t(L_ADDR_NULL);
 
   onode_layout_t() : omap_root(omap_type_t::OMAP),
     xattr_root(omap_type_t::XATTR) {}
@@ -143,6 +144,12 @@ public:
   virtual void clear_snapset(Transaction&) = 0;
   virtual void set_need_cow(Transaction&) = 0;
   virtual void unset_need_cow(Transaction&) = 0;
+  bool has_vector_node() const {
+    return get_vector_node_laddr() != L_ADDR_NULL;
+  }
+  virtual laddr_t get_vector_node_laddr() const = 0;
+  virtual void update_vector_node_laddr(Transaction&, laddr_t) = 0;
+  virtual void clear_vector_node_laddr(Transaction&) = 0;
   virtual void swap_layout(Transaction&, Onode&) = 0;
   virtual boost::intrusive_ptr<Onode> offload_data_and_md(Transaction&) = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -71,6 +71,12 @@ void FLTreeOnode::Recorder::apply_value_delta(
     case delta_op_t::CREATE_DEFAULT:
       mlayout = onode_layout_t{};
       break;
+    case delta_op_t::UPDATE_VECTOR_NODE_LADDR:
+      DEBUG("update vector node laddr");
+      bliter.copy(
+	sizeof(mlayout.vector_node_laddr),
+	(char *)&mlayout.vector_node_laddr);
+      break;
     default:
       ceph_abort();
     }
@@ -137,6 +143,12 @@ void FLTreeOnode::Recorder::encode_update(
       (const char *)&layout.ss[0],
       onode_layout_t::MAX_SS_LENGTH);
     ceph::encode(layout.ss_size, encoded);
+    break;
+  case delta_op_t::UPDATE_VECTOR_NODE_LADDR:
+    DEBUG("update vector node laddr");
+    encoded.append(
+      (const char *)&layout.vector_node_laddr,
+      sizeof(layout.vector_node_laddr));
     break;
   case delta_op_t::CREATE_DEFAULT:
     DEBUG("create default layout");

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -61,6 +61,15 @@ struct FakeOnode final : Onode {
   void clear_snapset(Transaction &) final { ceph_abort("impossible"); }
   void set_need_cow(Transaction &) final {}
   void unset_need_cow(Transaction &) final {}
+  laddr_t get_vector_node_laddr() const final {
+    return layout.vector_node_laddr;
+  }
+  void update_vector_node_laddr(Transaction &, laddr_t addr) final {
+    layout.vector_node_laddr = addr;
+  }
+  void clear_vector_node_laddr(Transaction &) final {
+    layout.vector_node_laddr = L_ADDR_NULL;
+  }
   void swap_layout(Transaction &, Onode &o) final { ceph_abort("impossible"); }
   boost::intrusive_ptr<Onode> offload_data_and_md(Transaction &t) final {
     ceph_abort("impossible");
@@ -111,7 +120,8 @@ struct FLTreeOnode final : Onode, Value {
       CLEAR_SNAPSET,
       CREATE_DEFAULT,
       SET_NEED_COW,
-      UNSET_NEED_COW
+      UNSET_NEED_COW,
+      UPDATE_VECTOR_NODE_LADDR = 11
     };
     Recorder(bufferlist &bl) : ValueDeltaRecorder(bl) {}
 
@@ -146,6 +156,28 @@ struct FLTreeOnode final : Onode, Value {
     layout_func(p.first, p.second);
   }
 
+  laddr_t get_vector_node_laddr() const final {
+    return get_layout().vector_node_laddr;
+  }
+
+  void update_vector_node_laddr(Transaction &t, laddr_t addr) final {
+    with_mutable_layout(
+      t,
+      [addr](NodeExtentMutable &payload_mut, Recorder *recorder) {
+	auto &mlayout = *reinterpret_cast<onode_layout_t*>(
+	  payload_mut.get_write());
+	mlayout.vector_node_laddr = addr;
+	if (recorder) {
+	  recorder->encode_update(
+	    payload_mut, Recorder::delta_op_t::UPDATE_VECTOR_NODE_LADDR);
+	}
+      });
+  }
+
+  void clear_vector_node_laddr(Transaction &t) final {
+    update_vector_node_laddr(t, L_ADDR_NULL);
+  }
+
   void swap_layout(Transaction &t, Onode &onode) final {
     _swap_layout(t, static_cast<FLTreeOnode&>(onode));
   }
@@ -178,6 +210,7 @@ struct FLTreeOnode final : Onode, Value {
     std::swap(mlayout.object_data, o_mlayout.object_data);
     std::swap(mlayout.omap_root, o_mlayout.omap_root);
     std::swap(mlayout.xattr_root, o_mlayout.xattr_root);
+    std::swap(mlayout.vector_node_laddr, o_mlayout.vector_node_laddr);
     if (recorder) {
       recorder->encode_update(
 	payload_mut, Recorder::delta_op_t::UPDATE_OBJECT_DATA);
@@ -185,6 +218,8 @@ struct FLTreeOnode final : Onode, Value {
 	payload_mut, Recorder::delta_op_t::UPDATE_OMAP_ROOT);
       recorder->encode_update(
 	payload_mut, Recorder::delta_op_t::UPDATE_XATTR_ROOT);
+      recorder->encode_update(
+	payload_mut, Recorder::delta_op_t::UPDATE_VECTOR_NODE_LADDR);
     }
     if (o_recorder) {
       o_recorder->encode_update(
@@ -193,6 +228,8 @@ struct FLTreeOnode final : Onode, Value {
 	o_payload_mut, Recorder::delta_op_t::UPDATE_OMAP_ROOT);
       o_recorder->encode_update(
 	o_payload_mut, Recorder::delta_op_t::UPDATE_XATTR_ROOT);
+      o_recorder->encode_update(
+	o_payload_mut, Recorder::delta_op_t::UPDATE_VECTOR_NODE_LADDR);
     }
   }
 

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -639,6 +639,8 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
     return out << "LOG_NODE";
   case extent_types_t::NONE:
     return out << "NONE";
+  case extent_types_t::VECTOR_NODE:
+    return out << "VECTOR_NODE";
   default:
     return out << "UNKNOWN(" << (unsigned)t << ")";
   }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1960,11 +1960,17 @@ enum class extent_types_t : uint8_t {
   BACKREF_INTERNAL = 14,
   BACKREF_LEAF = 15,
   LOG_NODE = 16,
+  // Extent type values are persisted in on-disk metadata and journal
+  // records.  NONE=17 was the existing sentinel and must not move; new
+  // persisted types must be appended after it.
   NONE = 17,
   VECTOR_NODE = 18,
 };
 using extent_types_le_t = uint8_t;
 constexpr uint8_t EXTENT_TYPES_MAX = 19;
+static_assert(static_cast<uint8_t>(extent_types_t::NONE) == 17);
+static_assert(static_cast<uint8_t>(extent_types_t::VECTOR_NODE) == 18);
+static_assert(EXTENT_TYPES_MAX == 19);
 
 constexpr size_t BACKREF_NODE_SIZE = 4096;
 
@@ -3184,9 +3190,13 @@ void minus_srcs(counter_by_src_t<CounterT>& base,
 template <typename CounterT>
 using counter_by_extent_t = std::array<CounterT, EXTENT_TYPES_MAX>;
 
-constexpr bool is_valid_extent_counter_type(extent_types_t ext) {
+constexpr bool is_valid_extent_type(extent_types_t ext) {
   return ext != extent_types_t::NONE &&
          static_cast<uint8_t>(ext) < EXTENT_TYPES_MAX;
+}
+
+constexpr bool is_valid_extent_counter_type(extent_types_t ext) {
+  return is_valid_extent_type(ext);
 }
 
 template <typename CounterT>

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1960,11 +1960,11 @@ enum class extent_types_t : uint8_t {
   BACKREF_INTERNAL = 14,
   BACKREF_LEAF = 15,
   LOG_NODE = 16,
-  // None and the number of valid extent_types_t
   NONE = 17,
+  VECTOR_NODE = 18,
 };
 using extent_types_le_t = uint8_t;
-constexpr auto EXTENT_TYPES_MAX = static_cast<uint8_t>(extent_types_t::NONE);
+constexpr uint8_t EXTENT_TYPES_MAX = 19;
 
 constexpr size_t BACKREF_NODE_SIZE = 4096;
 
@@ -1978,14 +1978,16 @@ constexpr bool is_data_type(extent_types_t type) {
 constexpr bool is_logical_metadata_type(extent_types_t type) {
   return (type >= extent_types_t::ROOT_META &&
          type <= extent_types_t::COLL_BLOCK) ||
-	 type == extent_types_t::LOG_NODE;
+	 type == extent_types_t::LOG_NODE ||
+         type == extent_types_t::VECTOR_NODE;
 }
 
 constexpr bool is_logical_type(extent_types_t type) {
   if ((type >= extent_types_t::ROOT_META &&
        type <= extent_types_t::OBJECT_DATA_BLOCK) ||
       type == extent_types_t::TEST_BLOCK ||
-      type == extent_types_t::LOG_NODE) {
+      type == extent_types_t::LOG_NODE ||
+      type == extent_types_t::VECTOR_NODE) {
     assert(is_logical_metadata_type(type) ||
            is_data_type(type));
     return true;
@@ -2036,7 +2038,8 @@ constexpr bool is_backref_mapped_type(extent_types_t type) {
        type <= extent_types_t::OBJECT_DATA_BLOCK) ||
       type == extent_types_t::TEST_BLOCK ||
       type == extent_types_t::TEST_BLOCK_PHYSICAL ||
-      type == extent_types_t::LOG_NODE) {
+      type == extent_types_t::LOG_NODE ||
+      type == extent_types_t::VECTOR_NODE) {
     assert(is_logical_type(type) ||
 	   is_lba_node(type) ||
 	   type == extent_types_t::TEST_BLOCK_PHYSICAL);
@@ -2052,7 +2055,8 @@ constexpr bool is_backref_mapped_type(extent_types_t type) {
 constexpr bool is_real_type(extent_types_t type) {
   if (type <= extent_types_t::OBJECT_DATA_BLOCK ||
       (type >= extent_types_t::TEST_BLOCK &&
-       type <= extent_types_t::LOG_NODE)) {
+       type <= extent_types_t::LOG_NODE) ||
+      type == extent_types_t::VECTOR_NODE) {
     assert(is_logical_type(type) ||
            is_physical_type(type));
     return true;
@@ -3180,12 +3184,17 @@ void minus_srcs(counter_by_src_t<CounterT>& base,
 template <typename CounterT>
 using counter_by_extent_t = std::array<CounterT, EXTENT_TYPES_MAX>;
 
+constexpr bool is_valid_extent_counter_type(extent_types_t ext) {
+  return ext != extent_types_t::NONE &&
+         static_cast<uint8_t>(ext) < EXTENT_TYPES_MAX;
+}
+
 template <typename CounterT>
 CounterT& get_by_ext(
     counter_by_extent_t<CounterT>& counters_by_ext,
     extent_types_t ext) {
   auto index = static_cast<uint8_t>(ext);
-  assert(index < EXTENT_TYPES_MAX);
+  assert(is_valid_extent_counter_type(ext));
   return counters_by_ext[index];
 }
 
@@ -3194,7 +3203,7 @@ const CounterT& get_by_ext(
     const counter_by_extent_t<CounterT>& counters_by_ext,
     extent_types_t ext) {
   auto index = static_cast<uint8_t>(ext);
-  assert(index < EXTENT_TYPES_MAX);
+  assert(is_valid_extent_counter_type(ext));
   return counters_by_ext[index];
 }
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -13,6 +13,7 @@
 #include "crimson/os/seastore/random_block_manager/rbm_device.h"
 #include "crimson/os/seastore/object_data_handler.h"
 #include "crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h"
+#include "crimson/os/seastore/vector_node.h"
 
 /*
  * TransactionManager logs
@@ -950,6 +951,20 @@ TransactionManager::move_region(
             auto maybe_indirect_extent = co_await read_pin<OMapInnerNode>(
               t, src, src.get_intermediate_offset(), src.get_length());
             auto extent = co_await alloc_non_data_extent<OMapInnerNode>(
+              t,
+              laddr_hint_t::create_as_fixed(calc_dst_key()),
+              src.get_length()
+            ).handle_error_interruptible(
+              move_region_iertr::pass_further(),
+              crimson::ct_error::assert_all("invalid error"));
+            extent->set_bptr(maybe_indirect_extent.extent->get_bptr());
+          }
+          break;
+        case extent_types_t::VECTOR_NODE:
+          {
+            auto maybe_indirect_extent = co_await read_pin<VectorNode>(
+              t, src, src.get_intermediate_offset(), src.get_length());
+            auto extent = co_await alloc_non_data_extent<VectorNode>(
               t,
               laddr_hint_t::create_as_fixed(calc_dst_key()),
               src.get_length()

--- a/src/crimson/os/seastore/vector_node.cc
+++ b/src/crimson/os/seastore/vector_node.cc
@@ -1,0 +1,315 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "crimson/os/seastore/vector_node.h"
+
+#include <algorithm>
+
+#include "common/error_code.h"
+#include "include/ceph_assert.h"
+#include "include/encoding.h"
+
+namespace crimson::os::seastore {
+
+namespace {
+
+void encode_entry(const vector_node_entry_t &entry, ceph::bufferlist &bl)
+{
+  using ceph::encode;
+  encode(entry.entry_id, bl);
+  encode(entry.vector_data, bl);
+}
+
+vector_node_entry_t decode_entry(ceph::bufferlist::const_iterator &p)
+{
+  using ceph::decode;
+  vector_node_entry_t entry;
+  decode(entry.entry_id, p);
+  decode(entry.vector_data, p);
+  return entry;
+}
+
+}
+
+ceph::bufferlist VectorNode::encode_contents(const vector_node_t &node)
+{
+  using ceph::encode;
+  ceph::bufferlist bl;
+  encode(node.format_version, bl);
+  encode(node.data_type, bl);
+  encode(node.dimension, bl);
+  encode(static_cast<uint32_t>(node.entries.size()), bl);
+  for (const auto &entry : node.entries) {
+    encode_entry(entry, bl);
+  }
+  return bl;
+}
+
+vector_node_t VectorNode::decode_contents(const ceph::bufferlist &bl)
+{
+  using ceph::decode;
+  auto p = bl.cbegin();
+  vector_node_t node;
+  decode(node.format_version, p);
+  if (node.format_version != VECTOR_NODE_FORMAT_VERSION) {
+    throw ceph::buffer::malformed_input("unsupported VectorNode format");
+  }
+  decode(node.data_type, p);
+  decode(node.dimension, p);
+  uint32_t entries = 0;
+  decode(entries, p);
+  node.entries.reserve(entries);
+  for (uint32_t i = 0; i < entries; ++i) {
+    node.entries.push_back(decode_entry(p));
+  }
+  if (!VectorNode::is_sorted(node.entries)) {
+    throw ceph::buffer::malformed_input("unsorted VectorNode entries");
+  }
+  return node;
+}
+
+VectorNode::VectorNode(ceph::bufferptr &&ptr)
+  : LogicalChildNode(std::move(ptr)) {}
+
+VectorNode::VectorNode(extent_len_t length)
+  : LogicalChildNode(length) {}
+
+VectorNode::VectorNode(const VectorNode &rhs)
+  : LogicalChildNode(rhs),
+    contents(rhs.contents),
+    decoded(rhs.decoded)
+{
+  ceph_assert(!rhs.dirty);
+}
+
+CachedExtentRef VectorNode::duplicate_for_write(Transaction&)
+{
+  return CachedExtentRef(new VectorNode(*this));
+}
+
+void VectorNode::on_clean_read()
+{
+  decode_from_buffer();
+  dirty = false;
+}
+
+void VectorNode::on_initial_write()
+{
+  dirty = false;
+}
+
+void VectorNode::prepare_commit(Transaction&)
+{
+  if (dirty) {
+    materialize();
+  }
+}
+
+ceph::bufferlist VectorNode::get_delta()
+{
+  if (dirty) {
+    materialize();
+  }
+
+  ceph::bufferlist bl;
+  ceph::bufferptr bptr(get_bptr(), 0, get_length());
+  bl.append(bptr);
+  return bl;
+}
+
+void VectorNode::clear_delta()
+{
+  dirty = false;
+}
+
+void VectorNode::initialize(uint32_t data_type, uint32_t dimension)
+{
+  contents = vector_node_t{
+    VECTOR_NODE_FORMAT_VERSION,
+    data_type,
+    dimension,
+    {}
+  };
+  decoded = true;
+  dirty = true;
+  materialize();
+}
+
+bool VectorNode::is_sorted(const std::vector<vector_node_entry_t> &entries)
+{
+  return std::adjacent_find(
+    entries.begin(),
+    entries.end(),
+    [](const auto &lhs, const auto &rhs) {
+      return !(lhs.entry_id < rhs.entry_id);
+    }) == entries.end();
+}
+
+void VectorNode::decode_from_buffer()
+{
+  ceph::bufferlist bl;
+  bl.append(get_bptr());
+  contents = decode_contents(bl);
+  decoded = true;
+}
+
+void VectorNode::materialize()
+{
+  ceph_assert(decoded);
+  auto bl = encode_contents(contents);
+  ceph_assert(bl.length() <= get_length());
+  ceph_assert(bl.length() <= VECTOR_NODE_MAX_BYTES);
+
+  bl.rebuild();
+  get_bptr().zero();
+  if (bl.length()) {
+    get_bptr().copy_in(0, bl.length(), bl.front().c_str());
+  }
+}
+
+void VectorNode::apply_delta(const ceph::bufferlist &_bl)
+{
+  ceph_assert(_bl.length() == get_length());
+
+  ceph::bufferlist bl = _bl;
+  bl.rebuild();
+  get_bptr().copy_in(0, bl.length(), bl.front().c_str());
+  decode_from_buffer();
+  dirty = false;
+}
+
+void VectorNode::logical_on_delta_write()
+{
+  dirty = false;
+}
+
+std::ostream &VectorNode::print_detail_l(std::ostream &out) const
+{
+  if (decoded) {
+    return out << "data_type=" << contents.data_type
+               << ", dimension=" << contents.dimension
+               << ", entries=" << contents.entries.size();
+  } else {
+    return out << "undecoded";
+  }
+}
+
+bool VectorNodeManager::is_valid_extent_size(extent_len_t length) const
+{
+  return length != 0 &&
+         length <= VECTOR_NODE_MAX_BYTES &&
+         is_aligned(length, tm.get_block_size()) &&
+         is_aligned(VECTOR_NODE_MAX_BYTES, tm.get_block_size());
+}
+
+VectorNodeManager::create_ret VectorNodeManager::create_vector_node(
+  Transaction &t,
+  uint32_t data_type,
+  uint32_t dimension)
+{
+  const auto block_size = tm.get_block_size();
+  if (!is_valid_extent_size(block_size)) {
+    return crimson::ct_error::enospc::make();
+  }
+
+  return tm.alloc_non_data_extent<VectorNode>(
+    t,
+    laddr_hint_t::create_global_md_hint(),
+    block_size
+  ).si_then([data_type, dimension](auto node) {
+    node->initialize(data_type, dimension);
+    return create_iertr::make_ready_future<VectorNodeRef>(std::move(node));
+  });
+}
+
+VectorNodeManager::read_ret VectorNodeManager::read_vector_node(
+  Transaction &t,
+  laddr_t addr)
+{
+  return tm.read_extent<VectorNode>(t, addr
+  ).si_then([](auto ret) {
+    return read_iertr::make_ready_future<VectorNodeRef>(
+      std::move(ret.extent));
+  });
+}
+
+VectorNodeManager::upsert_ret VectorNodeManager::upsert_vector_entry(
+  Transaction &t,
+  VectorNodeRef node,
+  const std::string &entry_id,
+  const ceph::bufferlist &vector_data)
+{
+  ceph_assert(node);
+  ceph_assert(node->decoded);
+
+  auto candidate = node->contents;
+  auto iter = std::lower_bound(
+    candidate.entries.begin(),
+    candidate.entries.end(),
+    entry_id,
+    [](const auto &entry, const auto &id) {
+      return entry.entry_id < id;
+    });
+  if (iter != candidate.entries.end() && iter->entry_id == entry_id) {
+    iter->vector_data = vector_data;
+  } else {
+    candidate.entries.insert(iter, vector_node_entry_t{entry_id, vector_data});
+  }
+
+  auto encoded = VectorNode::encode_contents(candidate);
+  if (encoded.length() > node->get_length() ||
+      encoded.length() > VECTOR_NODE_MAX_BYTES) {
+    return crimson::ct_error::enospc::make();
+  }
+
+  auto mutable_node = tm.get_mutable_extent(
+    t,
+    node->cast<LogicalChildNode>())->cast<VectorNode>();
+  mutable_node->contents = std::move(candidate);
+  mutable_node->decoded = true;
+  mutable_node->dirty = true;
+  mutable_node->materialize();
+  return mutate_iertr::make_ready_future<VectorNodeRef>(
+    std::move(mutable_node));
+}
+
+VectorNodeManager::remove_ret VectorNodeManager::remove_vector_entry(
+  Transaction &t,
+  VectorNodeRef node,
+  const std::string &entry_id)
+{
+  ceph_assert(node);
+  ceph_assert(node->decoded);
+
+  auto candidate = node->contents;
+  auto iter = std::lower_bound(
+    candidate.entries.begin(),
+    candidate.entries.end(),
+    entry_id,
+    [](const auto &entry, const auto &id) {
+      return entry.entry_id < id;
+    });
+  if (iter == candidate.entries.end() || iter->entry_id != entry_id) {
+    return mutate_iertr::make_ready_future<std::pair<VectorNodeRef, bool>>(
+      std::make_pair(std::move(node), false));
+  }
+  candidate.entries.erase(iter);
+
+  auto encoded = VectorNode::encode_contents(candidate);
+  if (encoded.length() > node->get_length() ||
+      encoded.length() > VECTOR_NODE_MAX_BYTES) {
+    return crimson::ct_error::enospc::make();
+  }
+
+  auto mutable_node = tm.get_mutable_extent(
+    t,
+    node->cast<LogicalChildNode>())->cast<VectorNode>();
+  mutable_node->contents = std::move(candidate);
+  mutable_node->decoded = true;
+  mutable_node->dirty = true;
+  mutable_node->materialize();
+  return mutate_iertr::make_ready_future<std::pair<VectorNodeRef, bool>>(
+    std::make_pair(std::move(mutable_node), true));
+}
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/vector_node.h
+++ b/src/crimson/os/seastore/vector_node.h
@@ -1,0 +1,122 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "include/buffer.h"
+#include "include/ceph_assert.h"
+
+#include "crimson/os/seastore/transaction_manager.h"
+
+namespace crimson::os::seastore {
+
+static constexpr uint32_t VECTOR_NODE_FORMAT_VERSION = 1;
+// Upper bound for future resize/split support. PR1 allocates one
+// tm.get_block_size() extent and returns enospc when that extent is full.
+static constexpr extent_len_t VECTOR_NODE_MAX_BYTES = 64 << 10;
+
+struct vector_node_entry_t {
+  std::string entry_id;
+  ceph::bufferlist vector_data;
+};
+
+struct vector_node_t {
+  uint32_t format_version = VECTOR_NODE_FORMAT_VERSION;
+  uint32_t data_type = 0;
+  uint32_t dimension = 0;
+  std::vector<vector_node_entry_t> entries;
+};
+
+class VectorNode : public LogicalChildNode {
+public:
+  using Ref = TCachedExtentRef<VectorNode>;
+  static constexpr extent_types_t TYPE = extent_types_t::VECTOR_NODE;
+
+  explicit VectorNode(ceph::bufferptr &&ptr);
+  explicit VectorNode(extent_len_t length);
+  VectorNode(const VectorNode &rhs);
+
+  CachedExtentRef duplicate_for_write(Transaction &t) final;
+
+  extent_types_t get_type() const final {
+    return TYPE;
+  }
+
+  void on_clean_read() final;
+  void on_initial_write() final;
+  void prepare_commit(Transaction &t) final;
+  ceph::bufferlist get_delta() final;
+  void clear_delta() final;
+
+  void initialize(uint32_t data_type, uint32_t dimension);
+
+  const vector_node_t &get_contents() const {
+    ceph_assert(decoded);
+    return contents;
+  }
+
+  static ceph::bufferlist encode_contents(const vector_node_t &node);
+  static vector_node_t decode_contents(const ceph::bufferlist &bl);
+  static bool is_sorted(const std::vector<vector_node_entry_t> &entries);
+
+private:
+  vector_node_t contents;
+  bool decoded = false;
+  bool dirty = false;
+
+  void decode_from_buffer();
+  void materialize();
+  void apply_delta(const ceph::bufferlist &bl) final;
+  void logical_on_delta_write() final;
+  std::ostream &print_detail_l(std::ostream &out) const final;
+
+  friend class VectorNodeManager;
+};
+using VectorNodeRef = VectorNode::Ref;
+
+class VectorNodeManager {
+public:
+  explicit VectorNodeManager(TransactionManager &tm) : tm(tm) {}
+
+  using create_iertr = TransactionManager::alloc_extent_iertr;
+  using create_ret = create_iertr::future<VectorNodeRef>;
+  create_ret create_vector_node(
+    Transaction &t,
+    uint32_t data_type,
+    uint32_t dimension);
+
+  using read_iertr = TransactionManager::read_extent_iertr;
+  using read_ret = read_iertr::future<VectorNodeRef>;
+  read_ret read_vector_node(
+    Transaction &t,
+    laddr_t addr);
+
+  using mutate_iertr = TransactionManager::alloc_extent_iertr;
+  using upsert_ret = mutate_iertr::future<VectorNodeRef>;
+  upsert_ret upsert_vector_entry(
+    Transaction &t,
+    VectorNodeRef node,
+    const std::string &entry_id,
+    const ceph::bufferlist &vector_data);
+
+  using remove_ret = mutate_iertr::future<std::pair<VectorNodeRef, bool>>;
+  remove_ret remove_vector_entry(
+    Transaction &t,
+    VectorNodeRef node,
+    const std::string &entry_id);
+
+private:
+  TransactionManager &tm;
+
+  bool is_valid_extent_size(extent_len_t length) const;
+};
+
+} // namespace crimson::os::seastore
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::VectorNode>
+  : fmt::ostream_formatter {};
+#endif

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -24,6 +24,7 @@
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/vector_placement.h"
+#include "librados/vector_put.h"
 #include "librados/vector_query_planner.h"
 #include "include/ceph_assert.h"
 #include "include/ceph_hash.h"
@@ -305,6 +306,14 @@ static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_COSINE ==
               ceph::rados::vector_distance_metric_cosine);
 static_assert(LIBRADOS_VECTOR_DISTANCE_METRIC_DOT ==
               ceph::rados::vector_distance_metric_dot);
+
+struct AioCompletionReleaser {
+  void operator()(librados::v14_2_0::AioCompletion *completion) const {
+    if (completion != nullptr) {
+      completion->release();
+    }
+  }
+};
 
 } // anonymous namespace
 
@@ -746,10 +755,16 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
 
   req.placement_algorithm = plan.placement_algorithm;
 
-  for (const auto& target : plan.targets) {
-    ::ObjectOperation op;
-    prepare_assert_ops(&op);
+  struct PendingVectorPut {
+    librados::vector_internal::put_op_state_t op_state;
+    std::unique_ptr<AioCompletion, AioCompletionReleaser> completion;
+    int submit_ret = 0;
+    int complete_ret = 0;
+  };
 
+  std::vector<std::unique_ptr<PendingVectorPut>> pending_puts;
+  pending_puts.reserve(plan.targets.size());
+  for (const auto& target : plan.targets) {
     ldout(client->cct, 20) << "vector-debug put computed oid="
 				  << target.oid
 				  << " algorithm=" << req.placement_algorithm
@@ -763,19 +778,33 @@ int librados::IoCtxImpl::put_vector(const std::string& vector_bucket_name,
 			  << " vector_hash=" << target.vector_hash
 			  << dendl;
 
-    req.placement_key = target.placement_key;
-    req.vector_hash = target.vector_hash;
+    auto pending = std::make_unique<PendingVectorPut>();
+    pending->completion.reset(librados::Rados::aio_create_completion());
+    prepare_assert_ops(&pending->op_state.op);
+    pending->submit_ret = librados::vector_internal::submit_put(
+        this, target.oid, std::string(), plan.placement_algorithm,
+        target.placement_key, target.vector_hash, req, &pending->op_state,
+        pending->completion.get());
+    pending_puts.push_back(std::move(pending));
+  }
 
-    bufferlist payload;
-    encode(req, payload);
-    op.put_vector(payload);
-
-    r = operate(target.oid, &op, NULL);
-    if (r < 0) {
-      return r;
+  // Fanout is non-atomic: collect every submitted op before reporting the
+  // first target-order error.
+  for (auto& pending : pending_puts) {
+    if (pending->submit_ret == 0) {
+      pending->completion->wait_for_complete();
+      pending->complete_ret = pending->completion->get_return_value();
     }
   }
 
+  for (const auto& pending : pending_puts) {
+    if (pending->submit_ret < 0) {
+      return pending->submit_ret;
+    }
+    if (pending->complete_ret < 0) {
+      return pending->complete_ret;
+    }
+  }
   return 0;
 }
 

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -38,6 +38,7 @@
 #include "librados/ListObjectImpl.h"
 #include "librados/librados_util.h"
 #include "librados/vector_pg_lsh.h"
+#include "librados/vector_put.h"
 #include "cls/lock/cls_lock_client.h"
 
 #include <string>
@@ -91,6 +92,12 @@ static TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tra
  * |          RadosClient                 |
  * +--------------------------------------+
  */
+
+librados::IoCtxImpl *librados::vector_internal::IoCtxAccess::get(
+    librados::v14_2_0::IoCtx& ioctx)
+{
+  return ioctx.io_ctx_impl;
+}
 
 size_t librados::ObjectOperation::size()
 {
@@ -489,28 +496,81 @@ int librados::v14_2_0::vector_pg_lsh::put_vector(
     const librados::v14_2_0::vector_pg_lsh::put_target_t& target,
     ceph::rados::put_vector_request_t req)
 {
+  struct CompletionReleaser {
+    void operator()(librados::v14_2_0::AioCompletion *completion) const {
+      if (completion != nullptr) {
+        completion->release();
+      }
+    }
+  };
+
+  std::unique_ptr<librados::v14_2_0::AioCompletion, CompletionReleaser> completion(
+      librados::v14_2_0::Rados::aio_create_completion());
+  put_op_state_t op_state;
+  int ret = submit_put(ioctx, target, std::move(req), &op_state,
+                       completion.get());
+  if (ret == 0) {
+    completion->wait_for_complete();
+    ret = completion->get_return_value();
+  }
+  return ret;
+}
+
+int librados::vector_internal::submit_put(
+    librados::IoCtxImpl *ioctx_impl,
+    const object_t& oid,
+    const std::string& locator_key,
+    const std::string& placement_algorithm,
+    const std::string& placement_key,
+    const std::string& vector_hash,
+    ceph::rados::put_vector_request_t req,
+    librados::vector_internal::put_op_state_t *op_state,
+    librados::v14_2_0::AioCompletion *completion)
+{
+  if (op_state == nullptr || completion == nullptr ||
+      ioctx_impl == nullptr ||
+      placement_algorithm.empty() || placement_key.empty() ||
+      vector_hash.empty()) {
+    return -EINVAL;
+  }
+
+  req.placement_algorithm = placement_algorithm;
+  req.placement_key = placement_key;
+  req.vector_hash = vector_hash;
+
+  op_state->payload.clear();
+  encode(req, op_state->payload);
+  op_state->op.put_vector(op_state->payload);
+
+  op_state->routed_ioctx.reset(new IoCtxImpl());
+  op_state->routed_ioctx->get();
+  op_state->routed_ioctx->dup(*ioctx_impl);
+  if (!locator_key.empty()) {
+    op_state->routed_ioctx->oloc.key = locator_key;
+  }
+
+  return op_state->routed_ioctx->aio_operate(
+      oid, &op_state->op, completion->pc, op_state->routed_ioctx->snapc,
+      nullptr, 0);
+}
+
+int librados::v14_2_0::vector_pg_lsh::submit_put(
+    librados::v14_2_0::IoCtx& ioctx,
+    const librados::v14_2_0::vector_pg_lsh::put_target_t& target,
+    ceph::rados::put_vector_request_t req,
+    librados::v14_2_0::vector_pg_lsh::put_op_state_t *op_state,
+    librados::v14_2_0::AioCompletion *completion)
+{
   int ret = verify_probe_locator(ioctx, target.pg, target.locator_key);
   if (ret < 0) {
     return ret;
   }
 
-  req.placement_algorithm =
-    ceph::rados::vector_placement_algorithm_pg_lsh_v0;
-  req.placement_key = target.placement_key;
-  req.vector_hash = target.vector_hash;
-
-  bufferlist payload;
-  encode(req, payload);
-
-  ::ObjectOperation op;
-  op.put_vector(payload);
-
-  librados::v14_2_0::IoCtx routed_ioctx;
-  routed_ioctx.dup(ioctx);
-  routed_ioctx.locator_set_key(target.locator_key);
-
-  IoCtxImpl *impl = vector_internal::IoCtxAccess::get(routed_ioctx);
-  return impl->operate(target.oid, &op, nullptr);
+  return vector_internal::submit_put(
+      vector_internal::IoCtxAccess::get(ioctx), target.oid, target.locator_key,
+      ceph::rados::vector_placement_algorithm_pg_lsh_v0,
+      target.placement_key, target.vector_hash, std::move(req), op_state,
+      completion);
 }
 
 int librados::v14_2_0::vector_pg_lsh::submit_query(

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -593,7 +593,6 @@ int librados::v14_2_0::vector_pg_lsh::submit_query(
   }
 
   req.probe_prefixes.clear();
-  req.local_top_k = std::numeric_limits<uint32_t>::max();
 
   op_state->payload.clear();
   encode(req, op_state->payload);
@@ -626,7 +625,6 @@ int librados::v14_2_0::vector_pg_lsh::query_sync(
   }
 
   req.probe_prefixes.clear();
-  req.local_top_k = std::numeric_limits<uint32_t>::max();
 
   bufferlist payload;
   encode(req, payload);

--- a/src/librados/vector_pg_lsh.h
+++ b/src/librados/vector_pg_lsh.h
@@ -20,19 +20,10 @@
 #include "include/object.h"
 #include "include/rados/librados.hpp"
 #include "include/rados/vector_ops.h"
-#include "librados/IoCtxImpl.h"
+#include "librados/vector_put.h"
 #include "librados/vector_placement.h"
 
 namespace librados {
-namespace vector_internal {
-
-inline IoCtxImpl *IoCtxAccess::get(v14_2_0::IoCtx& ioctx)
-{
-  return ioctx.io_ctx_impl;
-}
-
-} // namespace vector_internal
-
 inline namespace v14_2_0 {
 namespace vector_pg_lsh {
 
@@ -79,6 +70,8 @@ struct query_op_state_t {
   ::ObjectOperation op;
   ceph::bufferlist payload;
 };
+
+using put_op_state_t = vector_internal::put_op_state_t;
 
 inline int validate_params(const params_t& params,
                            const pool_pg_info_t& pool_info)
@@ -391,6 +384,12 @@ inline int verify_probe_locator(v14_2_0::IoCtx& ioctx,
 CEPH_RADOS_API int put_vector(v14_2_0::IoCtx& ioctx,
                               const put_target_t& target,
                               ceph::rados::put_vector_request_t req);
+
+CEPH_RADOS_API int submit_put(v14_2_0::IoCtx& ioctx,
+                              const put_target_t& target,
+                              ceph::rados::put_vector_request_t req,
+                              put_op_state_t *op_state,
+                              v14_2_0::AioCompletion *completion);
 
 CEPH_RADOS_API int submit_query(v14_2_0::IoCtx& ioctx,
                                 const query_probe_t& probe,

--- a/src/librados/vector_pg_lsh.h
+++ b/src/librados/vector_pg_lsh.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -40,6 +41,11 @@ struct params_t {
   uint32_t hamming_radius = 0;
   uint32_t d = 0;
   uint32_t m = 0;
+  uint32_t object_distance_group_bits = 0;
+  uint32_t object_residual_bits = 0;
+  uint32_t object_distance_probe_radius = 0;
+  uint32_t object_residual_hamming_radius = 0;
+  std::vector<double> object_anchor;
 };
 
 struct locator_state_t {
@@ -54,6 +60,7 @@ struct put_target_t {
   std::string locator_key;
   std::string placement_key;
   std::string vector_hash;
+  std::string object_name;
 };
 
 struct query_probe_t {
@@ -63,6 +70,7 @@ struct query_probe_t {
   object_t oid;
   std::string locator_key;
   std::string placement_key;
+  std::string object_name;
 };
 
 struct query_op_state_t {
@@ -83,6 +91,9 @@ inline int validate_params(const params_t& params,
       params.hamming_radius > params.k ||
       params.d == 0 ||
       params.m == 0 ||
+      params.object_distance_group_bits > 16 ||
+      params.object_residual_bits > 16 ||
+      params.object_residual_hamming_radius > params.object_residual_bits ||
       pool_info.pg_num == 0 ||
       pool_info.pgp_num == 0) {
     return -EINVAL;
@@ -93,7 +104,29 @@ inline int validate_params(const params_t& params,
   if (params.d > params.l) {
     return -EINVAL;
   }
+  if (params.object_distance_group_bits == 0 &&
+      params.object_distance_probe_radius != 0) {
+    return -EINVAL;
+  }
   return 0;
+}
+
+inline int compute_sub_oid_object_key(
+    const ceph::bufferlist& vector_data,
+    uint32_t dimension,
+    const params_t& params,
+    vector_placement::pg_lsh_v0_object_key_t *object_key)
+{
+  if (params.object_anchor.empty()) {
+    return vector_placement::pg_lsh_v0_compute_object_key(
+        vector_data, dimension, params.seed,
+        params.object_distance_group_bits, params.object_residual_bits,
+        object_key);
+  }
+  return vector_placement::pg_lsh_v0_compute_object_key_with_anchor(
+      vector_data, dimension, params.seed,
+      params.object_distance_group_bits, params.object_residual_bits,
+      params.object_anchor, object_key);
 }
 
 class locator_cache_t {
@@ -299,6 +332,18 @@ inline int build_put_targets(const std::string& bucket_name,
 
   const std::string vector_hash =
     vector_placement::hash_v0_vector_hash(vector_data);
+  std::string object_name;
+  if (vector_placement::pg_lsh_v0_sub_oid_enabled(
+        params.object_distance_group_bits, params.object_residual_bits)) {
+    vector_placement::pg_lsh_v0_object_key_t object_key;
+    ret = compute_sub_oid_object_key(
+        vector_data, dimension, params, &object_key);
+    if (ret < 0) {
+      return ret;
+    }
+    object_name = std::move(object_key.object_name);
+  }
+
   targets->reserve(write_pgs.size());
   for (const uint32_t pg : write_pgs) {
     std::string locator_key;
@@ -308,10 +353,12 @@ inline int build_put_targets(const std::string& bucket_name,
     }
     targets->push_back({
       pg,
-      vector_placement::make_pg_lsh_v0_oid(bucket_name, index_name, pg),
+      vector_placement::make_pg_lsh_v0_oid(
+          bucket_name, index_name, pg, object_name),
       std::move(locator_key),
       vector_placement::pg_lsh_v0_placement_key(pg),
       vector_hash,
+      object_name,
     });
   }
   return 0;
@@ -349,22 +396,50 @@ inline int build_query_probes(const std::string& bucket_name,
     return ret;
   }
 
-  probes->reserve(ranked.size());
+  std::vector<std::string> object_names;
+  if (vector_placement::pg_lsh_v0_sub_oid_enabled(
+        params.object_distance_group_bits, params.object_residual_bits)) {
+    vector_placement::pg_lsh_v0_object_key_t object_key;
+    ret = compute_sub_oid_object_key(
+        query_vector, dimension, params, &object_key);
+    if (ret < 0) {
+      return ret;
+    }
+    ret = vector_placement::pg_lsh_v0_object_probe_names(
+        object_key, params.object_distance_group_bits,
+        params.object_residual_bits, params.object_distance_probe_radius,
+        params.object_residual_hamming_radius, &object_names);
+    if (ret < 0) {
+      return ret;
+    }
+  } else {
+    object_names.emplace_back();
+  }
+
+  probes->reserve(ranked.size() * object_names.size());
+  std::unordered_set<std::string> seen_oid_names;
   for (const auto& candidate : ranked) {
     std::string locator_key;
     ret = locator_cache->locator_for_pg(candidate.pg, &locator_key);
     if (ret < 0) {
       return ret;
     }
-    probes->push_back({
-      candidate.pg,
-      candidate.min_hamming_distance,
-      candidate.table_votes,
-      vector_placement::make_pg_lsh_v0_oid(
-          bucket_name, index_name, candidate.pg),
-      std::move(locator_key),
-      vector_placement::pg_lsh_v0_placement_key(candidate.pg),
-    });
+    for (const auto& object_name : object_names) {
+      object_t oid = vector_placement::make_pg_lsh_v0_oid(
+          bucket_name, index_name, candidate.pg, object_name);
+      if (!seen_oid_names.insert(oid.name).second) {
+        continue;
+      }
+      probes->push_back({
+        candidate.pg,
+        candidate.min_hamming_distance,
+        candidate.table_votes,
+        std::move(oid),
+        locator_key,
+        vector_placement::pg_lsh_v0_placement_key(candidate.pg),
+        object_name,
+      });
+    }
   }
   return 0;
 }

--- a/src/librados/vector_pg_lsh.h
+++ b/src/librados/vector_pg_lsh.h
@@ -45,6 +45,7 @@ struct params_t {
   uint32_t object_residual_bits = 0;
   uint32_t object_distance_probe_radius = 0;
   uint32_t object_residual_hamming_radius = 0;
+  uint32_t object_probe_limit_per_pg = 0;
   std::vector<double> object_anchor;
 };
 
@@ -106,6 +107,11 @@ inline int validate_params(const params_t& params,
   }
   if (params.object_distance_group_bits == 0 &&
       params.object_distance_probe_radius != 0) {
+    return -EINVAL;
+  }
+  if (!vector_placement::pg_lsh_v0_sub_oid_enabled(
+        params.object_distance_group_bits, params.object_residual_bits) &&
+      params.object_probe_limit_per_pg != 0) {
     return -EINVAL;
   }
   return 0;
@@ -424,6 +430,7 @@ inline int build_query_probes(const std::string& bucket_name,
     if (ret < 0) {
       return ret;
     }
+    uint32_t emitted_for_pg = 0;
     for (const auto& object_name : object_names) {
       object_t oid = vector_placement::make_pg_lsh_v0_oid(
           bucket_name, index_name, candidate.pg, object_name);
@@ -439,6 +446,11 @@ inline int build_query_probes(const std::string& bucket_name,
         vector_placement::pg_lsh_v0_placement_key(candidate.pg),
         object_name,
       });
+      ++emitted_for_pg;
+      if (params.object_probe_limit_per_pg != 0 &&
+          emitted_for_pg >= params.object_probe_limit_per_pg) {
+        break;
+      }
     }
   }
   return 0;

--- a/src/librados/vector_placement.h
+++ b/src/librados/vector_placement.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -37,6 +38,19 @@ inline std::string hex_u32(uint32_t value)
 {
   char buf[9];
   std::snprintf(buf, sizeof(buf), "%08x", value);
+  return std::string(buf);
+}
+
+inline std::string hex_u32_width(uint32_t value, uint32_t width)
+{
+  char buf[9];
+  if (width == 0) {
+    width = 1;
+  }
+  if (width > 8) {
+    width = 8;
+  }
+  std::snprintf(buf, sizeof(buf), "%0*x", static_cast<int>(width), value);
   return std::string(buf);
 }
 
@@ -107,6 +121,18 @@ inline object_t make_pg_lsh_v0_oid(const std::string& bucket_name,
       ".rados.vector/v1/" + std::string(pg_lsh_v0_algorithm) + "/" +
       hash_string(bucket_name) + "/" + hash_string(index_name) + "/pg_" +
       std::to_string(pg));
+}
+
+inline object_t make_pg_lsh_v0_oid(const std::string& bucket_name,
+                                   const std::string& index_name,
+                                   uint32_t pg,
+                                   const std::string& object_name)
+{
+  object_t oid = make_pg_lsh_v0_oid(bucket_name, index_name, pg);
+  if (!object_name.empty()) {
+    oid.name += "/" + object_name;
+  }
+  return oid;
 }
 
 inline hash_v0_placement_t compute_hash_v0_placement(
@@ -255,6 +281,177 @@ struct pg_lsh_v0_group_t {
   uint32_t hamming_distance = 0;
 };
 
+struct pg_lsh_v0_object_key_t {
+  uint16_t distance16 = 0;
+  uint16_t distance_group = 0;
+  uint16_t residual_code = 0;
+  std::string object_name;
+};
+
+inline bool pg_lsh_v0_sub_oid_enabled(uint32_t distance_group_bits,
+                                      uint32_t residual_bits)
+{
+  return distance_group_bits != 0 || residual_bits != 0;
+}
+
+inline uint64_t pg_lsh_v0_object_space(uint32_t distance_group_bits,
+                                       uint32_t residual_bits)
+{
+  if (distance_group_bits > 16 || residual_bits > 16) {
+    return 0;
+  }
+  return (uint64_t{1} << distance_group_bits) *
+    (uint64_t{1} << residual_bits);
+}
+
+inline std::string pg_lsh_v0_object_name(uint32_t distance_group,
+                                         uint32_t distance_group_bits,
+                                         uint32_t residual_code,
+                                         uint32_t residual_bits)
+{
+  const uint32_t distance_width =
+    std::max<uint32_t>(1, (distance_group_bits + 3) / 4);
+  const uint32_t residual_width =
+    std::max<uint32_t>(1, (residual_bits + 3) / 4);
+  return "g" + hex_u32_width(distance_group, distance_width) +
+    "_r" + hex_u32_width(residual_code, residual_width);
+}
+
+inline int pg_lsh_v0_random_anchor(uint32_t dimension,
+                                   uint32_t seed,
+                                   std::vector<double> *anchor)
+{
+  if (anchor == nullptr || dimension == 0) {
+    return -EINVAL;
+  }
+  anchor->resize(dimension);
+  const double inv_sqrt_dim = 1.0 / std::sqrt(static_cast<double>(dimension));
+  const uint32_t anchor_seed = seed ^ 0x6a09e667U;
+  for (uint32_t dim = 0; dim < dimension; ++dim) {
+    (*anchor)[dim] =
+      static_cast<double>(
+          pg_lsh_v0_hyperplane_sign(anchor_seed, 0, 0, dim)) *
+      inv_sqrt_dim;
+  }
+  return 0;
+}
+
+inline int pg_lsh_v0_compute_object_key_with_anchor(
+    const ceph::bufferlist& vector_data,
+    uint32_t dimension,
+    uint32_t seed,
+    uint32_t distance_group_bits,
+    uint32_t residual_bits,
+    const std::vector<double>& anchor,
+    pg_lsh_v0_object_key_t *out)
+{
+  if (out == nullptr || distance_group_bits > 16 || residual_bits > 16 ||
+      !pg_lsh_v0_sub_oid_enabled(distance_group_bits, residual_bits) ||
+      anchor.size() != dimension) {
+    return -EINVAL;
+  }
+
+  std::vector<float> values;
+  int r = copy_float32_vector(vector_data, dimension, &values);
+  if (r < 0) {
+    return r;
+  }
+
+  double norm_sq = 0;
+  for (const float value : values) {
+    if (!std::isfinite(value)) {
+      return -EINVAL;
+    }
+    norm_sq += static_cast<double>(value) * value;
+  }
+
+  std::vector<double> normalized(values.size(), 0);
+  if (norm_sq > 0) {
+    const double inv_norm = 1.0 / std::sqrt(norm_sq);
+    for (size_t i = 0; i < values.size(); ++i) {
+      normalized[i] = static_cast<double>(values[i]) * inv_norm;
+    }
+  }
+
+  double anchor_norm_sq = 0;
+  for (const double component : anchor) {
+    if (!std::isfinite(component)) {
+      return -EINVAL;
+    }
+    anchor_norm_sq += component * component;
+  }
+  if (anchor_norm_sq <= 0) {
+    return -EINVAL;
+  }
+  const double anchor_inv_norm = 1.0 / std::sqrt(anchor_norm_sq);
+  const uint32_t residual_seed = seed ^ 0xbb67ae85U;
+
+  double dot = 0;
+  for (uint32_t dim = 0; dim < dimension; ++dim) {
+    dot += normalized[dim] * anchor[dim] * anchor_inv_norm;
+  }
+  dot = std::max(-1.0, std::min(1.0, dot));
+
+  const double scaled_distance =
+    std::max(0.0, std::min(1.0, (1.0 - dot) / 2.0));
+  const auto distance16 = static_cast<uint32_t>(
+      std::floor(scaled_distance * 65535.0 + 0.5));
+
+  uint32_t distance_group = 0;
+  if (distance_group_bits != 0) {
+    distance_group = distance16 >> (16 - distance_group_bits);
+  }
+
+  uint32_t residual_code = 0;
+  if (residual_bits != 0) {
+    std::vector<double> residual(values.size(), 0);
+    for (uint32_t dim = 0; dim < dimension; ++dim) {
+      const double anchor_component = anchor[dim] * anchor_inv_norm;
+      residual[dim] = normalized[dim] - dot * anchor_component;
+    }
+
+    const double inv_sqrt_dim = 1.0 / std::sqrt(static_cast<double>(dimension));
+    for (uint32_t bit = 0; bit < residual_bits; ++bit) {
+      double projection = 0;
+      for (uint32_t dim = 0; dim < dimension; ++dim) {
+        projection += residual[dim] *
+          static_cast<double>(
+              pg_lsh_v0_hyperplane_sign(residual_seed, 0, bit, dim)) *
+          inv_sqrt_dim;
+      }
+      if (projection >= 0) {
+        residual_code |= (uint32_t{1} << bit);
+      }
+    }
+  }
+
+  out->distance16 = static_cast<uint16_t>(
+      std::min<uint32_t>(distance16, 0xffffU));
+  out->distance_group = static_cast<uint16_t>(distance_group);
+  out->residual_code = static_cast<uint16_t>(residual_code);
+  out->object_name = pg_lsh_v0_object_name(
+      distance_group, distance_group_bits, residual_code, residual_bits);
+  return 0;
+}
+
+inline int pg_lsh_v0_compute_object_key(
+    const ceph::bufferlist& vector_data,
+    uint32_t dimension,
+    uint32_t seed,
+    uint32_t distance_group_bits,
+    uint32_t residual_bits,
+    pg_lsh_v0_object_key_t *out)
+{
+  std::vector<double> anchor;
+  int r = pg_lsh_v0_random_anchor(dimension, seed, &anchor);
+  if (r < 0) {
+    return r;
+  }
+  return pg_lsh_v0_compute_object_key_with_anchor(
+      vector_data, dimension, seed, distance_group_bits, residual_bits,
+      anchor, out);
+}
+
 inline void pg_lsh_v0_append_hamming_masks(uint32_t lsh_bucket_id_bits,
                                            uint32_t start_bit,
                                            uint32_t remaining,
@@ -309,6 +506,66 @@ inline std::vector<uint32_t> pg_lsh_v0_hamming_masks_at_distance(
   pg_lsh_v0_append_hamming_masks(
       lsh_bucket_id_bits, 0, distance, 0, &masks);
   return masks;
+}
+
+inline int pg_lsh_v0_object_probe_names(
+    const pg_lsh_v0_object_key_t& exact,
+    uint32_t distance_group_bits,
+    uint32_t residual_bits,
+    uint32_t distance_probe_radius,
+    uint32_t residual_hamming_radius,
+    std::vector<std::string> *object_names)
+{
+  if (object_names == nullptr ||
+      distance_group_bits > 16 ||
+      residual_bits > 16 ||
+      residual_hamming_radius > residual_bits ||
+      !pg_lsh_v0_sub_oid_enabled(distance_group_bits, residual_bits)) {
+    return -EINVAL;
+  }
+  if (distance_group_bits == 0 && distance_probe_radius != 0) {
+    return -EINVAL;
+  }
+
+  object_names->clear();
+
+  std::vector<uint32_t> distance_groups;
+  if (distance_group_bits == 0) {
+    distance_groups.push_back(0);
+  } else {
+    const uint32_t group_count = uint32_t{1} << distance_group_bits;
+    distance_groups.push_back(exact.distance_group);
+    for (uint32_t delta = 1; delta <= distance_probe_radius; ++delta) {
+      if (exact.distance_group >= delta) {
+        distance_groups.push_back(exact.distance_group - delta);
+      }
+      const uint32_t plus = exact.distance_group + delta;
+      if (plus < group_count) {
+        distance_groups.push_back(plus);
+      }
+    }
+  }
+
+  std::vector<uint32_t> residual_masks;
+  if (residual_bits == 0) {
+    residual_masks.push_back(0);
+  } else {
+    residual_masks =
+      pg_lsh_v0_hamming_masks(residual_bits, residual_hamming_radius);
+  }
+
+  object_names->reserve(distance_groups.size() * residual_masks.size());
+  const uint32_t residual_mask =
+    residual_bits == 0 ? 0 : ((uint32_t{1} << residual_bits) - 1);
+  for (const uint32_t distance_group : distance_groups) {
+    for (const uint32_t mask : residual_masks) {
+      const uint32_t residual_code =
+        residual_bits == 0 ? 0 : ((exact.residual_code ^ mask) & residual_mask);
+      object_names->push_back(pg_lsh_v0_object_name(
+          distance_group, distance_group_bits, residual_code, residual_bits));
+    }
+  }
+  return 0;
 }
 
 inline int pg_lsh_v0_exact_groups(const ceph::bufferlist& vector_data,

--- a/src/librados/vector_put.h
+++ b/src/librados/vector_put.h
@@ -1,0 +1,47 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_LIBRADOS_VECTOR_PUT_H
+#define CEPH_LIBRADOS_VECTOR_PUT_H
+
+#include <memory>
+#include <string>
+
+#include "include/buffer.h"
+#include "include/object.h"
+#include "include/rados/librados.hpp"
+#include "include/rados/vector_ops.h"
+#include "librados/IoCtxImpl.h"
+#include "osdc/Objecter.h"
+
+namespace librados {
+namespace vector_internal {
+
+struct IoCtxImplReleaser {
+  void operator()(IoCtxImpl *impl) const {
+    if (impl != nullptr) {
+      impl->put();
+    }
+  }
+};
+
+struct put_op_state_t {
+  std::unique_ptr<IoCtxImpl, IoCtxImplReleaser> routed_ioctx;
+  ::ObjectOperation op;
+  ceph::bufferlist payload;
+};
+
+CEPH_RADOS_API int submit_put(IoCtxImpl *ioctx_impl,
+                              const object_t& oid,
+                              const std::string& locator_key,
+                              const std::string& placement_algorithm,
+                              const std::string& placement_key,
+                              const std::string& vector_hash,
+                              ceph::rados::put_vector_request_t req,
+                              put_op_state_t *op_state,
+                              v14_2_0::AioCompletion *completion);
+
+} // namespace vector_internal
+} // namespace librados
+
+#endif

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -8,7 +8,9 @@
 #include "test/crimson/seastore/transaction_manager_test_state.h"
 
 #include "crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h"
+#include "crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h"
+#include "crimson/os/seastore/vector_node.h"
 
 using namespace crimson;
 using namespace crimson::os;
@@ -20,6 +22,25 @@ using namespace std;
 namespace {
   [[maybe_unused]] seastar::logger& logger() {
     return crimson::get_logger(ceph_subsys_test);
+  }
+
+  ceph::bufferlist make_vector_payload(const std::string &contents) {
+    ceph::bufferlist bl;
+    bl.append(contents);
+    return bl;
+  }
+
+  void expect_vector_entries(
+      const vector_node_t &node,
+      std::initializer_list<std::pair<std::string, std::string>> entries) {
+    ASSERT_EQ(entries.size(), node.entries.size());
+    auto expected = entries.begin();
+    for (const auto &actual : node.entries) {
+      EXPECT_EQ(expected->first, actual.entry_id);
+      EXPECT_TRUE(actual.vector_data.contents_equal(
+        make_vector_payload(expected->second)));
+      ++expected;
+    }
   }
 }
 
@@ -257,6 +278,152 @@ TEST_P(fltree_onode_manager_test_t, 1_single)
       }).unsafe_get();
     });
     validate_erased(iter);
+  });
+}
+
+TEST_P(fltree_onode_manager_test_t, vector_node_link_lifecycle)
+{
+  run_async([this] {
+    auto pool = KVPool<onode_item_t>::create_range(
+      {0, 2}, {128, 256}, tm->get_block_size());
+    auto src_item = *pool.begin();
+    auto dst_item = *(pool.begin() + 1);
+    auto src_key = src_item->key;
+    auto dst_key = dst_item->key;
+    laddr_t vector_addr = L_ADDR_NULL;
+
+    {
+      VectorNodeManager vector_manager(*tm);
+      auto t = create_mutate_transaction();
+      auto onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_or_create_onode(trans, src_key);
+      }).unsafe_get();
+      auto &flonode = static_cast<FLTreeOnode&>(*onode);
+      src_item->value.initialize(*t, *onode);
+      EXPECT_EQ(sizeof(onode_layout_t), flonode.get_payload_size());
+      EXPECT_FALSE(onode->has_vector_node());
+
+      auto node = with_trans_intr(*t, [&](auto &trans) {
+        return vector_manager.create_vector_node(trans, 1, 4);
+      }).unsafe_get();
+      vector_addr = node->get_laddr();
+      node = with_trans_intr(*t, [&](auto &trans) {
+        return vector_manager.upsert_vector_entry(
+          trans, std::move(node), "vec-a", make_vector_payload("aaaa"));
+      }).unsafe_get();
+      ASSERT_NE(L_ADDR_NULL, vector_addr);
+      onode->update_vector_node_laddr(*t, vector_addr);
+      EXPECT_EQ(vector_addr, onode->get_vector_node_laddr());
+      auto offloaded = onode->offload_data_and_md(*t);
+      EXPECT_EQ(vector_addr, offloaded->get_vector_node_laddr());
+      EXPECT_EQ(vector_addr, onode->get_vector_node_laddr());
+      src_item->value.initialize(*t, *onode);
+      submit_transaction(std::move(t));
+    }
+
+    {
+      VectorNodeManager vector_manager(*tm);
+      auto t = create_read_transaction();
+      auto onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, src_key);
+      }).unsafe_get();
+      EXPECT_EQ(vector_addr, onode->get_vector_node_laddr());
+      auto node = with_trans_intr(*t, [&](auto &trans) {
+        return vector_manager.read_vector_node(trans, vector_addr);
+      }).unsafe_get();
+      expect_vector_entries(node->get_contents(), {{"vec-a", "aaaa"}});
+    }
+
+    restart();
+
+    {
+      VectorNodeManager vector_manager(*tm);
+      auto t = create_read_transaction();
+      auto onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, src_key);
+      }).unsafe_get();
+      EXPECT_EQ(vector_addr, onode->get_vector_node_laddr());
+      auto node = with_trans_intr(*t, [&](auto &trans) {
+        return vector_manager.read_vector_node(trans, vector_addr);
+      }).unsafe_get();
+      expect_vector_entries(node->get_contents(), {{"vec-a", "aaaa"}});
+    }
+
+    {
+      auto t = create_mutate_transaction();
+      auto src_onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, src_key);
+      }).unsafe_get();
+      auto dst_onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_or_create_onode(trans, dst_key);
+      }).unsafe_get();
+      dst_item->value.initialize(*t, *dst_onode);
+      src_onode->swap_layout(*t, *dst_onode);
+      EXPECT_FALSE(src_onode->has_vector_node());
+      EXPECT_EQ(vector_addr, dst_onode->get_vector_node_laddr());
+      submit_transaction(std::move(t));
+    }
+
+    {
+      auto t = create_read_transaction();
+      auto src_onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, src_key);
+      }).unsafe_get();
+      auto dst_onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, dst_key);
+      }).unsafe_get();
+      EXPECT_FALSE(src_onode->has_vector_node());
+      EXPECT_EQ(vector_addr, dst_onode->get_vector_node_laddr());
+    }
+
+    restart();
+
+    {
+      auto t = create_read_transaction();
+      auto src_onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, src_key);
+      }).unsafe_get();
+      auto dst_onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, dst_key);
+      }).unsafe_get();
+      EXPECT_FALSE(src_onode->has_vector_node());
+      EXPECT_EQ(vector_addr, dst_onode->get_vector_node_laddr());
+    }
+
+    {
+      VectorNodeManager vector_manager(*tm);
+      auto t = create_mutate_transaction();
+      auto onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, dst_key);
+      }).unsafe_get();
+      auto ret = with_trans_intr(*t, [&](auto &trans) {
+        return vector_manager.read_vector_node(trans, vector_addr
+        ).si_then([&](auto node) {
+          return vector_manager.remove_vector_entry(
+            trans, std::move(node), "vec-a");
+        });
+      }).unsafe_get();
+      EXPECT_TRUE(ret.second);
+      EXPECT_TRUE(ret.first->get_contents().entries.empty());
+      auto refcnt = with_trans_intr(*t, [&](auto &trans) {
+        return tm->remove(trans, ret.first->cast<LogicalChildNode>());
+      }).unsafe_get();
+      EXPECT_EQ(0u, refcnt);
+      onode->clear_vector_node_laddr(*t);
+      EXPECT_FALSE(onode->has_vector_node());
+      submit_transaction(std::move(t));
+    }
+
+    restart();
+
+    {
+      auto t = create_read_transaction();
+      auto onode = with_trans_intr(*t, [&](auto &trans) {
+        return manager->get_onode(trans, dst_key);
+      }).unsafe_get();
+      EXPECT_FALSE(onode->has_vector_node());
+      EXPECT_EQ(L_ADDR_NULL, onode->get_vector_node_laddr());
+    }
   });
 }
 

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -87,6 +87,18 @@ public:
     });
   }
 
+  laddr_t get_vector_node_laddr() const final {
+    return layout.vector_node_laddr;
+  }
+
+  void update_vector_node_laddr(Transaction &, laddr_t addr) final {
+    layout.vector_node_laddr = addr;
+  }
+
+  void clear_vector_node_laddr(Transaction &) final {
+    layout.vector_node_laddr = L_ADDR_NULL;
+  }
+
   void update_onode_size(Transaction &t, uint32_t size) final {
     with_mutable_layout(t, [size](onode_layout_t &mlayout) {
       mlayout.size = size;

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -41,6 +41,7 @@ public:
       std::swap(layout.object_data, o_mlayout.object_data);
       std::swap(layout.omap_root, o_mlayout.omap_root);
       std::swap(layout.xattr_root, o_mlayout.xattr_root);
+      std::swap(layout.vector_node_laddr, o_mlayout.vector_node_laddr);
     });
   }
   laddr_hint_t init_hint(
@@ -167,6 +168,7 @@ public:
       ret->update_omap_root(t, root);
       root = layout.xattr_root.get(LADDR_HINT_NULL);
       ret->update_xattr_root(t, root);
+      ret->update_vector_node_laddr(t, layout.vector_node_laddr);
     }
     {
       auto data = object_data_t{L_ADDR_NULL, 0};

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -1084,10 +1084,11 @@ struct transaction_manager_test_t :
         extent_types_t::TEST_BLOCK_PHYSICAL,
         extent_types_t::BACKREF_INTERNAL,
         extent_types_t::BACKREF_LEAF,
-	extent_types_t::LOG_NODE
+	extent_types_t::LOG_NODE,
+        extent_types_t::VECTOR_NODE
       };
-      // exclude DINK_LADDR_LEAF, ALLOC_INFO, JOURNAL_TAIL
-      assert(all_extent_types.size() == EXTENT_TYPES_MAX - 3);
+      // exclude DINK_LADDR_LEAF, ALLOC_INFO, JOURNAL_TAIL, NONE
+      assert(all_extent_types.size() == EXTENT_TYPES_MAX - 4);
 
       std::vector<rewrite_gen_t> all_generations;
       for (auto i = INIT_GENERATION; i <= epm->dynamic_max_rewrite_generation; i++) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -12,6 +12,7 @@
 #include "crimson/os/seastore/transaction_manager.h"
 #include "crimson/os/seastore/segment_manager/ephemeral.h"
 #include "crimson/os/seastore/segment_manager.h"
+#include "crimson/os/seastore/vector_node.h"
 
 #include "test/crimson/seastore/test_block.h"
 #include "crimson/os/seastore/lba/lba_btree_node.h"
@@ -23,6 +24,32 @@ using namespace crimson::os::seastore;
 namespace {
   [[maybe_unused]] seastar::logger& logger() {
     return crimson::get_logger(ceph_subsys_test);
+  }
+
+  ceph::bufferlist make_vector_payload(std::string_view payload) {
+    ceph::bufferlist bl;
+    bl.append(payload.data(), payload.size());
+    return bl;
+  }
+
+  ceph::bufferlist get_extent_image(const VectorNodeRef &node) {
+    ceph::bufferlist bl;
+    ceph::bufferptr bptr(node->get_bptr(), 0, node->get_length());
+    bl.append(bptr);
+    return bl;
+  }
+
+  void expect_vector_entries(
+    const vector_node_t &node,
+    std::initializer_list<std::pair<std::string_view, std::string_view>> entries) {
+    ASSERT_EQ(entries.size(), node.entries.size());
+    auto expected = entries.begin();
+    for (const auto &entry : node.entries) {
+      EXPECT_EQ(expected->first, entry.entry_id);
+      auto expected_payload = make_vector_payload(expected->second);
+      EXPECT_TRUE(entry.vector_data.contents_equal(expected_payload));
+      ++expected;
+    }
   }
 }
 
@@ -1960,6 +1987,183 @@ TEST_P(tm_single_device_test_t, mutate)
     ASSERT_TRUE(check_usage());
     replay();
     check();
+  });
+}
+
+TEST_P(tm_single_device_test_t, vector_node_crud)
+{
+  run_async([this] {
+    VectorNodeManager manager(*tm);
+    laddr_t addr = L_ADDR_NULL;
+    {
+      auto t = create_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.create_vector_node(trans, 1, 4
+        ).si_then([&](auto node) {
+          addr = node->get_laddr();
+          return manager.upsert_vector_entry(
+            trans, std::move(node), "vec-b", make_vector_payload("bbbb"));
+        }).si_then([&](auto node) {
+          return manager.upsert_vector_entry(
+            trans, std::move(node), "vec-a", make_vector_payload("aaaa"));
+        });
+      }).unsafe_get();
+      ASSERT_NE(L_ADDR_NULL, addr);
+      ASSERT_EQ(addr, node->get_laddr());
+      expect_vector_entries(
+        node->get_contents(),
+        {{"vec-a", "aaaa"}, {"vec-b", "bbbb"}});
+      submit_transaction(std::move(t));
+    }
+    {
+      auto t = create_read_test_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.read_vector_node(trans, addr);
+      }).unsafe_get();
+      ASSERT_EQ(addr, node->get_laddr());
+      EXPECT_EQ(1u, node->get_contents().data_type);
+      EXPECT_EQ(4u, node->get_contents().dimension);
+      expect_vector_entries(
+        node->get_contents(),
+        {{"vec-a", "aaaa"}, {"vec-b", "bbbb"}});
+    }
+    {
+      auto t = create_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.read_vector_node(trans, addr
+        ).si_then([&](auto node) {
+          return manager.upsert_vector_entry(
+            trans, std::move(node), "vec-a", make_vector_payload("zzzz"));
+        });
+      }).unsafe_get();
+      expect_vector_entries(
+        node->get_contents(),
+        {{"vec-a", "zzzz"}, {"vec-b", "bbbb"}});
+      submit_transaction(std::move(t));
+    }
+    {
+      auto t = create_transaction();
+      auto ret = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.read_vector_node(trans, addr
+        ).si_then([&](auto node) {
+          return manager.remove_vector_entry(
+            trans, std::move(node), "vec-a");
+        });
+      }).unsafe_get();
+      EXPECT_TRUE(ret.second);
+      expect_vector_entries(ret.first->get_contents(), {{"vec-b", "bbbb"}});
+      submit_transaction(std::move(t));
+    }
+    {
+      auto t = create_transaction();
+      auto ret = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.read_vector_node(trans, addr
+        ).si_then([&](auto node) {
+          return manager.remove_vector_entry(
+            trans, std::move(node), "missing");
+        });
+      }).unsafe_get();
+      EXPECT_FALSE(ret.second);
+      expect_vector_entries(ret.first->get_contents(), {{"vec-b", "bbbb"}});
+    }
+  });
+}
+
+TEST_P(tm_single_device_test_t, vector_node_capacity_limit)
+{
+  run_async([this] {
+    VectorNodeManager manager(*tm);
+    laddr_t addr = L_ADDR_NULL;
+    {
+      auto t = create_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.create_vector_node(trans, 1, 4
+        ).si_then([&](auto node) {
+          addr = node->get_laddr();
+          return manager.upsert_vector_entry(
+            trans, std::move(node), "vec-a", make_vector_payload("aaaa"));
+        });
+      }).unsafe_get();
+      ASSERT_EQ(tm->get_block_size(), node->get_length());
+      submit_transaction(std::move(t));
+    }
+    {
+      auto t = create_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.read_vector_node(trans, addr);
+      }).unsafe_get();
+      const auto before_image = get_extent_image(node);
+      expect_vector_entries(node->get_contents(), {{"vec-a", "aaaa"}});
+
+      std::string oversized(tm->get_block_size(), 'x');
+      using ertr = with_trans_ertr<VectorNodeManager::mutate_iertr>;
+      bool got_enospc = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.upsert_vector_entry(
+          trans, node, "oversized", make_vector_payload(oversized));
+      }).safe_then([](auto) -> ertr::future<bool> {
+        return ertr::make_ready_future<bool>(false);
+      }).handle_error(
+        crimson::ct_error::enospc::handle([] {
+          return seastar::make_ready_future<bool>(true);
+        }),
+        crimson::ct_error::assert_all{
+          "vector_node_capacity_limit got invalid error"
+        }
+      ).get();
+
+      EXPECT_TRUE(got_enospc);
+      expect_vector_entries(node->get_contents(), {{"vec-a", "aaaa"}});
+      EXPECT_TRUE(get_extent_image(node).contents_equal(before_image));
+    }
+    {
+      auto t = create_read_test_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.read_vector_node(trans, addr);
+      }).unsafe_get();
+      expect_vector_entries(node->get_contents(), {{"vec-a", "aaaa"}});
+    }
+  });
+}
+
+TEST_P(tm_single_device_test_t, vector_node_delta_replay_image)
+{
+  run_async([this] {
+    VectorNodeManager manager(*tm);
+    laddr_t addr = L_ADDR_NULL;
+    {
+      auto t = create_transaction();
+      auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+        return manager.create_vector_node(trans, 7, 2
+        ).si_then([&](auto node) {
+          addr = node->get_laddr();
+          return manager.upsert_vector_entry(
+            trans, std::move(node), "vec-a", make_vector_payload("aabb"));
+        }).si_then([&](auto node) {
+          return manager.upsert_vector_entry(
+            trans, std::move(node), "vec-b", make_vector_payload("ccdd"));
+        });
+      }).unsafe_get();
+      submit_transaction(std::move(t));
+    }
+
+    auto t = create_read_test_transaction();
+    auto node = with_trans_intr(*(t.t), [&](auto &trans) {
+      return manager.read_vector_node(trans, addr);
+    }).unsafe_get();
+    auto delta = node->get_delta();
+    auto image = get_extent_image(node);
+    ASSERT_TRUE(delta.contents_equal(image));
+
+    VectorNodeRef replayed(new VectorNode(
+      create_extent_ptr_zero(node->get_length())));
+    replayed->apply_delta_and_adjust_crc(P_ADDR_NULL, delta);
+    EXPECT_EQ(node->calc_crc32c(), replayed->calc_crc32c());
+    EXPECT_TRUE(get_extent_image(replayed).contents_equal(image));
+    EXPECT_EQ(7u, replayed->get_contents().data_type);
+    EXPECT_EQ(2u, replayed->get_contents().dimension);
+    expect_vector_entries(
+      replayed->get_contents(),
+      {{"vec-a", "aabb"}, {"vec-b", "ccdd"}});
   });
 }
 

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -387,6 +387,64 @@ TEST(VectorQueryExecutor, LocalTopKLimitsPartialResults) {
   EXPECT_NEAR(1.0f, result.entries[0].distance, 1e-6f);
 }
 
+TEST(VectorQueryExecutor, LocalTopKKeepsBoundedSortedResults) {
+  float query[] = {0.0, 0.0};
+  bufferlist query_bl;
+  query_bl.append(reinterpret_cast<const char *>(query), sizeof(query));
+
+  ceph::rados::query_vectors_request_t req;
+  req.bucket_name = "bucket";
+  req.index_name = "index";
+  req.data_type = LIBRADOS_VECTOR_DATA_TYPE_FLOAT32;
+  req.distance_metric = LIBRADOS_VECTOR_DISTANCE_METRIC_EUCLIDEAN;
+  req.dimension = 2;
+  req.local_top_k = 2;
+  req.query_vector = query_bl;
+
+  ceph::rados::vector_query_exec::omap_scan_state_t scan;
+  auto add_entry = [&](const string& entry_id,
+                       const string& key,
+                       const string& content_key,
+                       float x,
+                       float y) {
+    ceph::rados::vector_query_exec::omap_entry_t entry;
+    entry.entry_id = entry_id;
+    entry.bucket_name = req.bucket_name;
+    entry.index_name = req.index_name;
+    entry.user_key = key;
+    entry.content_key = content_key;
+    entry.data_type = req.data_type;
+    entry.distance_metric = req.distance_metric;
+    entry.dimension = req.dimension;
+    entry.has_data_type = true;
+    entry.has_distance_metric = true;
+    entry.has_dimension = true;
+    scan.entries[entry.entry_id] = entry;
+
+    float vector[] = {x, y};
+    bufferlist vector_bl;
+    vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+    scan.contents[entry.content_key] = vector_bl;
+  };
+
+  add_entry("entry-a", "vec-a", "_CONTENT_a", 5.0, 0.0);
+  add_entry("entry-b", "vec-b", "_CONTENT_b", 1.0, 0.0);
+  add_entry("entry-c", "vec-c", "_CONTENT_c", 3.0, 0.0);
+  add_entry("entry-d", "vec-d", "_CONTENT_d", 2.0, 0.0);
+
+  ceph::rados::query_vectors_result_t result;
+  ceph::rados::vector_query_exec::query_filter_stats_t stats;
+  ASSERT_EQ(0, ceph::rados::vector_query_exec::build_local_results(
+      req, scan, &result, &stats));
+  ASSERT_EQ(2u, result.entries.size());
+  EXPECT_EQ("entry-b", result.entries[0].entry_id);
+  EXPECT_EQ("entry-d", result.entries[1].entry_id);
+  EXPECT_LE(result.entries[0].distance, result.entries[1].distance);
+  EXPECT_EQ(4u, stats.matched_entries);
+  EXPECT_EQ(4u, stats.merged_entries);
+  EXPECT_EQ(2u, stats.final_entries);
+}
+
 TEST(VectorQueryPlanner, HashV0SeparatesBucketAndIndex) {
   float query[] = {1.0, 2.0, 3.0, 4.0};
   bufferlist query_bl;
@@ -1079,7 +1137,7 @@ TEST_F(LibRadosIoPP, PgLshV0RawOpsRouteAndMergeByEntryId) {
     req.data_type = ceph::rados::vector_data_type_float32;
     req.distance_metric = ceph::rados::vector_distance_metric_euclidean;
     req.dimension = near_vector.size();
-    req.local_top_k = std::numeric_limits<uint32_t>::max();
+    req.local_top_k = 2;
     req.query_vector = near_bl;
 
     ASSERT_EQ(0, librados::vector_pg_lsh::submit_query(

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -623,6 +623,47 @@ TEST(VectorPlacement, PgLshV0SelectionUsesLogicalOrderAndBudget) {
   EXPECT_LT(query_pgs.size(), exhausted_params.m);
 }
 
+TEST(VectorPlacement, PgLshV0ObjectNameUsesCoarseDistanceGroup) {
+  float vector[] = {1.0, 2.0, 0.0, -1.0};
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(vector), sizeof(vector));
+
+  librados::vector_placement::pg_lsh_v0_object_key_t key;
+  ASSERT_EQ(0, librados::vector_placement::pg_lsh_v0_compute_object_key(
+      vector_bl, 4, 12345, 4, 4, &key));
+  EXPECT_EQ(0x4bbe, key.distance16);
+  EXPECT_EQ(0x4, key.distance_group);
+  EXPECT_EQ(0x5, key.residual_code);
+  EXPECT_EQ("g4_r5", key.object_name);
+
+  std::vector<std::string> object_names;
+  ASSERT_EQ(0, librados::vector_placement::pg_lsh_v0_object_probe_names(
+      key, 4, 4, 1, 1, &object_names));
+  ASSERT_EQ(15u, object_names.size());
+  EXPECT_EQ("g4_r5", object_names[0]);
+
+  const std::unordered_set<std::string> names(
+      object_names.begin(), object_names.end());
+  EXPECT_EQ(object_names.size(), names.size());
+  EXPECT_EQ(1u, names.count("g3_r5"));
+  EXPECT_EQ(1u, names.count("g5_r5"));
+  EXPECT_EQ(1u, names.count("g4_r4"));
+
+  float axis_vector[] = {2.0, 0.0, 0.0, 0.0};
+  bufferlist axis_bl;
+  axis_bl.append(reinterpret_cast<const char *>(axis_vector),
+                 sizeof(axis_vector));
+  std::vector<double> axis_anchor = {1.0, 0.0, 0.0, 0.0};
+  ASSERT_EQ(0,
+            librados::vector_placement::
+            pg_lsh_v0_compute_object_key_with_anchor(
+                axis_bl, 4, 12345, 4, 4, axis_anchor, &key));
+  EXPECT_EQ(0x0000, key.distance16);
+  EXPECT_EQ(0x0, key.distance_group);
+  EXPECT_EQ(0xf, key.residual_code);
+  EXPECT_EQ("g0_rf", key.object_name);
+}
+
 TEST(VectorPlacement, PgLshV0ManualCollisionSelection) {
   constexpr uint32_t seed = 12345;
   constexpr uint32_t pg_num = 16;

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -12,6 +12,7 @@
 #include <set>
 #include <sstream>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <unistd.h>
@@ -972,6 +973,137 @@ static int put_pg_lsh_test_vector(IoCtx& ioctx,
   target.vector_hash =
     librados::vector_placement::hash_v0_vector_hash(vector_bl);
   return librados::vector_pg_lsh::put_vector(ioctx, target, std::move(req));
+}
+
+TEST_F(LibRadosIoPP, PgLshV0SubOidProbeLimitIsPerPg) {
+  const std::string sub_pool_name =
+    get_temp_pool_name("pg-lsh-sub-oid-probe-limit-");
+  bufferlist outbl;
+  std::string cmd = "{\"prefix\":\"osd pool create\",\"pool\":\"" +
+    sub_pool_name + "\",\"pg_num\":8,\"pgp_num\":8,\"format\":\"json\"}";
+  ASSERT_EQ(0, cluster.mon_command(std::move(cmd), {}, &outbl, nullptr));
+  auto cleanup_sub_pool = make_scope_guard([&] {
+    cluster.pool_delete(sub_pool_name.c_str());
+  });
+
+  IoCtx sub_ioctx;
+  ASSERT_EQ(0, cluster.ioctx_create(sub_pool_name.c_str(), sub_ioctx));
+  ASSERT_EQ(0, sub_ioctx.application_enable("rados", true));
+  ASSERT_EQ(0, cluster.wait_for_latest_osdmap());
+
+  librados::vector_pg_lsh::pool_pg_info_t pool_info;
+  ASSERT_EQ(0, pool_pg_info_for_test(cluster, sub_pool_name, &pool_info));
+  ASSERT_GE(pool_info.pg_num, 8u);
+  ASSERT_GE(pool_info.pgp_num, 8u);
+
+  auto locator_state =
+    std::make_shared<librados::vector_pg_lsh::locator_state_t>();
+  librados::vector_pg_lsh::locator_cache_t locator_cache(
+      &sub_ioctx, pool_info, sub_pool_name, "pg-lsh-bucket", "pg-lsh-index",
+      locator_state);
+  ASSERT_EQ(0, locator_cache.precompute_all());
+
+  librados::vector_pg_lsh::params_t params;
+  params.k = 4;
+  params.l = 4;
+  params.seed = 12345;
+  params.hamming_radius = 0;
+  params.d = 2;
+  params.m = 2;
+  params.object_distance_group_bits = 4;
+  params.object_residual_bits = 4;
+  params.object_distance_probe_radius = 1;
+  params.object_residual_hamming_radius = 0;
+  params.object_probe_limit_per_pg = 3;
+  ASSERT_EQ(0, librados::vector_pg_lsh::validate_params(
+      params, pool_info));
+
+  std::array<float, 4> found_vector = {};
+  std::vector<librados::vector_pg_lsh::query_probe_t> probes;
+  bool found = false;
+  for (uint32_t candidate = 0; candidate < 4096; ++candidate) {
+    std::array<float, 4> candidate_vector = {};
+    for (uint32_t dim = 0; dim < candidate_vector.size(); ++dim) {
+      const uint32_t x = candidate * 1103515245u + 12345u +
+        dim * 2654435761u;
+      int raw = static_cast<int>((x >> 24) & 0xffU) - 128;
+      if (raw == 0) {
+        raw = static_cast<int>(dim) + 1;
+      }
+      candidate_vector[dim] = static_cast<float>(raw) / 17.0f;
+    }
+
+    bufferlist candidate_bl;
+    candidate_bl.append(
+        reinterpret_cast<const char *>(candidate_vector.data()),
+        candidate_vector.size() * sizeof(float));
+
+    std::vector<librados::vector_pg_lsh::query_probe_t> candidate_probes;
+    uint64_t generated_group_count = 0;
+    if (librados::vector_pg_lsh::build_query_probes(
+          "pg-lsh-bucket", "pg-lsh-index", candidate_bl,
+          candidate_vector.size(), params, pool_info, &locator_cache,
+          &candidate_probes, &generated_group_count) < 0 ||
+        candidate_probes.size() != 6 ||
+        generated_group_count != params.l) {
+      continue;
+    }
+
+    std::unordered_map<uint32_t, uint32_t> probes_per_pg;
+    for (const auto& probe : candidate_probes) {
+      ++probes_per_pg[probe.pg];
+    }
+    if (probes_per_pg.size() != params.m) {
+      continue;
+    }
+    bool every_pg_has_limit = true;
+    for (const auto& entry : probes_per_pg) {
+      if (entry.second != params.object_probe_limit_per_pg) {
+        every_pg_has_limit = false;
+        break;
+      }
+    }
+    if (!every_pg_has_limit) {
+      continue;
+    }
+
+    found_vector = candidate_vector;
+    probes = std::move(candidate_probes);
+    found = true;
+    break;
+  }
+
+  ASSERT_TRUE(found)
+    << "failed to find deterministic M=2 pg-lsh sub-OID route";
+  ASSERT_EQ(6u, probes.size());
+
+  bufferlist vector_bl;
+  vector_bl.append(reinterpret_cast<const char *>(found_vector.data()),
+                   found_vector.size() * sizeof(float));
+  librados::vector_placement::pg_lsh_v0_object_key_t exact_key;
+  ASSERT_EQ(0, librados::vector_placement::pg_lsh_v0_compute_object_key(
+      vector_bl, found_vector.size(), params.seed,
+      params.object_distance_group_bits, params.object_residual_bits,
+      &exact_key));
+
+  std::unordered_map<uint32_t, uint32_t> probes_per_pg;
+  for (const auto& probe : probes) {
+    uint32_t actual_pg = 0;
+    ASSERT_EQ(0, sub_ioctx.get_object_pg_hash_position2(
+        probe.locator_key, &actual_pg));
+    EXPECT_EQ(probe.pg, actual_pg);
+
+    auto& pg_probe_count = probes_per_pg[probe.pg];
+    if (pg_probe_count == 0) {
+      EXPECT_EQ(exact_key.object_name, probe.object_name);
+    }
+    ++pg_probe_count;
+  }
+
+  ASSERT_EQ(2u, probes_per_pg.size());
+  for (const auto& entry : probes_per_pg) {
+    EXPECT_EQ(3u, entry.second);
+  }
 }
 
 TEST_F(LibRadosIoPP, PgLshV0RawOpsRouteAndMergeByEntryId) {


### PR DESCRIPTION
기존 PG-LSH --> LSH로 PG를 선택한 뒤, 해당 PG의 큰 OID 내부를 전부 탐색하는 구조
이번 PR에서 PG 내부에서도 벡터를 나눌 수 있게 global anchor 기준 거리와 residual sign bit를 object name에 반영한 sub-OID 라우팅을 추가했습니다

기존: .../pg_3 (pg정보는 locator로 관리함)
변경: .../pg_3/g4_r5

- g4는 anchor와의 거리 그룹
- r5는 anchor 방향을 제외한 residual의 부호 비트

Query는 exact sub-OID와 설정된 주변 sub-OID만 선택하고 각 OID 내부의 OMAP은 exact distance로 탐색합니다
--> object name 기반 후보 축소

---
**주요 변경**
- global anchor 기준 16-bit distance 계산
- distance 상위 일부 비트로 coarse distance group 생성
- residual sign bit를 이용한 방향 그룹 생성
- g<distance>_r<residual> 형태의 sub-OID 추가
- Put과 Query에서 동일한 object name 계산 사용
- 인접 distance group과 residual Hamming neighbor 탐색 지원
- PG별 sub-OID probe 수 제한
- 여러 PG로의 vector put을 비동기로 submit
- OSD local top-k를 bounded heap으로 유지
- Crimson query 결과에 실제 distance computation 통계 연결

---
**주요 파라미터**
- M: query에서 탐색할 PG 수
- distance_bits: OID grouping에 사용할 거리 비트 수
- residual_bits: residual 방향을 나눌 부호 비트 수
- distance_radius: query 거리 그룹의 앞뒤 몇 그룹까지 탐색할지
- residual_radius: residual code가 몇 비트까지 다른 그룹을 탐색할지
- probe_limit_per_pg: PG 하나에서 탐색할 최대 sub-OID 수

Anchor는 random, centroid, representative 방식을 비교했습니다.

---
**실험**
Crimson/SeaStore에서 SIFT small 사용

- Base: 10,000개
- Query: 100개
- 128차원, Euclidean
- PG: 8개
- D=2, L=4, Top-K 100

초기 확인에서는 base 1,000개만 적재해 query당 약 49개의 distance를 계산했는데 QPS는 약 1,500~1,600이었고, oid 잔차비트 구현 전 omap 에서 한 벡터만 조회한 것은 5535 qps이었습니다
아래 결과는 siftsmall을 다 적재한 결과입니다

**결과**
방식 | M | distance/residual | M별 후보 수 (vector) | object probe | Recall@100 | latency
-- | -- | -- | -- | -- | -- | --
PG baseline | 2 | off | 6,537.31 | 2.00 | 72.29% | 31.60ms
random | 2 | 0/0 | 477.88 | 2.00 | 16.75% | 2.67ms
random | 2 | 1/0 | 863.61 | 6.00 | 25.77% | 4.81ms
random | 2 | 3/1 | 3,206.24 | 70.00 | 56.56% | 28.75ms
random | 4 | 3/1 | 4,347.09 | 140.00 | 71.99% | 56.42ms
random | 8 | 3/1 | 4,827.81 | 280.00 | 77.31% | 111.46ms
centroid | 2 | 1/0 | 449.26 | 6.00 | 18.66% | 2.57ms
representative | 2 | 1/0 | 293.28 | 6.00 | 18.38% | 1.88ms

- random, M=4, dist/res=3/1에서는 baseline보다 후보 수가 약 33% 감소했지만 Recall@100이 약 8%p 낮음. object probe는 크게 증가했습니다. 현재 설정에서 sub-OID가 후보 축소에는 효과가 있지만 recall 손실과 object 요청 오버헤드 때문에 이를 감안해야 됩니다
- L=4, PG Hamming radius 0에서는 실제 unique PG가 평균 약 3.26개에서 포화됩니다 M=8로 늘려도 recall은 증가하지 않고 object probe만 늘어났습니다.

---
**테스트**
- sub-OID distance/residual 계산 및 neighbor 생성 확인
- PG별 probe limit과 exact sub-OID 우선 탐색 확인
- Crimson/SeaStore에서 SIFT small 전체 load/query 확인
- 관련 빌드 및 git diff --check 통과